### PR TITLE
style: Only show side-nav scrollbar when open.

### DIFF
--- a/src/components/mobile.css
+++ b/src/components/mobile.css
@@ -17,6 +17,7 @@
     margin-right: -36.0rem;
     margin-bottom: calc(-100vh + var(--nav-height));
     pointer-events: none;
+    overflow: hidden;
   }
 
   .side-nav::after {
@@ -40,6 +41,7 @@
 
   .side-nav.side-nav--open {
     pointer-events: all;
+    overflow-y: auto;
   }
 
   .side-nav.side-nav--open::after {


### PR DESCRIPTION
Fixes #102.

One less than ideal result is that on open the scrollbar appears immediately while the side nav transforms out. There are probably ways to handle that but I'm not sure it's worth the effort.

Chrome with side nav closed doesn't show scrollbar:

![screenshot from 2019-02-21 16-44-32](https://user-images.githubusercontent.com/3341/53207325-047de880-35f9-11e9-9003-982b99cd250a.png)

With side nav open, scrollbar is shown:

![screenshot from 2019-02-21 16-44-401](https://user-images.githubusercontent.com/3341/53207331-08116f80-35f9-11e9-9fea-692a03b8e1f9.png)
