### PR TITLE
Remove scroll by x

### DIFF
--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -193,7 +193,7 @@ main {
   overflow: hidden;
   position: absolute;
   top: 0;
-  width: 100vw;
+  width: 100%;
 }
 
 .side-nav {


### PR DESCRIPTION
This happens because the hero section has set width: `100vw`, using `100%` instead. Some browsers do not include the scroll bar width to `100vw` so `100vw` exceeds the width of the browser when have a scroll bar on the right.

Close: #112