### PR TITLE
docs: Update repository url.

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby-starter-default"
+    "url": "https://github.com/nodejs/nodejs.dev"
   },
   "jest": {
     "transform": {


### PR DESCRIPTION
Minor fix, updates the repository url in package.json to point to this repo instead of gatsby-starter-default