### PR TITLE
Fix a mistake in the code 

### DIFF
--- a/src/documentation/0011-node-repl/index.md
+++ b/src/documentation/0011-node-repl/index.md
@@ -83,7 +83,7 @@ The REPL knows when you are typing a multi-line statement without the need to in
 For example if you start typing an iteration like this:
 
 ```js
-[1, 2, 3].forEach(num => {
+[1, 2, 3].forEach((num) => {
 ```
 
 and you press `enter`, the REPL will go to a new line that starts with 3 dots, indicating you can now continue to work on that block.


### PR DESCRIPTION
Fixed a mistake in the code - line 86
Before: `[1, 2, 3].forEach(num => {`. this won't work.
After: `[1, 2, 3].forEach((num) => {` this works