### PR TITLE
Fix npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "jest": "jest",
     "update-snapshot": "jest --updateSnapshot",
     "test": "yarn format-check && yarn tslint && yarn jest",
-    "testUpdate": "yarn format-check && yarn tslint && yarn update-snapshot",
+    "test-watch": "yarn jest --watch",
     "test-ci": "yarn test --coverage && codecov",
     "tslint": "tslint --project ./tsconfig.json",
     "serve": "yarn run build && clear && gatsby serve"

--- a/package.json
+++ b/package.json
@@ -46,9 +46,9 @@
     "format": "prettier --write '**/*.{ts,tsx,js}'",
     "format-check": "prettier --check '**/*.{ts,tsx,js}'",
     "jest": "jest",
-    "jestUpdate": "jest --updateSnapshot",
+    "update-snapshot": "jest --updateSnapshot",
     "test": "yarn format-check && yarn tslint && yarn jest",
-    "testUpdate": "yarn format-check && yarn tslint && yarn jestUpdate",
+    "testUpdate": "yarn format-check && yarn tslint && yarn update-snapshot",
     "test-ci": "yarn test --coverage && codecov",
     "tslint": "tslint --project ./tsconfig.json",
     "serve": "yarn run build && clear && gatsby serve"


### PR DESCRIPTION
## Description

1. fix: Rename `jestUpdate` to `update-snapshot`
- As a name, `update-snapshot` more accurately reflects what the script
is intended to do
- For naming npm scripts, kebab-case is preferred across the community
  1. The npm CLI uses kebab-case for naming their scripts
  2. Many of the top most-depended-upon packages on npm use kebab-case,
  with the notable exception of lodash, who use colons

Refs: https://github.com/npm/cli/blob/latest/package.json
Refs: https://www.npmjs.com/browse/depended

2. fix: Replace `testUpdate` with `test-watch`
- Having a script that runs jest in watch mode is more useful in general
to everyone
- This way you don't have to run this script everytime you edit a file,
unlike `testUpdate`
- You can now use the awesome jest CLI's interactive snapshot mode to do
it efficiently.

Refs: https://jestjs.io/docs/en/snapshot-testing#interactive-snapshot-mode

## Related Issues

Continued from https://github.com/nodejs/nodejs.dev/pull/221#pullrequestreview-222827001.