### PR TITLE
feat: Improve slug generation.

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,3 +1,5 @@
+const createSlug = require('./src/util/createSlug');
+
 exports.onCreatePage = async ({ page, actions }) => {
   const { createPage, deletePage } = actions
 
@@ -12,6 +14,18 @@ exports.onCreatePage = async ({ page, actions }) => {
     createPage({
       ...page,
       matchPath: "/learn/*",
+    });
+  }
+}
+
+exports.onCreateNode = ({ node, getNode, actions }) => {
+  if (node.internal.type === 'MarkdownRemark') {
+    const { createNodeField } = actions;
+    const slug = createSlug(node.frontmatter.title);
+    createNodeField({
+      node,
+      name: `slug`,
+      value: slug,
     });
   }
 }

--- a/src/pages/learn.tsx
+++ b/src/pages/learn.tsx
@@ -32,6 +32,9 @@ interface RemarkPage {
     description: string;
     author: string;
   }
+  fields: {
+    slug: string
+  }
 }
 
 interface LearnPageData {
@@ -64,9 +67,7 @@ export default ({ data, location }: Props) => {
     // If this page does not have a title, skip.
     if (!page.frontmatter.title) { continue; }
 
-    // Generate a slug for this page
-    // TODO: We need a more robust slug creation here.
-    const slug = page.frontmatter.title.toLowerCase().replace(/ /g, '-').replace(/[^a-z|-]/g, '');
+    const slug = page.fields.slug;
 
     // If there is no current page slug discovered from the URL, use the first page's.
     if (!currentPage) { currentPage = slug; }
@@ -133,6 +134,9 @@ export const query = graphql`{
           title
           description
           author
+        }
+        fields {
+          slug
         }
       }
     }

--- a/src/util/createSlug.js
+++ b/src/util/createSlug.js
@@ -1,0 +1,19 @@
+function createSlug(title) {
+  let slug = title.toLowerCase().trim();
+  
+  const sets = [
+    {to: 'nodejs', from: /node.js/ }, // Replace node.js
+    {to: '-and-', from: /&/ }, // Replace &
+    {to: '-', from: /(\/|_|,|:|;|\\|\ |\.)/g } // Replace /_,:;\. and whitespace
+  ];
+  
+  sets.forEach(set => {
+    slug = slug.replace(set.from, set.to);
+  });
+
+  return slug
+    .replace(/[^\w\-]+/g, '') // Remove any non word characters
+    .replace(/\-\-+/g, '-');  // Replace multiple hyphens
+}
+
+module.exports = createSlug;


### PR DESCRIPTION
This PR moves slug generation to `gatsby-node.js` which makes it possible to query the slug later on. It also attempts to make the slug generation process a bit more robust, taking into account that we might want to customize this for other languages in the future.

Ps: should probably add some tests for this once we have a test runner set up