### PR TITLE
chore: Add format-check and tslint scripts in pre-push hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "format": "prettier --write '**/*.{ts,tsx,js}'",
     "format-check": "prettier --check '**/*.{ts,tsx,js}'",
     "jest": "jest",
-    "test": "yarn run jest && yarn run format-check && yarn run tslint",
+    "test": "yarn jest && yarn format-check && yarn tslint",
     "tslint": "tslint --project ./tsconfig.json"
   },
   "devDependencies": {
@@ -96,7 +96,8 @@
   },
   "husky": {
     "hooks": {
-      "commit-msg": "commitlint --edit $HUSKY_GIT_PARAMS"
+      "commit-msg": "commitlint --edit $HUSKY_GIT_PARAMS",
+      "pre-push": "yarn format-check && yarn tslint"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "format": "prettier --write '**/*.{ts,tsx,js}'",
     "format-check": "prettier --check '**/*.{ts,tsx,js}'",
     "jest": "jest",
-    "test": "yarn jest && yarn format-check && yarn tslint",
+    "test": "yarn format-check && yarn tslint && yarn jest",
     "tslint": "tslint --project ./tsconfig.json"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

* Add format-check and tslint scripts in pre-push hook
* Remove unneeded keyword "run" in `yarn` commands of the `test` npm-run script
* Correct `test` script to run `format-check` and `tslin`, before `jest` to avoid snapshot update flag (`-u`) not being supported by `tslint` script:

```sh
$ tslint --project ./tsconfig.json -u
error: unknown option `-u'
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

## Related Issues

Fixes #164 