### PR TITLE
feat: Update commitlint config and docs to disallow a period at the end

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,12 @@
 {
+  "printWidth": 80,
+  "tabWidth": 2,
+  "useTabs": false,
   "semi": true,
   "singleQuote": true,
+  "jsxSingleQuote": false,
   "trailingComma": "es5",
   "bracketSpacing": true,
-  "jsxBracketSameLine": true
+  "jsxBracketSameLine": false,
+  "arrowParens": "avoid"
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,12 +1,7 @@
 {
-  "printWidth": 80,
-  "tabWidth": 2,
-  "useTabs": false,
   "semi": true,
   "singleQuote": true,
-  "jsxSingleQuote": false,
   "trailingComma": "es5",
   "bracketSpacing": true,
-  "jsxBracketSameLine": false,
-  "arrowParens": "avoid"
+  "jsxBracketSameLine": true
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,19 @@
-# Making changes to the Website-Prototype
+# Making changes to nodejs.dev
 
 ## Commit Guidelines
 
-There is a built in commit linter. Basic rules:
+This project follows the [Conventional Commits][] specification.
 
-* Commit messages must be prefixed with the name of the changed subsystem and start with an imperative verb. Check the output of `git log --oneline files/you/changed` to find out what subsystems your changes touch.
+There is a built-in commit linter. Basic rules:
+
+- Commit messages must be prefixed with the name of the changed subsystem, followed by a colon and a space and start with an imperative verb. Check the output of `git log --oneline files/you/changed` to find out what subsystems your changes touch.
 
   Supported subsystems:
 
   > build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test
 
-* Commit messages must start with a capital letter
-* Commit message must end with a period `.`
+- Commit messages must start with a capital letter
+- Commit messages must not end with a period `.`
 
 ## Collaboration Policy
 
@@ -21,11 +23,12 @@ There is a built in commit linter. Basic rules:
 - Pull Requests must be open for at least 24 hours unless included in the special exemptions section below
 
 ### Special Exemptions
+
 Pull requests seeking to make any of the following changes do not need to wait 24 hours
 
-* Errata fixes
-* Infrastructure Maintenance
-* Tests
+- Errata fixes
+- Infrastructure Maintenance
+- Tests
 
 ## Landing Pull Requests
 
@@ -44,18 +47,19 @@ Pull requests seeking to make any of the following changes do not need to wait 2
 
 By making a contribution to this project, I certify that:
 
-* (a) The contribution was created in whole or in part by me and I have the right to
+- (a) The contribution was created in whole or in part by me and I have the right to
   submit it under the open source license indicated in the file; or
-* (b) The contribution is based upon previous work that, to the best of my knowledge,
+- (b) The contribution is based upon previous work that, to the best of my knowledge,
   is covered under an appropriate open source license and I have the right under that
   license to submit that work with modifications, whether created in whole or in part
   by me, under the same open source license (unless I am permitted to submit under a
   different license), as indicated in the file; or
-* (c) The contribution was provided directly to me by some other person who certified
+- (c) The contribution was provided directly to me by some other person who certified
   (a), (b) or (c) and I have not modified it.
-* (d) I understand and agree that this project and the contribution are public and that
+- (d) I understand and agree that this project and the contribution are public and that
   a record of the contribution (including all personal information I submit with it,
   including my sign-off) is maintained indefinitely and may be redistributed consistent
   with this project or the open source license(s) involved.
 
+[conventional commits]: https://www.conventionalcommits.org/
 [`squash`]: https://help.github.com/en/articles/about-pull-request-merges#squash-and-merge-your-pull-request-commits

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,10 +1,7 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
   rules: {
-    'subject-full-stop': [2, 'always', '.'],
-    'subject-case': [
-      2, 'always',
-      ['sentence-case']
-    ]
-  }
-}
+    'subject-full-stop': [2, 'never', '.'],
+    'subject-case': [2, 'always', ['sentence-case']],
+  },
+};


### PR DESCRIPTION
- Update commitlint config to disallow period at the end of a commit
message
- Document this decision in CONTRIBUTING.md and add a link to the
Conventional Commits specification

Refs: https://www.conventionalcommits.org/
Fixes: https://github.com/nodejs/nodejs.dev/issues/150