### PR TITLE
fix: Avoid side nav menu items bleeding through the title

### DIFF
--- a/src/components/mobile.css
+++ b/src/components/mobile.css
@@ -113,7 +113,7 @@
   }
 
   .side-nav::before {
-    width: 100%;
+    width: 110%;
   }
 
   .side-nav.side-nav--open {


### PR DESCRIPTION
## Description

Fixes the behaviour where long-ish menu items previously bled through the side navigation title.

![Kapture 2019-03-13 at 10 54 59](https://user-images.githubusercontent.com/2608321/54255593-c97b2f00-457e-11e9-80c2-03aa6cf97df0.gif)

## Related Issues

Fixes: https://github.com/nodejs/nodejs.dev/issues/190