### PR TITLE
Improve actions-toolkit usage

### DIFF
--- a/.github/action/result-poster/index.js
+++ b/.github/action/result-poster/index.js
@@ -1,13 +1,13 @@
 const { Toolkit } = require('actions-toolkit')
-const { context, github: { request } } = new Toolkit()
+const { context, github } = new Toolkit({ event: 'check_suite' })
 
 const name = context.payload.check_suite.app.name;
 const conclusion = context.payload.check_suite.conclusion
 const sha = context.payload.check_suite.head_sha;
 const prs = context.payload.check_suite.pull_requests;
 
-if (name === 'Google Cloud Build' && conclusion === 'success' && prs[0]) {
-  request('POST /repos/:owner/:repo/issues/:number/comments', context.repo({
+if (name === 'Google Cloud Build' && conclusion === 'success' && prs[0]) {  
+  github.issues.createComment(context.repo({
     number: prs[0].number,
     body: `Preview at: https://storage.googleapis.com/staging.nodejs.dev/${sha.slice(0,7)}/index.html`
   }));

--- a/.github/action/result-poster/index.js
+++ b/.github/action/result-poster/index.js
@@ -6,7 +6,7 @@ const conclusion = context.payload.check_suite.conclusion
 const sha = context.payload.check_suite.head_sha;
 const prs = context.payload.check_suite.pull_requests;
 
-if (name === 'Google Cloud Build' && conclusion === 'success' && prs[0]) {  
+if (name === 'Google Cloud Build' && conclusion === 'success' && prs[0]) {
   github.issues.createComment(context.repo({
     number: prs[0].number,
     body: `Preview at: https://storage.googleapis.com/staging.nodejs.dev/${sha.slice(0,7)}/index.html`


### PR DESCRIPTION
Hello! Awesome to see you using [actions-toolkit](https://github.com/JasonEtco/actions-toolkit) for an action here. Thought I'd pop in with some semantic improvements, as well as a newly added feature that'd help make the action a tad bit more reliable.

* Added the `event` option in the Toolkit constructor - this feature [was added in 1.4.0](https://github.com/JasonEtco/actions-toolkit/releases/tag/v1.4.0) and will skip the action if the event trigger doesn't match. Just ensures that your action isn't being triggered by the wrong event.
* Replaced `request` with `issues.createComment` - that way you don't need to remember the API endpoint 👌 it's a little more clear whats happening.

Feel free to dismiss if you don't think these changes are necessary of course 🇨🇦 