### PR TITLE
refactor: Update regular expression in util/createSlug.js.

### DIFF
--- a/src/util/createSlug.js
+++ b/src/util/createSlug.js
@@ -4,7 +4,7 @@ function createSlug(title) {
   const sets = [
     {to: 'nodejs', from: /node.js/ }, // Replace node.js
     {to: '-and-', from: /&/ }, // Replace &
-    {to: '-', from: /([\/_,:;\\ .])/g } // Replace /_,:;\. and whitespace
+    {to: '-', from: /[/_,:;\\ .]/g } // Replace /_,:;\. and whitespace
   ];
 
   sets.forEach(set => {

--- a/src/util/createSlug.js
+++ b/src/util/createSlug.js
@@ -1,19 +1,19 @@
 function createSlug(title) {
   let slug = title.toLowerCase().trim();
-  
+
   const sets = [
     {to: 'nodejs', from: /node.js/ }, // Replace node.js
     {to: '-and-', from: /&/ }, // Replace &
-    {to: '-', from: /(\/|_|,|:|;|\\|\ |\.)/g } // Replace /_,:;\. and whitespace
+    {to: '-', from: /([\/_,:;\\ .])/g } // Replace /_,:;\. and whitespace
   ];
-  
+
   sets.forEach(set => {
     slug = slug.replace(set.from, set.to);
   });
 
   return slug
     .replace(/[^\w\-]+/g, '') // Remove any non word characters
-    .replace(/\-\-+/g, '-')   // Replace multiple hyphens with single
+    .replace(/--+/g, '-')   // Replace multiple hyphens with single
     .replace(/^-/, '')        // Remove any leading hyphen
     .replace(/-$/, '');       // Remove any trailing hyphen
 }


### PR DESCRIPTION
While checking out `util/createSlug.js`, my IDE warned about a couple of trivial improvement opportunities for two simple regular expressions in `util/createSlug.js`.

Took a stab to simplify the warned regular expressions. Tested in local comparing the page title (and nav item name to the parsed URL slug. Looked okay. Will test in staging more. 🙏 

<img width="469" alt="screen shot 2019-02-27 at 9 57 58 pm" src="https://user-images.githubusercontent.com/6441326/53538805-271e6e80-3add-11e9-8489-66a56b8d9028.png">

<img width="376" alt="screen shot 2019-02-27 at 10 01 29 pm" src="https://user-images.githubusercontent.com/6441326/53538821-37364e00-3add-11e9-8719-d32983c4b2fa.png">
