### PR TITLE
docs: Fix EventEmitter initialization example

### DIFF
--- a/src/documentation/0036-node-event-emitter/index.md
+++ b/src/documentation/0036-node-event-emitter/index.md
@@ -14,7 +14,8 @@ This module, in particular, offers the `EventEmitter` class, which we'll use to 
 You initialize that using
 
 ```js
-const eventEmitter = require('events').EventEmitter()
+const EventEmitter = require('events')
+const eventEmitter = new EventEmitter()
 ```
 
 This object exposes, among many others, the `on` and `emit` methods.


### PR DESCRIPTION
## Description

We should consider using `new` keyword to properly instantiate EventEmitter class object, otherwise we get an error (as per current docs example):
```js
const eventEmitter = require('events').EventEmitter()
eventEmitter.on('start', () => {
  console.log('started')
})
```
ends up with:
```
TypeError: Cannot read property 'on' of undefined
```

Whereas instantiating with `new`:
```js
const EventEmitter = require('events')                                          
const eventEmitter = new EventEmitter()

console.log(eventEmitter instanceof EventEmitter) // true

eventEmitter.on('start', () => {
  console.log('started')
})
eventEmitter.emit('start')
```
outputs:
```
true
started
```

## Related Issues

Fixes #242 