### PR TITLE
refactor: Use SerializedStyles type for css props

### DIFF
--- a/src/components/author.tsx
+++ b/src/components/author.tsx
@@ -1,11 +1,11 @@
-import { css } from '@emotion/core';
+import { css, SerializedStyles } from '@emotion/core';
 import React from 'react';
 
-const list = css`
+const list: SerializedStyles = css`
   list-style: none;
 `;
 
-const link = css`
+const link: SerializedStyles = css`
   margin-left: 0.5rem;
 
   &:hover img {
@@ -13,7 +13,7 @@ const link = css`
   }
 `;
 
-const img = css`
+const img: SerializedStyles = css`
   height: 30px;
   width: 30px;
   margin-top: 5px;

--- a/src/components/authors-list.tsx
+++ b/src/components/authors-list.tsx
@@ -1,8 +1,8 @@
-import { css } from '@emotion/core';
+import { css, SerializedStyles } from '@emotion/core';
 import React from 'react';
 import Author from './author';
 
-const list = css`
+const list: SerializedStyles = css`
   display: flex;
   flex-wrap: wrap;
   margin: 5rem 0 2.5rem;

--- a/src/components/edit-link.tsx
+++ b/src/components/edit-link.tsx
@@ -1,12 +1,12 @@
-import { css } from '@emotion/core';
+import { css, SerializedStyles } from '@emotion/core';
 import React from 'react';
 
-const edit = css`
+const edit: SerializedStyles = css`
   display: flex;
   flex-wrap: wrap;
 `;
 
-const link = css`
+const link: SerializedStyles = css`
   color: var(--gray7) !important;
   text-transform: uppercase;
   text-decoration: none !important;
@@ -25,7 +25,7 @@ const link = css`
   }
 `;
 
-const icon = css`
+const icon: SerializedStyles = css`
   margin-left: 0.5rem;
   vertical-align: middle;
 `;


### PR DESCRIPTION
## Description

Improve type for  emotion css props in code w. `SerializedStyles` (similar to pagination.tsx):

https://github.com/nodejs/nodejs.dev/blob/e47be96332301101bc66b4422defeaeb37f339ed/src/components/pagination.tsx#L6

## Related Issues

N/A
