### PR TITLE
chore: Add coverage directory to .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 .cache/
 .github/
 public/
+coverage/


### PR DESCRIPTION
## Description
Adding coverage directory to `.prettierignore` (a few files in the coverage directory causes `format-check` to fail) 