### PR TITLE
build: replace gcr images w/ official images

### DIFF
--- a/cloudbuild-deploy.yaml
+++ b/cloudbuild-deploy.yaml
@@ -13,9 +13,11 @@
 # to grant publishing access to Cloud Build.)
 
 steps:
-- name: 'gcr.io/cloud-builders/yarn'
+- name: 'node:10'
+  entrypoint: yarn
   args: ['install']
-- name: 'gcr.io/cloud-builders/yarn'
+- name: 'node:10'
+  entrypoint: yarn
   args: ['run', 'build']
 - name: 'gcr.io/$PROJECT_ID/firebase'
   args: ['deploy', "--project", "$PROJECT_ID", "--only", "hosting"]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,7 +1,9 @@
 steps:
-- name: 'gcr.io/cloud-builders/yarn'
+- name: 'node:10'
+  entrypoint: yarn
   args: ['install']
-- name: 'gcr.io/cloud-builders/yarn'
+- name: 'node:10'
+  entrypoint: yarn
   args: ['run', 'build-ci']
   env:
     - 'PATH_PREFIX=staging.nodejs.dev/$SHORT_SHA'


### PR DESCRIPTION

## Description

currently we use the GCR images which don't allow us to specify node versions. This improves that.