### PR TITLE
docs: Harden commit message in Commit Guidelines.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,11 @@
 
 There is a built in commit linter. Basic rules:
 
+* Commit messages must be prefixed with the name of the changed subsystem and start with an imperative verb. Check the output of `git log --oneline files/you/changed` to find out what subsystems your changes touch.
+
+  Supported subsystems:
+
+  > build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test
+
 * Commit messages must start with a capital letter
 * Commit message must end with a period `.`
-* Supported subsystems:
-
-build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test


### PR DESCRIPTION
Reference from our core repo `nodejs/node`: [commit-message-guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

> be prefixed with the name of the changed subsystem and start with an imperative verb. Check the output of `git log --oneline files/you/changed` to find out what subsystems your changes touch.

Refs: #134 