### PR TITLE
fix: Include defaults to be explicit and turn off `jsxBracketSameLine`

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,12 @@
 {
+  "printWidth": 80,
+  "tabWidth": 2,
+  "useTabs": false,
   "semi": true,
   "singleQuote": true,
+  "jsxSingleQuote": false,
   "trailingComma": "es5",
   "bracketSpacing": true,
-  "jsxBracketSameLine": true
+  "jsxBracketSameLine": false,
+  "arrowParens": "avoid"
 }


### PR DESCRIPTION
- As agreed in the website-redesign meeting on 28-FEB-2019, it is
recommended to include the default settings too in our prettier config
to explicitly state the project's choices

- The existing config remains as is, with the exception of
`jsxBracketSameLine` which is turned off

Refs: https://github.com/nodejs/nodejs.dev/issues/44