### PR TITLE
Fix TOC links for HTML code tags

### DIFF
--- a/src/components/toc.tsx
+++ b/src/components/toc.tsx
@@ -10,7 +10,7 @@ const TOC = ({ heading, tableOfContents }: Props) => {
   if (!tableOfContents) {
     return null;
   }
-  tableOfContents = fixTocCodeTag(tableOfContents)
+  tableOfContents = fixTocCodeTag(tableOfContents);
 
   return (
     <details className="toc">

--- a/src/components/toc.tsx
+++ b/src/components/toc.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { fixTocCodeTag } from '../util/tocFormatter';
 
 type Props = {
   heading: string;
@@ -9,6 +10,7 @@ const TOC = ({ heading, tableOfContents }: Props) => {
   if (!tableOfContents) {
     return null;
   }
+  tableOfContents = fixTocCodeTag(tableOfContents)
 
   return (
     <details className="toc">

--- a/src/documentation/0032-javascript-timers/index.md
+++ b/src/documentation/0032-javascript-timers/index.md
@@ -5,7 +5,7 @@ authors: flaviocopes, MylesBorins, LaRuaNa, amiller-gh, ahmadawais
 section: Getting Started
 ---
 
-## setTimeout()
+## `setTimeout()`
 
 When writing JavaScript code, you might want to delay the execution of a function.
 
@@ -61,7 +61,7 @@ This is especially useful to avoid blocking the CPU on intensive tasks and let o
 
 > Some browsers (IE and Edge) implement a `setImmediate()` method that does this same exact functionality, but it's not standard and [unavailable on other browsers](https://caniuse.com/#feat=setimmediate). But it's a standard function in Node.js.
 
-## setInterval()
+## `setInterval()`
 
 `setInterval` is a function similar to `setTimeout`, with a difference: instead of running the callback function once, it will run it forever, at the specific time interval you specify (in milliseconds):
 

--- a/src/documentation/0034-javascript-promises/index.md
+++ b/src/documentation/0034-javascript-promises/index.md
@@ -212,7 +212,7 @@ new Promise((resolve, reject) => {
 
 ## Orchestrating promises
 
-### Promise.all()
+### `Promise.all()`
 
 If you need to synchronize different promises, `Promise.all()` helps you define a list of promises, and execute something when they are all resolved.
 
@@ -241,7 +241,7 @@ Promise.all([f1, f2]).then(([res1, res2]) => {
 
 You are not limited to using `fetch` of course, **any promise can be used in this fashion**.
 
-### Promise.race()
+### `Promise.race()`
 
 `Promise.race()` runs when the first of the promises you pass to it resolves, and it runs the attached callback just once, with the result of the first promise resolved.
 

--- a/src/util/tocFormatter.ts
+++ b/src/util/tocFormatter.ts
@@ -1,5 +1,5 @@
 // See related issue: https://github.com/gatsbyjs/gatsby/issues/8982
-export function fixTocCodeTag(tocLinks: string) {
+export function fixTocCodeTag(tocLinks: string = '' ) {
   const lessThanSignRegex = /&#x3C;/gi;
 
   return tocLinks.replace(lessThanSignRegex, '<');

--- a/src/util/tocFormatter.ts
+++ b/src/util/tocFormatter.ts
@@ -1,0 +1,6 @@
+// See related issue: https://github.com/gatsbyjs/gatsby/issues/8982
+export function fixTocCodeTag(tocLinks: string) {
+    const lessThanSignRegex = /&#x3C;/gi
+
+    return tocLinks.replace(lessThanSignRegex, '<')
+}

--- a/src/util/tocFormatter.ts
+++ b/src/util/tocFormatter.ts
@@ -1,5 +1,5 @@
 // See related issue: https://github.com/gatsbyjs/gatsby/issues/8982
-export function fixTocCodeTag(tocLinks: string = '' ) {
+export function fixTocCodeTag(tocLinks: string = '') {
   const lessThanSignRegex = /&#x3C;/gi;
 
   return tocLinks.replace(lessThanSignRegex, '<');

--- a/src/util/tocFormatter.ts
+++ b/src/util/tocFormatter.ts
@@ -1,6 +1,6 @@
 // See related issue: https://github.com/gatsbyjs/gatsby/issues/8982
 export function fixTocCodeTag(tocLinks: string) {
-    const lessThanSignRegex = /&#x3C;/gi
+  const lessThanSignRegex = /&#x3C;/gi;
 
-    return tocLinks.replace(lessThanSignRegex, '<')
+  return tocLinks.replace(lessThanSignRegex, '<');
 }


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description
There's a [bug in Gatsby](https://github.com/gatsbyjs/gatsby/issues/8982) such that Table of Content links with code tags inside of them aren't sanitized properly. We can see this bug on several of our pages:

https://nodejs.dev/the-nodejs-path-module
https://nodejs.dev/the-nodejs-os-module
https://nodejs.dev/the-nodejs-events-module
https://nodejs.dev/the-nodejs-http-module

<img width="675" alt="Screen Shot 2019-04-08 at 2 51 27 AM" src="https://user-images.githubusercontent.com/15851351/55715296-4c8a7c00-59a9-11e9-9632-5a32fe86ce70.png">

## Fix
This PR is a fix for Gatsby's issue so our pages can display code in TOC links properly:

<img width="747" alt="Screen Shot 2019-04-08 at 2 57 20 AM" src="https://user-images.githubusercontent.com/15851351/55715674-14376d80-59aa-11e9-9049-b7d8f905f48c.png">

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues
https://github.com/nodejs/nodejs.dev/issues/212
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
