### PR TITLE
style: Set max-height to 100% in mobile.css

### DIFF
--- a/src/components/mobile.css
+++ b/src/components/mobile.css
@@ -117,7 +117,7 @@
   }
 
   .side-nav.side-nav--open {
-    max-height: 3250px; /* TODO: Magic number. Get programmatically based on content. */
+    max-height: 100vh;
     overflow: visible;
     position: static;
   }

--- a/src/components/mobile.css
+++ b/src/components/mobile.css
@@ -117,7 +117,7 @@
   }
 
   .side-nav.side-nav--open {
-    max-height: 100vh;
+    max-height: 100%;
     overflow: visible;
     position: static;
   }


### PR DESCRIPTION
## Description

While reviewing `mobile.css`, found the `TODO` note about setting max height based on content.

Tried a fix to address this TODO by using `100%` to set the max height the height of the viewport. 

## Related Issues

N/A
