### PR TITLE
fix: Navigation title color in FF and legacy browsers

### DIFF
--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -247,6 +247,19 @@ main {
   transition: color 0.28s;
 }
 
+[data-browser=legacy] .side-nav__title {
+  background-attachment: fixed;
+  -webkit-background-clip: text;
+  background-clip: text;
+  background-image: linear-gradient(to top, rgba(0, 0, 0, 1) 49%, rgba(255, 255, 255, 1) 51%);
+  background-position: 0 calc(-50vh + var(--magic-hero-number));
+  background-size: 100% 100vh;
+  color: white;
+  filter: opacity(0.9);
+  -webkit-text-fill-color: transparent;
+  will-change: background-position;
+}
+
 .side-nav__list {
   margin: 0;
   padding: 0;

--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -244,6 +244,7 @@ main {
   position: sticky;
   top: 2.8rem;
   z-index: 999;
+  transition: color 0.28s;
 }
 
 .side-nav__list {

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -14,7 +14,7 @@ type Props = {
 };
 
 const Layout = ({ children, title, description, img }: Props) => {
-  const prevOffset = useRef(-1);
+  const prevOffset = useRef<number>(-1);
 
   useEffect(() => {
     if ('IntersectionObserver' in window) {

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -51,6 +51,35 @@ const Layout = ({ children, title, description, img }: Props) => {
       doc.body.setAttribute('style', `--magic-hero-number: ${356 - offset}px`);
     }
     window.requestAnimationFrame(magicHeroNumber);
+
+    if (doc.body.dataset.browser !== 'legacy') {
+      doc.body.dataset.browser = 'legacy';
+
+      const css = doc.createElement('style');
+      css.type = 'text/css';
+      const styles = `
+        .side-nav__title {
+          background-attachment: fixed;
+          -webkit-background-clip: text;
+          background-clip: text;
+          background-image: linear-gradient(to top, rgba(0, 0, 0, 1) 49%, rgba(255, 255, 255, 1) 51%);
+          background-position: 0 calc(-50vh + var(--magic-hero-number));
+          background-size: 100% 100vh;
+          color: white;
+          filter: opacity(0.9);
+          -webkit-text-fill-color: transparent;
+          will-change: background-position;
+        }
+
+        @media (max-width: 720px) {
+          .side-nav__title {
+            background-position: 0 calc(-50vh + var(--magic-hero-number) - 32px);
+          }
+        }
+      `;
+      css.appendChild(document.createTextNode(styles));
+      doc.getElementsByTagName('head')[0].appendChild(css);
+    }
   };
 
   return (

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -77,7 +77,7 @@ const Layout = ({ children, title, description, img }: Props) => {
           }
         }
       `;
-      css.appendChild(document.createTextNode(styles));
+      css.appendChild(doc.createTextNode(styles));
       doc.getElementsByTagName('head')[0].appendChild(css);
     }
   };

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -36,7 +36,7 @@ const Layout = ({ children, title, description, img }: Props) => {
   const onIntersectionChange = (entries: IntersectionObserverEntry[]) => {
     entries.forEach((entry: IntersectionObserverEntry) => {
       const element = entry.target as HTMLElement;
-      element.style.color = entry.isIntersecting ? '#000' : '#fff';
+      element.style.color = entry.intersectionRatio > 0.5 ? '#000' : '#fff';
     });
   };
 

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -45,41 +45,15 @@ const Layout = ({ children, title, description, img }: Props) => {
       return;
     } // Guard for SSR.
     const doc = window.document;
+    if (!doc.body.dataset.browser) {
+      doc.body.dataset.browser = 'legacy';
+    }
     const offset = Math.min(doc.scrollingElement!.scrollTop - 62, 210);
     if (Math.abs(prevOffset.current - offset) > 5) {
       prevOffset.current = offset;
       doc.body.setAttribute('style', `--magic-hero-number: ${356 - offset}px`);
     }
     window.requestAnimationFrame(magicHeroNumber);
-
-    if (doc.body.dataset.browser !== 'legacy') {
-      doc.body.dataset.browser = 'legacy';
-
-      const css = doc.createElement('style');
-      css.type = 'text/css';
-      const styles = `
-        .side-nav__title {
-          background-attachment: fixed;
-          -webkit-background-clip: text;
-          background-clip: text;
-          background-image: linear-gradient(to top, rgba(0, 0, 0, 1) 49%, rgba(255, 255, 255, 1) 51%);
-          background-position: 0 calc(-50vh + var(--magic-hero-number));
-          background-size: 100% 100vh;
-          color: white;
-          filter: opacity(0.9);
-          -webkit-text-fill-color: transparent;
-          will-change: background-position;
-        }
-
-        @media (max-width: 720px) {
-          .side-nav__title {
-            background-position: 0 calc(-50vh + var(--magic-hero-number) - 32px);
-          }
-        }
-      `;
-      css.appendChild(doc.createTextNode(styles));
-      doc.getElementsByTagName('head')[0].appendChild(css);
-    }
   };
 
   return (

--- a/src/components/mobile.css
+++ b/src/components/mobile.css
@@ -150,6 +150,10 @@
     top: calc(var(--nav-height) + 12px);
   }
 
+  [data-browser=legacy] .side-nav__title {
+    background-position: 0 calc(-50vh + var(--magic-hero-number) - 32px);
+  }
+
   .article-reader {
     width: 100%;
     padding: 0 1.0rem;


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Fix for FF: switched to using `intersectionRatio` instead of `isIntersecting` to detect intersection of the target with specified root (`isIntersecting` is apparently buggy and inconsistent across browsers, and therefore not reliable).

Fix for older browsers like Safari 12: apply custom CSS on the presence of `[data-browser=legacy]`. Set `[data-browser=legacy]` during the first invocation of the side-effect function `magicHeroNumber`.

## Related Issues

Fixes: https://github.com/nodejs/nodejs.dev/issues/184