### PR TITLE
docs: Fix link in docs

### DIFF
--- a/src/documentation/0013-node-output-to-cli/index.md
+++ b/src/documentation/0013-node-output-to-cli/index.md
@@ -146,7 +146,7 @@ It will not appear in the console, but it will appear in the error log.
 
 ## Color the output
 
-You can color the output of your text in the console by using [escape sequences](https://gist.github.com/chrisopedia/8754917). An escape sequence is a set of characters that identifies a color.
+You can color the output of your text in the console by using [escape sequences](https://gist.github.com/iamnewton/8754917). An escape sequence is a set of characters that identifies a color.
 
 Example:
 


### PR DESCRIPTION
Fixes #241 

Previous link was 404 because users seems to change his github handle