### PR TITLE
Refactor to resolve the returned promise from scrollTo function

### DIFF
--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -19,14 +19,19 @@ const Navigation = ({ sections, currentSlug }: Props) => {
       toggle();
     }
   };
-  const autoScroll = (height: number) => {
+  const autoScroll = async (height: number) => {
     if (isOpen && !hasScrolled && navElement.current) {
       const { newScrollPos, scrollWindow, scrollTime } = calcNavScrollParams(
         height,
         navElement.current
       );
-      scrollTo(newScrollPos, scrollWindow, scrollTime);
-      setHasScrolled(true);
+
+      try {
+        await scrollTo(newScrollPos, scrollWindow, scrollTime);
+        setHasScrolled(true);
+      } catch (e) {
+        setHasScrolled(false);
+      }
     }
   };
 

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -30,6 +30,7 @@ const Navigation = ({ sections, currentSlug }: Props) => {
         await scrollTo(newScrollPos, scrollWindow, scrollTime);
         setHasScrolled(true);
       } catch (e) {
+        // TODO: follow up with appropriate error logging if any
         setHasScrolled(false);
       }
     }

--- a/src/util/scrollTo.tsx
+++ b/src/util/scrollTo.tsx
@@ -19,8 +19,8 @@ export function scrollTo(
   let previousTime = window.performance.now();
   let currentTime = 0;
 
-  const ret: Promise<boolean> = new Promise((resolve, _reject) => {
-    const animateScroll = function animateScroll() {
+  return new Promise((resolve, _reject) => {
+    const animateScroll = () => {
       const time = window.performance.now();
       const increment = time - previousTime;
       previousTime = time;
@@ -30,14 +30,12 @@ export function scrollTo(
         easeInOutCubic(currentTime, start, change, duration)
       );
       if (currentTime < duration) {
-        return window.requestAnimationFrame(animateScroll);
+        window.requestAnimationFrame(animateScroll);
       }
       resolve(true);
     };
     animateScroll();
   });
-
-  return ret;
 }
 
 const SPEED_MODIFIER = 0.9;


### PR DESCRIPTION
## Description

Ran into these IDE warning and gave an attempt to refactor to address the best I could. Sanity tested locally. Looking forward to more sanity test in staging and your review. Thanks.

* returned value is indeed a promise from `scrollTo` function; use `async` / `await` to resolve promise with `try` / `catch` for error scenario

<img width="471" alt="Screen Shot 2019-04-16 at 12 17 51 AM" src="https://user-images.githubusercontent.com/6441326/56182642-1ec4b900-5fe1-11e9-8bd0-b42ef6f056a1.png">

* local variant `ret` in `scrollTo` function could be simplified
<img width="304" alt="Screen Shot 2019-04-16 at 12 18 41 AM" src="https://user-images.githubusercontent.com/6441326/56182672-3ac85a80-5fe1-11e9-914d-dffa736d04d8.png">

* since the promise is always resolving `true` as successful scenario, it seems safe to omit `return` statement, in interest to avoid such nit by code analysis in IDE(s) (e.g. Webstorms)
<img width="416" alt="Screen Shot 2019-04-16 at 12 33 02 AM" src="https://user-images.githubusercontent.com/6441326/56182745-84b14080-5fe1-11e9-8579-adc5bfb9e3a0.png">


## Related Issues

N/A
