### PR TITLE
feat: Edit links with SVG Icons & Consistent styles for Pagination/Contributors

### DIFF
--- a/src/components/authors-list.tsx
+++ b/src/components/authors-list.tsx
@@ -5,15 +5,19 @@ import Author from './author';
 const list = css`
   display: flex;
   flex-wrap: wrap;
-  margin: 5rem 0;
+  margin: 5rem 0 2.5rem;
   align-items: center;
   color: var(--gray7);
   text-transform: uppercase;
   padding-left: 0;
 
   h5 {
-    margin: 0.5rem;
+    display: flex;
+    flex-wrap: wrap;
+    width: 100%;
+    margin: 0.5rem 0.5rem 0.5rem 0;
     font-weight: normal;
+    font-size: 1.4rem;
   }
 `;
 

--- a/src/components/edit-link.tsx
+++ b/src/components/edit-link.tsx
@@ -1,4 +1,34 @@
+import { css } from '@emotion/core';
 import React from 'react';
+
+const edit = css`
+  display: flex;
+  flex-wrap: wrap;
+`;
+
+const link = css`
+  color: var(--gray7) !important;
+  text-transform: uppercase;
+  text-decoration: none !important;
+  font-size: 1.4rem;
+  font-weight: normal;
+  font-family: var(--sans-serif);
+  vertical-align: middle;
+
+  span {
+    vertical-align: middle;
+    font-weight: normal;
+  }
+
+  &:hover {
+    color: var(--brand-light) !important;
+  }
+`;
+
+const icon = css`
+  margin-left: 0.5rem;
+  vertical-align: middle;
+`;
 
 type Props = {
   relativePath?: string;
@@ -12,9 +42,20 @@ const EditLink = ({ relativePath }: Props) => {
   const href = `https://github.com/nodejs/nodejs.dev/edit/master/src/documentation/${relativePath}`;
 
   return (
-    <a style={{ display: 'inlineFlex', marginTop: '1rem' }} href={href}>
-      Edit this page on GitHub
-    </a>
+    <div css={edit}>
+      <a css={link} href={href}>
+        <span>Edit this page on GitHub</span>{' '}
+        <svg
+          css={icon}
+          fill="currentColor"
+          height="1em"
+          width="1em"
+          viewBox="0 0 40 40"
+        >
+          <path d="m34.5 11.7l-3 3.1-6.3-6.3 3.1-3q0.5-0.5 1.2-0.5t1.1 0.5l3.9 3.9q0.5 0.4 0.5 1.1t-0.5 1.2z m-29.5 17.1l18.4-18.5 6.3 6.3-18.4 18.4h-6.3v-6.2z" />
+        </svg>
+      </a>
+    </div>
   );
 };
 

--- a/src/components/pagination.tsx
+++ b/src/components/pagination.tsx
@@ -1,7 +1,21 @@
+import { css, SerializedStyles } from '@emotion/core';
 import { Link } from 'gatsby';
 import React from 'react';
-import { css, SerializedStyles } from '@emotion/core';
 import { PaginationInfo } from '../types';
+
+const link: SerializedStyles = css`
+  color: var(--gray7) !important;
+  text-transform: uppercase;
+  text-decoration: none !important;
+  font-size: 1.4rem;
+  font-weight: normal;
+  font-family: var(--sans-serif);
+  vertical-align: middle;
+
+  &:hover {
+    color: var(--brand-light) !important;
+  }
+`;
 
 type Props = {
   previous?: PaginationInfo;
@@ -13,21 +27,21 @@ const ulStyles: SerializedStyles = css`
   flex-wrap: wrap;
   justify-content: space-between;
   list-style: none;
-  padding: 30px;
+  padding: 5rem 0;
 `;
 
 const Pagination = ({ previous, next }: Props) => (
   <ul css={ulStyles}>
     <li>
       {previous && previous.title && (
-        <Link to={`/${previous.slug}`} rel="prev">
+        <Link css={link} to={`/${previous.slug}`} rel="prev">
           ← &nbsp; Prev
         </Link>
       )}
     </li>
     <li>
       {next && next.title && (
-        <Link to={`/${next.slug}`} rel="next">
+        <Link css={link} to={`/${next.slug}`} rel="next">
           Next &nbsp; →
         </Link>
       )}

--- a/test/components/__snapshots__/authors-list.test.tsx.snap
+++ b/test/components/__snapshots__/authors-list.test.tsx.snap
@@ -5,20 +5,24 @@ exports[`AuthorsList component renders correctly 1`] = `
   css={
     Object {
       "map": undefined,
-      "name": "1bnswin",
+      "name": "irphdi",
       "next": undefined,
       "styles": "
   display: flex;
   flex-wrap: wrap;
-  margin: 5rem 0;
+  margin: 5rem 0 2.5rem;
   align-items: center;
   color: var(--gray7);
   text-transform: uppercase;
   padding-left: 0;
 
   h5 {
-    margin: 0.5rem;
+    display: flex;
+    flex-wrap: wrap;
+    width: 100%;
+    margin: 0.5rem 0.5rem 0.5rem 0;
     font-weight: normal;
+    font-size: 1.4rem;
   }
 ",
     }

--- a/test/components/__snapshots__/edit-link.test.tsx.snap
+++ b/test/components/__snapshots__/edit-link.test.tsx.snap
@@ -1,15 +1,72 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EditLink component renders correctly 1`] = `
-<a
-  href="https://github.com/nodejs/nodejs.dev/edit/master/src/documentation/0002-node-history/index.md"
-  style={
+<div
+  css={
     Object {
-      "display": "inlineFlex",
-      "marginTop": "1rem",
+      "map": undefined,
+      "name": "rtde4j",
+      "next": undefined,
+      "styles": "
+  display: flex;
+  flex-wrap: wrap;
+",
     }
   }
 >
-  Edit this page on GitHub
-</a>
+  <a
+    css={
+      Object {
+        "map": undefined,
+        "name": "1dmmrc2",
+        "next": undefined,
+        "styles": "
+  color: var(--gray7) !important;
+  text-transform: uppercase;
+  text-decoration: none !important;
+  font-size: 1.4rem;
+  font-weight: normal;
+  font-family: var(--sans-serif);
+  vertical-align: middle;
+
+  span {
+    vertical-align: middle;
+    font-weight: normal;
+  }
+
+  &:hover {
+    color: var(--brand-light) !important;
+  }
+",
+      }
+    }
+    href="https://github.com/nodejs/nodejs.dev/edit/master/src/documentation/0002-node-history/index.md"
+  >
+    <span>
+      Edit this page on GitHub
+    </span>
+     
+    <svg
+      css={
+        Object {
+          "map": undefined,
+          "name": "y6j8ah",
+          "next": undefined,
+          "styles": "
+  margin-left: 0.5rem;
+  vertical-align: middle;
+",
+        }
+      }
+      fill="currentColor"
+      height="1em"
+      viewBox="0 0 40 40"
+      width="1em"
+    >
+      <path
+        d="m34.5 11.7l-3 3.1-6.3-6.3 3.1-3q0.5-0.5 1.2-0.5t1.1 0.5l3.9 3.9q0.5 0.4 0.5 1.1t-0.5 1.2z m-29.5 17.1l18.4-18.5 6.3 6.3-18.4 18.4h-6.3v-6.2z"
+      />
+    </svg>
+  </a>
+</div>
 `;

--- a/test/components/__snapshots__/pagination.test.tsx.snap
+++ b/test/components/__snapshots__/pagination.test.tsx.snap
@@ -5,20 +5,40 @@ exports[`Pagination component only renders links to pages that has a title 1`] =
   css={
     Object {
       "map": undefined,
-      "name": "4bjqmt",
+      "name": "1gwj20b",
       "next": undefined,
       "styles": "
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
   list-style: none;
-  padding: 30px;
+  padding: 5rem 0;
 ",
     }
   }
 >
   <li>
     <a
+      css={
+        Object {
+          "map": undefined,
+          "name": "u0j7sy",
+          "next": undefined,
+          "styles": "
+  color: var(--gray7) !important;
+  text-transform: uppercase;
+  text-decoration: none !important;
+  font-size: 1.4rem;
+  font-weight: normal;
+  font-family: var(--sans-serif);
+  vertical-align: middle;
+
+  &:hover {
+    color: var(--brand-light) !important;
+  }
+",
+        }
+      }
       href="/test-slug"
       rel="prev"
     >
@@ -34,20 +54,40 @@ exports[`Pagination component renders correctly when there is no next page 1`] =
   css={
     Object {
       "map": undefined,
-      "name": "4bjqmt",
+      "name": "1gwj20b",
       "next": undefined,
       "styles": "
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
   list-style: none;
-  padding: 30px;
+  padding: 5rem 0;
 ",
     }
   }
 >
   <li>
     <a
+      css={
+        Object {
+          "map": undefined,
+          "name": "u0j7sy",
+          "next": undefined,
+          "styles": "
+  color: var(--gray7) !important;
+  text-transform: uppercase;
+  text-decoration: none !important;
+  font-size: 1.4rem;
+  font-weight: normal;
+  font-family: var(--sans-serif);
+  vertical-align: middle;
+
+  &:hover {
+    color: var(--brand-light) !important;
+  }
+",
+        }
+      }
       href="/test-slug"
       rel="prev"
     >
@@ -63,14 +103,14 @@ exports[`Pagination component renders correctly when there is no previous page 1
   css={
     Object {
       "map": undefined,
-      "name": "4bjqmt",
+      "name": "1gwj20b",
       "next": undefined,
       "styles": "
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
   list-style: none;
-  padding: 30px;
+  padding: 5rem 0;
 ",
     }
   }
@@ -78,6 +118,26 @@ exports[`Pagination component renders correctly when there is no previous page 1
   <li />
   <li>
     <a
+      css={
+        Object {
+          "map": undefined,
+          "name": "u0j7sy",
+          "next": undefined,
+          "styles": "
+  color: var(--gray7) !important;
+  text-transform: uppercase;
+  text-decoration: none !important;
+  font-size: 1.4rem;
+  font-weight: normal;
+  font-family: var(--sans-serif);
+  vertical-align: middle;
+
+  &:hover {
+    color: var(--brand-light) !important;
+  }
+",
+        }
+      }
       href="/test-slug"
       rel="next"
     >
@@ -92,20 +152,40 @@ exports[`Pagination component renders links to the next and previous page 1`] = 
   css={
     Object {
       "map": undefined,
-      "name": "4bjqmt",
+      "name": "1gwj20b",
       "next": undefined,
       "styles": "
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
   list-style: none;
-  padding: 30px;
+  padding: 5rem 0;
 ",
     }
   }
 >
   <li>
     <a
+      css={
+        Object {
+          "map": undefined,
+          "name": "u0j7sy",
+          "next": undefined,
+          "styles": "
+  color: var(--gray7) !important;
+  text-transform: uppercase;
+  text-decoration: none !important;
+  font-size: 1.4rem;
+  font-weight: normal;
+  font-family: var(--sans-serif);
+  vertical-align: middle;
+
+  &:hover {
+    color: var(--brand-light) !important;
+  }
+",
+        }
+      }
       href="/test-slug"
       rel="prev"
     >
@@ -114,6 +194,26 @@ exports[`Pagination component renders links to the next and previous page 1`] = 
   </li>
   <li>
     <a
+      css={
+        Object {
+          "map": undefined,
+          "name": "u0j7sy",
+          "next": undefined,
+          "styles": "
+  color: var(--gray7) !important;
+  text-transform: uppercase;
+  text-decoration: none !important;
+  font-size: 1.4rem;
+  font-weight: normal;
+  font-family: var(--sans-serif);
+  vertical-align: middle;
+
+  &:hover {
+    color: var(--brand-light) !important;
+  }
+",
+        }
+      }
       href="/test-slug"
       rel="next"
     >


### PR DESCRIPTION
This is one of my favorite PRs — since the inconsistent styles for the footer area of docs were eating up on me. So, here it goes. GUI representation first. 💯

### BEFORE

![before](https://on.ahmda.ws/d0cb50/c)

### AFTER

![after](https://on.ahmda.ws/31d8d9/c)


---

### BEFORE

![before](https://on.ahmda.ws/8aaca1/c)

### AFTER

![after](https://on.ahmda.ws/c14320/c)

As you can see this PR adds the following things:

- [x] SVG Edit icon
- [x] Consistent link styles
- [x] Better styles for pagination
- [x] Hover based brand colors FTW

/gcbrun