### PR TITLE
style: Remove toc outline on focus

### DIFF
--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -128,6 +128,10 @@ main {
   grid-template-columns: 420px auto;
 }
 
+summary {
+  outline: none;
+}
+
 .nav {
   background: white;
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.33), 0 2px 3px rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
Small style change to remove the blue outline that appears when opening or closing the `TABLE OF CONTENTS` dropdown.

<img width="736" alt="Screen Shot 2019-04-05 at 1 53 56 AM" src="https://user-images.githubusercontent.com/15851351/55616239-3630b600-5746-11e9-9072-ad8b955ea9ea.png">
