### PR TITLE
Show outline on keyboard nav and style outline to match theme

### DIFF
--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -128,7 +128,7 @@ main {
   grid-template-columns: 420px auto;
 }
 
-summary {
+[data-is-focused="true"] {
   outline: none;
 }
 

--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -128,6 +128,10 @@ main {
   grid-template-columns: 420px auto;
 }
 
+:focus {
+  outline: var(--green3) dotted 2px;
+}
+
 [data-is-focused="true"] {
   outline: none;
 }

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -8,6 +8,7 @@ import SEO from './seo';
 import { isMobileScreen } from '../util/isScreenWithinWidth';
 import { notifyWhenStickyHeadersChange } from '../util/notifyWhenStickyHeadersChange';
 import { StickyChange, SentinelObserverSetupOptions } from '../types';
+import { addFocusOutlineListeners, removeFocusOutlineListeners } from '../util/outlineOnKeyboardNav';
 
 type Props = {
   children: React.ReactNode;
@@ -20,12 +21,17 @@ const Layout = ({ children, title, description, img }: Props) => {
   const prevOffset = useRef<number>(-1);
 
   useEffect(() => {
+    if (window.document && 'documentElement' in window.document) {
+      addFocusOutlineListeners();
+    }
     if ('IntersectionObserver' in window) {
       setupObserver();
     } else {
       // Fallback for browsers without IntersectionObserver support
       magicHeroNumber();
     }
+
+    return cleanUp
   });
 
   const setupObserver = (): void => {
@@ -76,6 +82,10 @@ const Layout = ({ children, title, description, img }: Props) => {
     }
     window.requestAnimationFrame(magicHeroNumber);
   };
+
+  const cleanUp = (): void => {
+    return removeFocusOutlineListeners()
+  }
 
   return (
     <>

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -8,7 +8,10 @@ import SEO from './seo';
 import { isMobileScreen } from '../util/isScreenWithinWidth';
 import { notifyWhenStickyHeadersChange } from '../util/notifyWhenStickyHeadersChange';
 import { StickyChange, SentinelObserverSetupOptions } from '../types';
-import { addFocusOutlineListeners, removeFocusOutlineListeners } from '../util/outlineOnKeyboardNav';
+import {
+  addFocusOutlineListeners,
+  removeFocusOutlineListeners,
+} from '../util/outlineOnKeyboardNav';
 
 type Props = {
   children: React.ReactNode;
@@ -31,7 +34,7 @@ const Layout = ({ children, title, description, img }: Props) => {
       magicHeroNumber();
     }
 
-    return cleanUp
+    return cleanUp;
   });
 
   const setupObserver = (): void => {
@@ -84,8 +87,8 @@ const Layout = ({ children, title, description, img }: Props) => {
   };
 
   const cleanUp = (): void => {
-    return removeFocusOutlineListeners()
-  }
+    return removeFocusOutlineListeners();
+  };
 
   return (
     <>

--- a/src/util/outlineOnKeyboardNav.ts
+++ b/src/util/outlineOnKeyboardNav.ts
@@ -1,0 +1,58 @@
+const TAB_KEYCODE = 9;
+const FOCUS_ATTR = 'data-is-focused';
+const BLUR_EVENT = 'blur';
+const FOCUS_EVENT = 'focus';
+const KEYDOWN_EVENT = 'keydown';
+const MOUSEDOWN_EVENT = 'mousedown';
+
+let IS_MOUSE_EVENT = false;
+
+/**
+ * Attaches listeners for keydown, mousedown, focus, and blur to the document,
+ * which handle adding or removing focus outline css class for mouse events.
+ */
+export function addFocusOutlineListeners() {
+    const docEl = window.document.documentElement;
+    IS_MOUSE_EVENT = false;
+
+    docEl.addEventListener(KEYDOWN_EVENT, handleKeyDown, false);
+    docEl.addEventListener(MOUSEDOWN_EVENT, handleMouseDown, false);
+    docEl.addEventListener(FOCUS_EVENT, handleFocus, true);
+    docEl.addEventListener(BLUR_EVENT, handleBlur, true);
+  }
+
+/**
+ * Detaches listeners
+ */
+export function removeFocusOutlineListeners() {
+  const docEl = window.document.documentElement;
+
+  if (docEl) {
+    docEl.removeEventListener(KEYDOWN_EVENT, handleKeyDown, false);
+    docEl.removeEventListener(MOUSEDOWN_EVENT, handleMouseDown, false);
+    docEl.removeEventListener(FOCUS_EVENT, handleFocus, true);
+    docEl.removeEventListener(BLUR_EVENT, handleBlur, true);
+  }
+}
+
+function handleKeyDown(event: KeyboardEvent) {
+  if (event.keyCode === TAB_KEYCODE) {
+    IS_MOUSE_EVENT = false;
+  }
+}
+
+function handleMouseDown(event: MouseEvent) {
+  IS_MOUSE_EVENT = true;
+}
+
+function handleFocus(event: Event) {
+  if (IS_MOUSE_EVENT && event.target && event.target !== event.currentTarget) {
+    (event.target as Element).setAttribute(FOCUS_ATTR, 'true');
+  }
+}
+
+function handleBlur(event: Event) {
+  if (event.target !== event.currentTarget) {
+    (event.target as Element).removeAttribute(FOCUS_ATTR);
+  }
+}

--- a/src/util/outlineOnKeyboardNav.ts
+++ b/src/util/outlineOnKeyboardNav.ts
@@ -12,14 +12,14 @@ let IS_MOUSE_EVENT = false;
  * which handle adding or removing focus outline css class for mouse events.
  */
 export function addFocusOutlineListeners() {
-    const docEl = window.document.documentElement;
-    IS_MOUSE_EVENT = false;
+  const docEl = window.document.documentElement;
+  IS_MOUSE_EVENT = false;
 
-    docEl.addEventListener(KEYDOWN_EVENT, handleKeyDown, false);
-    docEl.addEventListener(MOUSEDOWN_EVENT, handleMouseDown, false);
-    docEl.addEventListener(FOCUS_EVENT, handleFocus, true);
-    docEl.addEventListener(BLUR_EVENT, handleBlur, true);
-  }
+  docEl.addEventListener(KEYDOWN_EVENT, handleKeyDown, false);
+  docEl.addEventListener(MOUSEDOWN_EVENT, handleMouseDown, false);
+  docEl.addEventListener(FOCUS_EVENT, handleFocus, true);
+  docEl.addEventListener(BLUR_EVENT, handleBlur, true);
+}
 
 /**
  * Detaches listeners

--- a/src/util/outlineOnKeyboardNav.ts
+++ b/src/util/outlineOnKeyboardNav.ts
@@ -35,23 +35,23 @@ export function removeFocusOutlineListeners() {
   }
 }
 
-function handleKeyDown(event: KeyboardEvent) {
+export function handleKeyDown(event: KeyboardEvent) {
   if (event.keyCode === TAB_KEYCODE) {
     IS_MOUSE_EVENT = false;
   }
 }
 
-function handleMouseDown(event: MouseEvent) {
+export function handleMouseDown(event: MouseEvent) {
   IS_MOUSE_EVENT = true;
 }
 
-function handleFocus(event: Event) {
+export function handleFocus(event: Event) {
   if (IS_MOUSE_EVENT && event.target && event.target !== event.currentTarget) {
     (event.target as Element).setAttribute(FOCUS_ATTR, 'true');
   }
 }
 
-function handleBlur(event: Event) {
+export function handleBlur(event: Event) {
   if (event.target !== event.currentTarget) {
     (event.target as Element).removeAttribute(FOCUS_ATTR);
   }

--- a/test/util/outlineOnKeyboardNav.test.js
+++ b/test/util/outlineOnKeyboardNav.test.js
@@ -1,0 +1,35 @@
+import {
+  handleMouseDown,
+  handleFocus,
+  handleKeyDown,
+  handleBlur,
+} from '../../src/util/outlineOnKeyboardNav';
+describe('Tests for focus and blur handlers', () => {
+  const FOCUS_ATTR = 'data-is-focused';
+  const TAB_KEYCODE = 9;
+  let event = {};
+  beforeEach(() => {
+    event = {
+      target: document.createElement('div'),
+      currentTarget: document.createElement('div'),
+      keyCode: TAB_KEYCODE,
+    };
+  });
+  it('hides outline for mouse focus', () => {
+    handleMouseDown(event);
+    handleFocus(event);
+    expect(event.target.getAttribute(FOCUS_ATTR)).toEqual('true');
+  });
+  it('doesnt hide outline for keyboard focus', () => {
+    handleKeyDown(event);
+    handleFocus(event);
+    expect(event.target.getAttribute(FOCUS_ATTR)).toBeNull();
+  });
+  it('Blurs after leaving focus', () => {
+    handleMouseDown(event);
+    handleFocus(event);
+    expect(event.target.getAttribute(FOCUS_ATTR)).toEqual('true');
+    handleBlur(event);
+    expect(event.target.getAttribute(FOCUS_ATTR)).toBeNull();
+  });
+});


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description
This PR partially reverts the changes made in #224 to [comply with a11y on outlines](https://a11yproject.com/posts/never-remove-css-outlines/). 
<!-- Write a brief description of the changes introduced by this PR -->

Outlines will display during keyboard navigation (ex. tabbing) and will hide on mouse clicks.

Outlines have also been styled using nodejs.dev's brand colors, for better visual appeal.

#### Default vs custom style comparison
<img width="313" alt="Screen Shot 2019-04-12 at 9 38 43 PM" src="https://user-images.githubusercontent.com/15851351/56074674-7528c200-5d6b-11e9-97d0-3328921ea6e3.png">

**vs.**

<img width="346" alt="Screen Shot 2019-04-12 at 9 38 31 PM" src="https://user-images.githubusercontent.com/15851351/56074675-78bc4900-5d6b-11e9-816d-8d0c36862113.png">

Resolves #239 