### PR TITLE
fix: Correct logic to mark nav items done

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -14,7 +14,7 @@ type Props = {
 };
 
 const Layout = ({ children, title, description, img }: Props) => {
-  const prevOffset = useRef(-1);
+  const prevOffset = useRef<number>(-1);
 
   useEffect(() => {
     if ('IntersectionObserver' in window) {

--- a/src/components/navigation-section.tsx
+++ b/src/components/navigation-section.tsx
@@ -22,17 +22,20 @@ const NavigationSection = ({
     <ul className="side-nav__list">
       <h2 className="side-nav__title">{title}</h2>
       {section.map((item: NavigationSectionItem) => {
-        const flatItem = flatSessions.find(x => x.slug === item.slug) || {
-          ...item,
-          isDone: false,
-        };
+        let flatItem: NavigationSectionItem = { ...item, isDone: false };
+        for (let i = 0; i < flatSessions.length; i++) {
+          if (flatSessions[i].slug === item.slug) {
+            flatItem = flatSessions[i];
+            break;
+          }
+        }
 
         return (
           <NavigationItem
             key={item.slug}
             title={item.title}
             slug={item.slug}
-            isDone={flatItem.isDone}
+            isDone={flatItem.isDone || false}
             isActive={item.slug === currentSlug}
             onClick={onItemClick}
           />

--- a/src/components/navigation-section.tsx
+++ b/src/components/navigation-section.tsx
@@ -8,7 +8,7 @@ type Props = {
   section: NavigationItemList;
   currentSlug: string;
   onItemClick: () => void;
-  flatSessions: NavigationSectionItem[];
+  flatSections: NavigationSectionItem[];
 };
 
 const NavigationSection = ({
@@ -16,16 +16,16 @@ const NavigationSection = ({
   section,
   currentSlug,
   onItemClick,
-  flatSessions,
+  flatSections,
 }: Props) => {
   return (
     <ul className="side-nav__list">
       <h2 className="side-nav__title">{title}</h2>
       {section.map((item: NavigationSectionItem) => {
         let flatItem: NavigationSectionItem = { ...item, isDone: false };
-        for (let i: number = 0; i < flatSessions.length; i++) {
-          if (flatSessions[i].slug === item.slug) {
-            flatItem = flatSessions[i];
+        for (let i: number = 0; i < flatSections.length; i++) {
+          if (flatSections[i].slug === item.slug) {
+            flatItem = flatSections[i];
             break;
           }
         }

--- a/src/components/navigation-section.tsx
+++ b/src/components/navigation-section.tsx
@@ -23,7 +23,7 @@ const NavigationSection = ({
       <h2 className="side-nav__title">{title}</h2>
       {section.map((item: NavigationSectionItem) => {
         let flatItem: NavigationSectionItem = { ...item, isDone: false };
-        for (let i = 0; i < flatSessions.length; i++) {
+        for (let i: number = 0; i < flatSessions.length; i++) {
           if (flatSessions[i].slug === item.slug) {
             flatItem = flatSessions[i];
             break;

--- a/src/components/navigation-section.tsx
+++ b/src/components/navigation-section.tsx
@@ -8,6 +8,7 @@ type Props = {
   section: NavigationItemList;
   currentSlug: string;
   onItemClick: () => void;
+  flatSessions: NavigationSectionItem[];
 };
 
 const NavigationSection = ({
@@ -15,44 +16,30 @@ const NavigationSection = ({
   section,
   currentSlug,
   onItemClick,
+  flatSessions,
 }: Props) => {
   return (
     <ul className="side-nav__list">
       <h2 className="side-nav__title">{title}</h2>
       {section.map((item: NavigationSectionItem) => {
+        const flatItem = flatSessions.find(x => x.slug === item.slug) || {
+          ...item,
+          isDone: false,
+        };
+
         return (
           <NavigationItem
             key={item.slug}
             title={item.title}
             slug={item.slug}
-            isDone={isDone(currentSlug, item.slug, section)}
+            isDone={flatItem.isDone}
             isActive={item.slug === currentSlug}
-            onClick={() => onItemClick}
+            onClick={onItemClick}
           />
         );
       })}
     </ul>
   );
-};
-
-const isDone = (
-  currentSlug: string,
-  requestedSlug: string,
-  section: NavigationItemList
-): boolean => {
-  let currentSlugIndex: number = 0;
-  let requestedSlugIndex: number = 0;
-  section.forEach((navigationItem, index) => {
-    if (navigationItem.slug === currentSlug) {
-      currentSlugIndex = index;
-    }
-
-    if (navigationItem.slug === requestedSlug) {
-      requestedSlugIndex = index;
-    }
-  });
-
-  return currentSlugIndex > requestedSlugIndex;
 };
 
 export default NavigationSection;

--- a/src/components/navigation-section.tsx
+++ b/src/components/navigation-section.tsx
@@ -35,7 +35,7 @@ const NavigationSection = ({
             key={item.slug}
             title={item.title}
             slug={item.slug}
-            isDone={flatItem.isDone || false}
+            isDone={flatItem.isDone}
             isActive={item.slug === currentSlug}
             onClick={onItemClick}
           />

--- a/src/components/navigation-section.tsx
+++ b/src/components/navigation-section.tsx
@@ -22,13 +22,9 @@ const NavigationSection = ({
     <ul className="side-nav__list">
       <h2 className="side-nav__title">{title}</h2>
       {section.map((item: NavigationSectionItem) => {
-        let flatItem: NavigationSectionItem = { ...item, isDone: false };
-        for (let i: number = 0; i < flatSections.length; i++) {
-          if (flatSections[i].slug === item.slug) {
-            flatItem = flatSections[i];
-            break;
-          }
-        }
+        const flatItem: NavigationSectionItem = flatSections.find(
+          (flatSection: NavigationSectionItem) => flatSection.slug === item.slug
+        ) || { ...item, isDone: false };
 
         return (
           <NavigationItem

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -17,20 +17,20 @@ const Navigation = ({ sections, currentSlug }: Props) => {
     }
   };
   const className = isOpen ? 'side-nav side-nav--open' : 'side-nav';
-  let flatSessions: NavigationSectionItem[] = [];
+  let flatSections: NavigationSectionItem[] = [];
   Object.keys(sections).map((sectionKey: string) => {
-    flatSessions = [...flatSessions, ...sections[sectionKey]];
+    flatSections = [...flatSections, ...sections[sectionKey]];
   });
 
   let currentSlugIndex: number = -1;
-  for (let i: number = 0; i < flatSessions.length; i++) {
-    if (flatSessions[i].slug === currentSlug) {
+  for (let i: number = 0; i < flatSections.length; i++) {
+    if (flatSections[i].slug === currentSlug) {
       currentSlugIndex = i;
       break;
     }
   }
 
-  flatSessions.forEach((item: NavigationSectionItem, index: number) => {
+  flatSections.forEach((item: NavigationSectionItem, index: number) => {
     item.isDone = index < currentSlugIndex;
   });
 
@@ -46,7 +46,7 @@ const Navigation = ({ sections, currentSlug }: Props) => {
           section={sections[sectionKey]}
           currentSlug={currentSlug}
           onItemClick={onItemClick}
-          flatSessions={flatSessions}
+          flatSections={flatSections}
         />
       ))}
     </nav>

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -23,7 +23,7 @@ const Navigation = ({ sections, currentSlug }: Props) => {
   });
 
   let currentSlugIndex: number = -1;
-  for (let i = 0; i < flatSessions.length; i++) {
+  for (let i: number = 0; i < flatSessions.length; i++) {
     if (flatSessions[i].slug === currentSlug) {
       currentSlugIndex = i;
       break;

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import NavigationSection from './navigation-section';
-import { NavigationSectionData } from '../types';
+import { NavigationSectionData, NavigationSectionItem } from '../types';
 import { isSmallScreen } from '../util/isSmallScreen';
 
 type Props = {
@@ -9,7 +9,7 @@ type Props = {
 };
 
 const Navigation = ({ sections, currentSlug }: Props) => {
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState<boolean>(false);
   const toggle = () => setIsOpen(!isOpen);
   const onItemClick = () => {
     if (isSmallScreen()) {
@@ -17,6 +17,16 @@ const Navigation = ({ sections, currentSlug }: Props) => {
     }
   };
   const className = isOpen ? 'side-nav side-nav--open' : 'side-nav';
+  let flatSessions: NavigationSectionItem[] = [];
+  Object.keys(sections).map(sectionKey => {
+    flatSessions = [...flatSessions, ...sections[sectionKey]];
+  });
+  const currentSlugIndex = flatSessions.findIndex(
+    item => item.slug === currentSlug
+  );
+  flatSessions.forEach((item, index) => {
+    item.isDone = index < currentSlugIndex;
+  });
 
   return (
     <nav className={className}>
@@ -30,6 +40,7 @@ const Navigation = ({ sections, currentSlug }: Props) => {
           section={sections[section]}
           currentSlug={currentSlug}
           onItemClick={onItemClick}
+          flatSessions={flatSessions}
         />
       ))}
     </nav>

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -22,13 +22,9 @@ const Navigation = ({ sections, currentSlug }: Props) => {
     flatSections = [...flatSections, ...sections[sectionKey]];
   });
 
-  let currentSlugIndex: number = -1;
-  for (let i: number = 0; i < flatSections.length; i++) {
-    if (flatSections[i].slug === currentSlug) {
-      currentSlugIndex = i;
-      break;
-    }
-  }
+  const currentSlugIndex: number = flatSections.findIndex(
+    (flatSection: NavigationSectionItem) => flatSection.slug === currentSlug
+  );
 
   flatSections.forEach((item: NavigationSectionItem, index: number) => {
     item.isDone = index < currentSlugIndex;

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -18,13 +18,19 @@ const Navigation = ({ sections, currentSlug }: Props) => {
   };
   const className = isOpen ? 'side-nav side-nav--open' : 'side-nav';
   let flatSessions: NavigationSectionItem[] = [];
-  Object.keys(sections).map(sectionKey => {
+  Object.keys(sections).map((sectionKey: string) => {
     flatSessions = [...flatSessions, ...sections[sectionKey]];
   });
-  const currentSlugIndex = flatSessions.findIndex(
-    item => item.slug === currentSlug
-  );
-  flatSessions.forEach((item, index) => {
+
+  let currentSlugIndex: number = -1;
+  for (let i = 0; i < flatSessions.length; i++) {
+    if (flatSessions[i].slug === currentSlug) {
+      currentSlugIndex = i;
+      break;
+    }
+  }
+
+  flatSessions.forEach((item: NavigationSectionItem, index: number) => {
     item.isDone = index < currentSlugIndex;
   });
 
@@ -33,11 +39,11 @@ const Navigation = ({ sections, currentSlug }: Props) => {
       <button className="side-nav__open" onClick={toggle}>
         Menu
       </button>
-      {Object.keys(sections).map(section => (
+      {Object.keys(sections).map((sectionKey: string) => (
         <NavigationSection
-          key={section}
-          title={section}
-          section={sections[section]}
+          key={sectionKey}
+          title={sectionKey}
+          section={sections[sectionKey]}
           currentSlug={currentSlug}
           onItemClick={onItemClick}
           flatSessions={flatSessions}

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -18,7 +18,7 @@ const Navigation = ({ sections, currentSlug }: Props) => {
   };
   const className = isOpen ? 'side-nav side-nav--open' : 'side-nav';
   let flatSections: NavigationSectionItem[] = [];
-  Object.keys(sections).map((sectionKey: string) => {
+  Object.keys(sections).forEach((sectionKey: string) => {
     flatSections = [...flatSections, ...sections[sectionKey]];
   });
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,7 +30,7 @@ export interface LearnPageData {
 export type NavigationItemList = NavigationSectionItem[];
 
 export interface NavigationSectionItem {
-  isDone: boolean;
+  isDone: boolean | null | undefined;
   slug: string;
   title: string;
   section: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,6 +30,7 @@ export interface LearnPageData {
 export type NavigationItemList = NavigationSectionItem[];
 
 export interface NavigationSectionItem {
+  isDone: boolean;
   slug: string;
   title: string;
   section: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,7 +30,7 @@ export interface LearnPageData {
 export type NavigationItemList = NavigationSectionItem[];
 
 export interface NavigationSectionItem {
-  isDone: boolean | null | undefined;
+  isDone: boolean;
   slug: string;
   title: string;
   section: string;


### PR DESCRIPTION
## Description

Use a flattened data structure (`flatSessions`) to determine `isDone` flags for each navigation item, based on the index of the active slug.

## Related Issues

Fixes #176 

![mark-done](https://user-images.githubusercontent.com/6441326/54091721-a1f74d00-4359-11e9-93a8-aa7cd15ff13a.gif)
