### PR TITLE
Docs: Fixed SpiderMonkey reference and added links to other JavaScript engines referenced. 

### DIFF
--- a/src/documentation/0006-v8/index.md
+++ b/src/documentation/0006-v8/index.md
@@ -17,7 +17,7 @@ The Node.js ecosystem is huge and thanks to it V8 also powers desktop apps, with
 
 Other browsers have their own JavaScript engine:
 
-- Firefox has [**Spidermonkey**](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey)
+- Firefox has [**SpiderMonkey**](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey)
 - Safari has [**JavaScriptCore**](https://developer.apple.com/documentation/javascriptcore) (also called Nitro)
 - Edge has [**Chakra**](https://github.com/Microsoft/ChakraCore)
 

--- a/src/documentation/0006-v8/index.md
+++ b/src/documentation/0006-v8/index.md
@@ -18,8 +18,8 @@ The Node.js ecosystem is huge and thanks to it V8 also powers desktop apps, with
 Other browsers have their own JavaScript engine:
 
 - Firefox has [**Spidermonkey**](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey)
-- Safari has **JavaScriptCore** (also called Nitro)
-- Edge has **Chakra**
+- Safari has [**JavaScriptCore**](https://developer.apple.com/documentation/javascriptcore) (also called Nitro)
+- Edge has [**Chakra**](https://github.com/Microsoft/ChakraCore)
 
 and many others exist as well.
 


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description

1. I have attempted to link the references of other JavaScript Engines with their respective documentation or GitHub Links. Just like how it was previously done with SpiderMonkey
2. Spidermonkey is referenced as `SpiderMonkey` in the MDN docs for the same, so I have attempted to change it in the article here.

## Related Issues

Have not created an issue for the same, as I felt that this PR is attempting simple changes.

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->