### PR TITLE
refactor: Split components into smaller pieces.

### DIFF
--- a/src/components/article.tsx
+++ b/src/components/article.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { RemarkPage, PageInfo } from '../types';
+import Pagination from './pagination';
+import EditLink from './edit-link';
+
+type Props = {
+  page: RemarkPage;
+  previous?: PageInfo;
+  next?: PageInfo;
+}
+
+const Article = ({ page, previous, next }: Props) => (
+  <article className="article-reader">
+    <h1 className="article-reader__headline">{page.frontmatter.title}</h1>
+    <div dangerouslySetInnerHTML={{ __html: page.html }} />
+    <EditLink relativePath={page.parent.relativePath} />
+    <Pagination previous={previous} next={next}/>
+  </article>
+)
+
+export default Article

--- a/src/components/edit-link.tsx
+++ b/src/components/edit-link.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+type Props = {
+  relativePath?: string
+}
+
+const EditLink = ({ relativePath }: Props) => {
+  if (!relativePath) {
+    return null;
+  }
+
+  const href = `https://github.com/nodejs/nodejs.dev/edit/master/src/documentation/${relativePath}`;
+
+  return (
+    <a href={href} >
+      Edit this page on GitHub
+    </a>
+  )
+}
+
+export default EditLink

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+type Props = {
+  title: string
+}
+
+const Hero = ({ title }: Props) => (
+  <div className="hero">
+    <h1>{title}</h1>
+    <div className="diagonal-hero-bg">
+      <div className="stars">
+          <div className="small"/>
+          <div className="medium"/>
+          <div className="big"/>
+        </div>
+    </div>
+  </div>
+)
+
+export default Hero

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 type Props = {
-  title: string
+  title: string;
 }
 
 const Hero = ({ title }: Props) => (

--- a/src/components/navigation-item.tsx
+++ b/src/components/navigation-item.tsx
@@ -33,8 +33,9 @@ class NavigationItem extends React.Component<Props> {
     } else if (isActive) {
       className += 'side-nav__item--active';
     }
+
     return (
-      <Link to={`/learn/${slug}`} ref={this.setReference as any} onClick={onClick} className={className}>
+      <Link to={`/learn/${slug}`} ref={this.setReference} onClick={onClick} className={className}>
         {title}
       </Link>
     )

--- a/src/components/navigation-item.tsx
+++ b/src/components/navigation-item.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Link } from 'gatsby';
+
+type Props = {
+  isDone: boolean;
+  isActive: boolean;
+  slug: string;
+  title: string;
+  onClick: () => void;
+}
+
+class NavigationItem extends React.Component<Props> {
+  private element?: HTMLAnchorElement;
+
+  setReference = (ref: HTMLAnchorElement) => {
+    if (this.props.isActive) {
+      this.element = ref;
+    }
+  }
+
+  componentDidMount() {
+    if (this.element) {
+      // TODO: Scroll ref element in to view
+      // this.element.scrollIntoView(true);
+    }
+  }
+
+  render() {
+    const { isDone, isActive, slug, title, onClick } = this.props;
+    let className = 'side-nav__item ';
+    if (isDone) {
+      className += 'side-nav__item--done';
+    } else if (isActive) {
+      className += 'side-nav__item--active';
+    }
+    return (
+      <Link to={`/learn/${slug}`} ref={this.setReference as any} onClick={onClick} className={className}>
+        {title}
+      </Link>
+    )
+  }
+}
+
+export default NavigationItem

--- a/src/components/navigation-section.tsx
+++ b/src/components/navigation-section.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { NavigationItemData } from '../types';
+import NavigationItem from './navigation-item';
+
+type Props = {
+  title: string;
+  items: Array<NavigationItemData>;
+  onItemClick: () => void;
+}
+
+const NavigationSection = ({ title, items, onItemClick }: Props) => {
+  return (
+    <ul className="side-nav__list">
+      <h2 className="side-nav__title">{title}</h2>
+      {items.map((item: NavigationItemData) => (
+        <NavigationItem
+          key={item.id}
+          title={item.title}
+          slug={item.slug}
+          isDone={item.isDone}
+          isActive={item.isActive}
+          onClick={onItemClick}
+        />
+      ))}
+    </ul>
+  )
+}
+
+export default NavigationSection

--- a/src/components/navigation-section.tsx
+++ b/src/components/navigation-section.tsx
@@ -4,7 +4,7 @@ import NavigationItem from './navigation-item';
 
 type Props = {
   title: string;
-  items: Array<NavigationItemData>;
+  items: NavigationItemData[];
   onItemClick: () => void;
 }
 

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import NavigationSection from './navigation-section';
+import { RemarkPage, NavigationSectionData } from '../types';
+
+/** Small screen width
+ *  If the width of the viewport is lesser than this value
+ * it means that the website is viewed in a tablet or mobile
+ * TODO have this number shared in one place in the project
+ */
+const MAX_SMALLSCREEN_WIDTH = 1262
+
+type Props = {
+  activePage: RemarkPage;
+  sections: Array<NavigationSectionData>;
+}
+
+type State = {
+  isOpen: boolean;
+}
+
+class Navigation extends React.Component<Props, State> {
+  state = {
+    isOpen: false
+  }
+
+  toggle = () => {
+    this.setState({ isOpen: !this.state.isOpen });
+  }
+
+  onItemClick = () => {
+    // Get viewport width
+    // Source - https://stackoverflow.com/a/8876069/2621400
+    const w = Math.max(
+      document.documentElement.clientWidth,
+      window.innerWidth || 0
+    )
+    // If width is lesser or equal to max small screen width
+    if (w <= MAX_SMALLSCREEN_WIDTH) {
+      this.toggle();
+    }
+  }
+
+  render() {
+    const className = this.state.isOpen ? 'side-nav side-nav--open': 'side-nav';
+    return (
+      <nav className={className}>
+        <button className="side-nav__open" onClick={this.toggle}>Menu</button>
+        {this.props.sections.map((section: NavigationSectionData) => {
+          return (
+            <NavigationSection 
+              title={section.title}
+              items={section.items}
+              key={section.title}
+              onItemClick={this.onItemClick}
+            />
+          )
+        })}
+      </nav>
+    )
+  }
+}
+
+export default Navigation

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -11,7 +11,7 @@ const MAX_SMALLSCREEN_WIDTH = 1262
 
 type Props = {
   activePage: RemarkPage;
-  sections: Array<NavigationSectionData>;
+  sections: NavigationSectionData[];
 }
 
 type State = {
@@ -41,7 +41,8 @@ class Navigation extends React.Component<Props, State> {
   }
 
   render() {
-    const className = this.state.isOpen ? 'side-nav side-nav--open': 'side-nav';
+    const className = this.state.isOpen ? 'side-nav side-nav--open' : 'side-nav';
+
     return (
       <nav className={className}>
         <button className="side-nav__open" onClick={this.toggle}>Menu</button>

--- a/src/components/pagination.tsx
+++ b/src/components/pagination.tsx
@@ -1,0 +1,37 @@
+import { Link } from 'gatsby';
+import React from 'react';
+import { PageInfo } from '../types';
+
+type Props = {
+  previous?: PageInfo;
+  next?: PageInfo;
+}
+
+const Pagination = ({ previous, next }: Props) => (
+  <ul
+    style={{
+      display: `flex`,
+      flexWrap: `wrap`,
+      justifyContent: `space-between`,
+      listStyle: `none`,
+      padding: '30px',
+    }}
+  >
+    <li>
+      {previous && previous.frontmatter.title && (
+        <Link to={`/learn/${previous.fields.slug}`} rel="prev">
+          ← &nbsp; Prev
+        </Link>
+      )}
+    </li>
+    <li>
+      {next && next.frontmatter.title && (
+        <Link to={`/learn/${next.fields.slug}`} rel="next">
+          Next &nbsp; →
+        </Link>
+      )}
+    </li>
+  </ul>
+)
+
+export default Pagination

--- a/src/documentation/0001-node-introduction/index.md
+++ b/src/documentation/0001-node-introduction/index.md
@@ -2,6 +2,7 @@
 title: Introduction to Node.js
 description: "This post is a getting started guide to Node.js, the server-side JavaScript runtime environment. Node.js is built on top of the Google Chrome V8 JavaScript engine, and it's mainly used to create web servers - but it's not limited to that"
 author: flaviocopes
+section: Quick Start
 ---
 
 ## Overview

--- a/src/documentation/0002-node-history/index.md
+++ b/src/documentation/0002-node-history/index.md
@@ -2,6 +2,7 @@
 title: A brief history of Node.js
 description: 'A look back on the history of Node.js from 2009 to today'
 author: flaviocopes
+section: Quick Start
 ---
 
 Believe it or not, Node.js is just 9 years old.

--- a/src/documentation/0003-node-installation/index.md
+++ b/src/documentation/0003-node-installation/index.md
@@ -2,6 +2,7 @@
 title: How to install Node.js
 description: 'How you can install Node.js on your system: a package manager, the official website installer or nvm'
 author: flaviocopes
+section: Quick Start
 ---
 
 Node.js can be installed in different ways. This post highlights the most common and convenient ones.

--- a/src/documentation/0004-node-javascript-language/index.md
+++ b/src/documentation/0004-node-javascript-language/index.md
@@ -2,6 +2,7 @@
 title: How much JavaScript do you need to know to use Node.js?
 description: 'If you are just starting out with JavaScript, how much deeply do you need to know the language?'
 author: flaviocopes
+section: Quick Start
 ---
 
 As a beginner, it's hard to get to a point where you are confident enough in your programming abilities.

--- a/src/documentation/0005-node-difference-browser/index.md
+++ b/src/documentation/0005-node-difference-browser/index.md
@@ -2,6 +2,7 @@
 title: Differences between Node.js and the Browser
 description: 'How writing JavaScript application in Node.js differs from programming for the Web inside the browser'
 author: flaviocopes
+section: Quick Start
 ---
 
 Both the browser and Node.js use JavaScript as their programming language.

--- a/src/pages/learn.tsx
+++ b/src/pages/learn.tsx
@@ -1,259 +1,73 @@
-import { graphql, Link } from 'gatsby'
-import React from 'react'
-import Layout from '../components/layout'
-import { scrollTo } from '../util/scrollTo'
+import React from 'react';
+import { graphql } from 'gatsby';
+
+import { LearnPageData } from '../types';
+import Layout from '../components/layout';
+import Hero from '../components/hero';
+import Article from '../components/article';
+import Navigation from '../components/navigation';
+import { findActive } from '../util/findActive';
 import Page404 from './404'
 
-/**
- * When on the "Learn" page, we need to update the background gradient
- * that runs the side menu's title color change from white to black
- * as it becomes sticky and overlays the hero banner.
- * TODO: This should happen in the component, only when rendered.
- */
-let prevOffset = -1
-function magicHeroNumber() {
-  if (typeof window === 'undefined') { return; } // Guard for SSR.
-  const doc = window.document;
-  const offset = Math.min(doc.scrollingElement!.scrollTop - 62, 210);
-  if (Math.abs(prevOffset - offset) > 5) {
-    prevOffset = offset;
-    doc.body.setAttribute('style', `--magic-hero-number: ${356 - offset}px`);
-  }
-  window.requestAnimationFrame(magicHeroNumber)
-}
-magicHeroNumber()
-
-interface RemarkPage {
-  id: string;
-  fileAbsolutePath: string;
-  html: string;
-  parent: {
-    relativePath: string
-  }
-  frontmatter: {
-    title: string
-    description: string
-    author: string
-  }
-  fields: {
-    slug: string
-  }
-}
-
-interface PreviousPage {
-  frontmatter: {
-    title: string
-  }
-  fields: {
-    slug: string
-  }
-}
-
-interface NextPage {
-  frontmatter: {
-    title: string
-  }
-  fields: {
-    slug: string
-  }
-}
-
-interface LearnPageData {
-  pages: {
-    edges: ({ node: RemarkPage; previous: PreviousPage; next: NextPage })[]
-  }
-}
 type Props = {
-  data: LearnPageData
-  location: Location
+  data: LearnPageData;
+  location: Location;
 }
 
-let prev = 0
-function openNav() {
-  const old = prev
-  prev = document.scrollingElement!.scrollTop
-  document
-    .getElementsByClassName('side-nav')[0]
-    .classList.toggle('side-nav--open')
-  scrollTo(old)
-}
-/** Small screen width
- *  If the width of the viewport is lesser than this value
- * it means that the website is viewed in a tablet or mobile
- * TODO have this number shared in one place in the project
- */
-const MAX_SMALLSCREEN_WIDTH = 1262
-/**
- * When on smaller devices such as tablets and mobiles, the side menu needs
- * to be close when an article is selected.
- * closeNavOnSmallScreens checks for the viewport width and toggles it sideNav
- * if it is open on a small screen
- */
-function closeNavOnSmallScreens() {
-  // Get viewport width
-  // Source - https://stackoverflow.com/a/8876069/2621400
-  const w = Math.max(
-    document.documentElement.clientWidth,
-    window.innerWidth || 0
-  )
-  // If width is lesser or equal to max small screen width
-  if (w <= MAX_SMALLSCREEN_WIDTH) {
-    openNav()
+export default class LearnPage extends React.Component<Props> {
+  prevOffset: number = -1;
+  
+  componentDidMount() {
+    this.magicHeroNumber();
+  }
+
+  /**
+   * When on the "Learn" page, we need to update the background gradient
+   * that runs the side menu's title color change from white to black
+   * as it becomes sticky and overlays the hero banner.
+   */
+  magicHeroNumber = () => {
+    if (typeof window === 'undefined') { return; } // Guard for SSR.
+    const doc = window.document;
+    const offset = Math.min(doc.scrollingElement!.scrollTop - 62, 210);
+    if (Math.abs(this.prevOffset - offset) > 5) {
+      this.prevOffset = offset;
+      doc.body.setAttribute('style', `--magic-hero-number: ${356 - offset}px`);
+    }
+    window.requestAnimationFrame(this.magicHeroNumber);
+  }
+
+  render() {
+    const { data } = this.props;
+    const currentPage = location.pathname.split('/').pop();
+    const { activePage, previousPage, nextPage, navigationSections } = findActive(data.sections.group, currentPage);
+    if (!activePage) {
+      // Rendering 404 page as a component here
+      // The reason is to show the 404 component but maintaining the url (instead of redirecting to 404)
+      return <Page404 />
+    }
+    return (
+      <Layout
+        title={`${activePage.frontmatter.title} by ${activePage.frontmatter.author}`}
+        description={activePage.frontmatter.description}
+      >
+        <Hero title={activePage.frontmatter.title} />
+        <Navigation activePage={activePage} sections={navigationSections} />
+        <Article page={activePage} previous={previousPage} next={nextPage} />
+      </Layout>
+    );
   }
 }
 
-export default ({ data, location }: Props) => {
-  const pages = [];
-  let currentPage = location.pathname.split('/').pop();
-  let activePage = {
-    title: "404",
-    html: "404",
-    relativePath: "",
-    author: "",
-    description: ""
-  };
-
-
-  let previousPage = { frontmatter: { title: '404', path: '404' } }
-  let nextPage = { frontmatter: { title: '404', path: '404' } }
-
-  let foundActive = false
-
-  // For every page,
-  for (const { node: page, previous, next } of data.pages.edges) {
-    // If this page does not have a title, skip
-    if (!page.frontmatter.title) {
-      continue
+export const query = graphql`{
+  sections: allMarkdownRemark(
+    sort: {
+      fields: [fileAbsolutePath]
+      order: ASC
     }
-
-    const slug = page.fields.slug
-
-    // If there is no current page slug discovered from the URL, use the first page's.
-    if (!currentPage) {
-      currentPage = slug
-    }
-
-    // Determine if this is the active page, and mark if we've found the active page yet.
-    const isActive = slug === currentPage
-    foundActive = foundActive || isActive
-    if (isActive) {
-      activePage = {
-        html: page.html,
-        title: page.frontmatter.title,
-        description: page.frontmatter.description,
-        author: page.frontmatter.author,
-        relativePath: page.parent.relativePath
-      }
-
-      previousPage = {
-        frontmatter: {
-          title: previous.frontmatter.title,
-          path: previous.fields.slug,
-        },
-      }
-
-      nextPage = {
-        frontmatter: {
-          title: next && next.frontmatter.title,
-          path: next && next.fields.slug,
-        },
-      }
-    }
-    // Construct class name for this side nav item.
-    const className = `side-nav__item ${
-      !foundActive ? 'side-nav__item--done' : ''
-    } ${isActive ? 'side-nav__item--active' : ''}`
-
-    // Add the constructed page JSX to the pages list.
-    pages.push(
-      <Link to={`/learn/${slug}`} onClick={closeNavOnSmallScreens} className={className}>
-        {page.frontmatter.title}
-      </Link>
-    )
-  }
-
-  if (!foundActive) {
-    // Rendering 404 page as a component here
-    // The reason is to show the 404 component but maintaining the url (instead of redirecting to 404)
-    return <Page404 />
-  }
-
-  return (
-    <Layout
-      title={`${activePage.title} by ${activePage.author}`}
-      description={activePage.description}
-    >
-      <div className="hero">
-        <h1>{activePage.title}</h1>
-        <div className="diagonal-hero-bg">
-          <div className="stars">
-            <div className="small" />
-            <div className="medium" />
-            <div className="big" />
-          </div>
-        </div>
-      </div>
-      <nav className="side-nav">
-        <button className="side-nav__open" onClick={openNav}>
-          Menu
-        </button>
-        {/* TODO: Get side nav sections from frontmatter fields. Need a new one. */}
-        {/* TODO: H2s should not be in the ULs, but needed to make sticky titles work. Find a new way. */}
-        <ul className="side-nav__list">
-          <h2 className="side-nav__title">Quick Start</h2>
-          {pages.slice(0, 5)}
-        </ul>
-        <ul className="side-nav__list">
-          <h2 className="side-nav__title">Getting Started</h2>
-          {pages.slice(5)}
-        </ul>
-      </nav>
-      <article className="article-reader">
-        <h1 className="article-reader__headline">{activePage.title}</h1>
-        <div dangerouslySetInnerHTML={{ __html: activePage.html }} />
-        {
-          activePage.relativePath && (
-            <a
-              href={`https://github.com/nodejs/nodejs.dev/edit/master/src/documentation/${
-                activePage.relativePath
-              }`}
-            >
-              Edit this page on GitHub
-            </a>
-          )
-        }
-        <ul
-          style={{
-            display: `flex`,
-            flexWrap: `wrap`,
-            justifyContent: `space-between`,
-            listStyle: `none`,
-            padding: '30px',
-          }}
-        >
-          <li>
-            {previousPage.frontmatter.title && (
-              <Link to={`/learn/${previousPage.frontmatter.path}`} rel="prev">
-                ← &nbsp; Prev
-              </Link>
-            )}
-          </li>
-          <li>
-            {nextPage.frontmatter.title && (
-              <Link to={`/learn/${nextPage.frontmatter.path}`} rel="next">
-                Next &nbsp; →
-              </Link>
-            )}
-          </li>
-        </ul>
-      </article>
-    </Layout>
-  )
-}
-
-export const query = graphql`
-  {
-    pages: allMarkdownRemark {
+  ) {
+    group(field: frontmatter___section) {
+      fieldValue
       edges {
         node {
           id
@@ -292,4 +106,4 @@ export const query = graphql`
       }
     }
   }
-`
+}`;

--- a/src/pages/learn.tsx
+++ b/src/pages/learn.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import { graphql } from 'gatsby';
-
 import { LearnPageData } from '../types';
 import Layout from '../components/layout';
 import Hero from '../components/hero';
 import Article from '../components/article';
 import Navigation from '../components/navigation';
 import { findActive } from '../util/findActive';
-import Page404 from './404'
+import Page404 from './404';
 
 type Props = {
   data: LearnPageData;

--- a/src/pages/learn.tsx
+++ b/src/pages/learn.tsx
@@ -37,7 +37,7 @@ export default class LearnPage extends React.Component<Props> {
   }
 
   render() {
-    const { data } = this.props;
+    const { data, location } = this.props;
     const currentPage = location.pathname.split('/').pop();
     const { activePage, previousPage, nextPage, navigationSections } = findActive(data.sections.group, currentPage);
     if (!activePage) {

--- a/src/pages/learn.tsx
+++ b/src/pages/learn.tsx
@@ -45,6 +45,7 @@ export default class LearnPage extends React.Component<Props> {
       // The reason is to show the 404 component but maintaining the url (instead of redirecting to 404)
       return <Page404 />
     }
+
     return (
       <Layout
         title={`${activePage.frontmatter.title} by ${activePage.frontmatter.author}`}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -26,12 +26,12 @@ export interface PageInfo {
 
 export interface RemarkSection {
   fieldValue: string;
-  edges: Array<{ node: RemarkPage; previous: PageInfo; next: PageInfo }>;
+  edges: { node: RemarkPage; previous: PageInfo; next: PageInfo }[];
 }
 
 export interface LearnPageData {
   sections: {
-    group: Array<RemarkSection>;
+    group: RemarkSection[];
   }
 }
 
@@ -45,5 +45,5 @@ export interface NavigationItemData {
 
 export interface NavigationSectionData {
   title: string;
-  items: Array<NavigationItemData>;
+  items: NavigationItemData[];
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,27 +11,27 @@ export interface RemarkPage {
     author: string;
   }
   fields: {
-    slug: string
+    slug: string;
   }
 }
 
 export interface PageInfo {
   frontmatter: {
-    title: string
+    title: string;
   }
   fields: {
-    slug: string
+    slug: string;
   }
 }
 
 export interface RemarkSection {
-  fieldValue: string,
+  fieldValue: string;
   edges: Array<{ node: RemarkPage; previous: PageInfo; next: PageInfo }>;
 }
 
 export interface LearnPageData {
   sections: {
-    group: Array<RemarkSection>
+    group: Array<RemarkSection>;
   }
 }
 
@@ -44,6 +44,6 @@ export interface NavigationItemData {
 }
 
 export interface NavigationSectionData {
-  title: string,
-  items: Array<NavigationItemData>
+  title: string;
+  items: Array<NavigationItemData>;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,49 @@
+export interface RemarkPage {
+  id: string;
+  fileAbsolutePath: string;
+  html: string;
+  parent: {
+    relativePath: string
+  }
+  frontmatter: {
+    title: string;
+    description: string;
+    author: string;
+  }
+  fields: {
+    slug: string
+  }
+}
+
+export interface PageInfo {
+  frontmatter: {
+    title: string
+  }
+  fields: {
+    slug: string
+  }
+}
+
+export interface RemarkSection {
+  fieldValue: string,
+  edges: Array<{ node: RemarkPage; previous: PageInfo; next: PageInfo }>;
+}
+
+export interface LearnPageData {
+  sections: {
+    group: Array<RemarkSection>
+  }
+}
+
+export interface NavigationItemData {
+  id: string;
+  title: string;
+  isActive: boolean;
+  isDone: boolean;
+  slug: string;
+}
+
+export interface NavigationSectionData {
+  title: string,
+  items: Array<NavigationItemData>
+}

--- a/src/util/findActive.ts
+++ b/src/util/findActive.ts
@@ -1,0 +1,52 @@
+import { RemarkSection, RemarkPage, NavigationSectionData, PageInfo } from '../types';
+
+type ActiveResults = {
+  activePage?: RemarkPage,
+  previousPage?: PageInfo,
+  nextPage?: PageInfo,
+  navigationSections: Array<NavigationSectionData>
+}
+
+export function findActive(sections: Array<RemarkSection>, currentPage?: string): ActiveResults {
+  let activePage: RemarkPage | undefined;
+  let previousPage: PageInfo | undefined;
+  let nextPage: PageInfo | undefined;
+  const navigationSections = [];
+
+  for (const { fieldValue, edges } of sections) {
+    const items = []
+    const title = fieldValue === 'undefined' ? 'Getting Started' : fieldValue;
+    for (const { node: page, previous, next } of edges ) {
+      if (!page.frontmatter.title) {
+        continue;
+      }
+      if (!currentPage) {
+        currentPage = page.fields.slug;
+      }
+      const isActivePage = currentPage === page.fields.slug;
+      if (isActivePage) {
+        activePage = page;
+        previousPage = previous;
+        nextPage = next;
+      }
+      items.push({
+        id: page.id,
+        title: page.frontmatter.title,
+        isActive: isActivePage,
+        isDone: !activePage && !isActivePage,
+        slug: page.fields.slug
+      });
+    }
+    navigationSections.push({
+      title,
+      items
+    })
+  }
+
+  return {
+    activePage,
+    previousPage,
+    nextPage,
+    navigationSections
+  }
+}

--- a/src/util/findActive.ts
+++ b/src/util/findActive.ts
@@ -1,10 +1,10 @@
 import { RemarkSection, RemarkPage, NavigationSectionData, PageInfo } from '../types';
 
 type ActiveResults = {
-  activePage?: RemarkPage,
-  previousPage?: PageInfo,
-  nextPage?: PageInfo,
-  navigationSections: Array<NavigationSectionData>
+  activePage?: RemarkPage;
+  previousPage?: PageInfo;
+  nextPage?: PageInfo;
+  navigationSections: Array<NavigationSectionData>;
 }
 
 export function findActive(sections: Array<RemarkSection>, currentPage?: string): ActiveResults {

--- a/src/util/findActive.ts
+++ b/src/util/findActive.ts
@@ -4,10 +4,10 @@ type ActiveResults = {
   activePage?: RemarkPage;
   previousPage?: PageInfo;
   nextPage?: PageInfo;
-  navigationSections: Array<NavigationSectionData>;
+  navigationSections: NavigationSectionData[];
 }
 
-export function findActive(sections: Array<RemarkSection>, currentPage?: string): ActiveResults {
+export function findActive(sections: RemarkSection[], currentPage?: string): ActiveResults {
   let activePage: RemarkPage | undefined;
   let previousPage: PageInfo | undefined;
   let nextPage: PageInfo | undefined;


### PR DESCRIPTION
Rather extensive but all changes felt related.

### Summary of changes:
- Split components/page into smaller chunks that will make it less painful to merge changes in the future
- The navigation now lives in its own component(s) that handle state for toggling the menu on mobile devices
- Generates nav sections from frontmatter fields
- magicHeroNumber handled inside of component when rendered