### PR TITLE
feat: Use intersection-observer polyfill to support IntersectionObserver

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "gatsby-source-contentful": "^2.0.1",
     "gatsby-source-filesystem": "^2.0.16",
     "gatsby-transformer-remark": "^2.1.5",
+    "intersection-observer": "^0.5.1",
     "prismjs": "^1.15.0",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "testUpdate": "yarn format-check && yarn tslint && yarn jestUpdate",
     "test-ci": "yarn test --coverage && codecov",
     "tslint": "tslint --project ./tsconfig.json",
-    "serve": "yarn run build && clear && gatsby serve"
+    "serve": "yarn build && clear && gatsby serve"
   },
   "devDependencies": {
     "@babel/core": "^7.3.3",

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -23,8 +23,15 @@ const Layout = ({ children, title, description, img }: Props) => {
     if ('IntersectionObserver' in window) {
       setupObserver();
     } else {
-      // Fallback for browsers without IntersectionObserver support
-      magicHeroNumber();
+      import('intersection-observer')
+        .then(() => {
+          // Use polyfill for browsers without IntersectionObserver support
+          setupObserver();
+        })
+        .catch(() => {
+          // Fallback for browsers without IntersectionObserver support
+          magicHeroNumber();
+        });
     }
   });
 

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -23,15 +23,11 @@ const Layout = ({ children, title, description, img }: Props) => {
     if ('IntersectionObserver' in window) {
       setupObserver();
     } else {
+      // Use polyfill for browsers without IntersectionObserver support
       import('intersection-observer')
-        .then(() => {
-          // Use polyfill for browsers without IntersectionObserver support
-          setupObserver();
-        })
-        .catch(() => {
-          // Fallback for browsers without IntersectionObserver support
-          magicHeroNumber();
-        });
+        .then(setupObserver)
+        // Fallback for browsers without IntersectionObserver support
+        .catch(magicHeroNumber);
     }
   });
 

--- a/src/templates/learn.tsx
+++ b/src/templates/learn.tsx
@@ -6,10 +6,6 @@ import Layout from '../components/layout';
 import Navigation from '../components/navigation';
 import { LearnPageContext, LearnPageData } from '../types';
 
-if (typeof window !== 'undefined') {
-  require('intersection-observer');
-}
-
 type Props = {
   data: LearnPageData;
   pageContext: LearnPageContext;

--- a/src/templates/learn.tsx
+++ b/src/templates/learn.tsx
@@ -1,3 +1,4 @@
+import 'intersection-observer';
 import { graphql } from 'gatsby';
 import React from 'react';
 import Article from '../components/article';

--- a/src/templates/learn.tsx
+++ b/src/templates/learn.tsx
@@ -6,7 +6,7 @@ import Layout from '../components/layout';
 import Navigation from '../components/navigation';
 import { LearnPageContext, LearnPageData } from '../types';
 
-if (typeof window !== `undefined`) {
+if (typeof window !== 'undefined') {
   require('intersection-observer');
 }
 

--- a/src/templates/learn.tsx
+++ b/src/templates/learn.tsx
@@ -1,4 +1,3 @@
-import 'intersection-observer';
 import { graphql } from 'gatsby';
 import React from 'react';
 import Article from '../components/article';
@@ -6,6 +5,10 @@ import Hero from '../components/hero';
 import Layout from '../components/layout';
 import Navigation from '../components/navigation';
 import { LearnPageContext, LearnPageData } from '../types';
+
+if (typeof window !== `undefined`) {
+  require('intersection-observer');
+}
 
 type Props = {
   data: LearnPageData;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6480,6 +6480,11 @@ internal-ip@^3.0.1:
     default-gateway "^2.6.0"
     ipaddr.js "^1.5.2"
 
+intersection-observer@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.5.1.tgz#e340fc56ce74290fe2b2394d1ce88c4353ac6dfa"
+  integrity sha512-Zd7Plneq82kiXFixs7bX62YnuZ0BMRci9br7io88LwDyF3V43cQMI+G5IiTlTNTt+LsDUppl19J/M2Fp9UkH6g==
+
 into-stream@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/into-stream/-/into-stream-3.1.0.tgz#96fb0a936c12babd6ff1752a17d05616abd094c6"


### PR DESCRIPTION
## Description

After researching polyfill for `IntersectionObserver`, trying out the [`intersection-observer` polyfill from w3c](https://github.com/w3c/IntersectionObserver/tree/master/polyfill) in this PR.

Navigation Title color looks okay in local testing with the XCode iOS Simulator (usually pretty native to real iPhone). Looking forward to review & testing more in staging.

## Related Issues

Fixes #207

![observer-polyfill](https://user-images.githubusercontent.com/6441326/55528376-918d7600-566a-11e9-9d64-f42ebe018a8c.gif)