### PR TITLE
feat: Demo Tabs

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -32,6 +32,14 @@ module.exports = {
         include: ['**/*.md'], // ignore files starting with a dot
       },
     },
+    {
+      resolve: 'gatsby-source-filesystem',
+      options: {
+        name: 'content',
+        path: `${__dirname}/src/content/`,
+        include: ['*/*.md'], // ignore files starting with a dot
+      },
+    },
 
     {
       resolve: 'gatsby-plugin-manifest',

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -7,14 +7,18 @@ exports.createPages = ({ graphql, actions }) => {
   const { createPage } = actions;
 
   return new Promise((resolve, reject) => {
-    const docTemplate = path.resolve('./src/templates/learn.tsx');
+    const learnTemplate = path.resolve('./src/templates/learn.tsx');
+    const contentTemplate = path.resolve('./src/templates/content.tsx');
 
     resolve(
       graphql(
         `
           {
             allMarkdownRemark(
-              filter: { fields: { slug: { ne: "" } } }
+              filter: {
+                fields: { slug: { ne: "" } }
+                frontmatter: { section: { ne: "Content" } }
+              }
               sort: { fields: [fileAbsolutePath], order: ASC }
             ) {
               edges {
@@ -112,29 +116,45 @@ exports.createPages = ({ graphql, actions }) => {
         });
 
         docPages.forEach(page => {
-          createPage({
-            path: `/learn/${page.slug}`,
-            component: docTemplate,
-            context: {
-              slug: page.slug,
-              next: page.next,
-              previous: page.previous,
-              relativePath: page.relativePath,
-              navigationData,
-            },
-          });
-          if (page.slug === 'introduction-to-nodejs') {
-            createPage({
-              path: `/learn`,
-              component: docTemplate,
-              context: {
-                slug: page.slug,
-                next: page.next,
-                previous: page.previous,
-                relativePath: page.relativePath,
-                navigationData,
-              },
-            });
+          switch (page.slug) {
+            case 'installing-via-package-manager':
+              // createPage({
+              //   path: `/`,
+              //   component: contentTemplate,
+              //   context: {
+              //     slug: page.slug,
+              //     next: page.next,
+              //     previous: page.previous,
+              //     relativePath: page.relativePath,
+              //     navigationData,
+              //   },
+              // });
+              break;
+            case 'introduction-to-nodejs':
+              createPage({
+                path: `/learn`,
+                component: learnTemplate,
+                context: {
+                  slug: page.slug,
+                  next: page.next,
+                  previous: page.previous,
+                  relativePath: page.relativePath,
+                  navigationData,
+                },
+              });
+              break;
+            default:
+              createPage({
+                path: `/learn/${page.slug}`,
+                component: learnTemplate,
+                context: {
+                  slug: page.slug,
+                  next: page.next,
+                  previous: page.previous,
+                  relativePath: page.relativePath,
+                  navigationData,
+                },
+              });
           }
         });
       })

--- a/src/components/demo-tabs.tsx
+++ b/src/components/demo-tabs.tsx
@@ -3,6 +3,7 @@ import { StaticQuery, graphql } from 'gatsby';
 import { ContentPageData } from '../types';
 import AuthorsList from './authors-list';
 import EditLink from './edit-link';
+import { ParsedContent } from '../util/ParsedContent';
 
 const query = graphql`
   query DemoTabsContent {
@@ -32,26 +33,143 @@ const query = graphql`
   }
 `;
 
-const DemoTabs = (): JSX.Element => (
-  <StaticQuery
-    query={query}
-    render={({
-      content: {
-        // frontmatter: { title, description },
-        parent: { relativePath } = { relativePath: '' },
-        html,
-        tableOfContents,
-        fields: { authors },
-      },
-    }: ContentPageData) => (
-      <article className="article-reader">
-        {/* <h1 className="article-reader__headline">{title}</h1> */}
-        <div dangerouslySetInnerHTML={{ __html: html }} />
-        <AuthorsList authors={authors} />
-        {relativePath && <EditLink relativePath={relativePath} />}
-      </article>
-    )}
-  ></StaticQuery>
-);
+export interface Props {
+  parsedContent?: ParsedContent;
+}
+
+class DemoTabs extends React.Component<Props> {
+  public parsedContent: ParsedContent;
+
+  public articleRef: React.RefObject<HTMLElement>;
+
+  public selectRef: React.RefObject<HTMLSelectElement>;
+
+  public optionMap: Map<HTMLOptionElement, HTMLElement>;
+
+  public options: HTMLOptionElement[];
+
+  public sections: HTMLElement[];
+
+  public currentSection: HTMLElement | null;
+
+  public constructor(props: Props) {
+    super(props);
+    this.parsedContent = (props && props.parsedContent) || new ParsedContent();
+    this.articleRef = React.createRef();
+    this.selectRef = React.createRef();
+    this.optionMap = new Map<HTMLOptionElement, HTMLElement>();
+    this.options = [];
+    this.sections = [];
+    this.currentSection = null;
+  }
+
+  public componentDidMount() {
+    this.populate();
+  }
+
+  public populate() {
+    /* eslint-disable */
+    this.options.splice(0, this.options.length);
+    this.sections.splice(0, this.sections.length);
+    this.currentSection = null;
+
+    // @ts-ignore
+    for (const node of [].concat(...this.optionMap.entries()))
+      node && node.remove();
+
+    this.optionMap.clear();
+
+    const {
+      parsedContent,
+      articleRef: { current: articleNode },
+      selectRef: { current: selectNode },
+    } = this;
+
+    if (!articleNode || !selectNode) return; // requestAnimationFrame(() => this.populate());
+
+    for (const node of [
+      // @ts-ignore
+      ...articleNode.querySelectorAll(':scope > section'),
+      // @ts-ignore
+      ...selectNode.childNodes,
+    ])
+      node && node.remove();
+
+    if (parsedContent.sections) {
+      this.sections.push(...this.parsedContent.sections);
+
+      for (const section of this.sections) {
+        section.removeAttribute('visible');
+        const name = section.getAttribute('name') || '';
+        const option = selectNode.appendChild(document.createElement('option'));
+        this.optionMap.set(option, section);
+        option.setAttribute('value', (option.innerText = name));
+        this.options.push(option);
+      }
+
+      // articleNode.append(... this.sections);
+      articleNode.append(...this.sections, ...articleNode.children);
+      selectNode.append(...this.options);
+      this.select(this.sections[0]);
+    }
+    /* eslint-enable */
+  }
+
+  public select(selection: HTMLOptionElement | HTMLElement) {
+    /* eslint-disable */
+    !selection ||
+      this.sections.includes(selection) ||
+      // @ts-ignore
+      (selection = this.optionMap.get(selection));
+    if (!selection || selection === this.currentSection) return;
+    if (this.currentSection != null)
+      this.currentSection.removeAttribute('visible');
+    selection.setAttribute('visible', '');
+    this.currentSection = selection;
+
+    const heading = /** @type {HTMLHeadingElement} */ this.currentSection.querySelector(
+      'h2:first-child, h3:first-child'
+    );
+    if (heading) heading.hidden = true;
+    /* eslint-enable */
+  }
+
+  public render() {
+    return (
+      <React.Fragment>
+        <label htmlFor="demo-input">
+          <select
+            id="demo-input"
+            ref={this.selectRef}
+            onChange={({ target: { selectedOptions } }) =>
+              this.select(selectedOptions && selectedOptions[0])
+            }
+          />
+        </label>
+        <article className="article-reader" ref={this.articleRef}>
+          <StaticQuery
+            query={query}
+            render={({ content }: ContentPageData) => {
+              const { parent, fields } = content;
+              this.parsedContent.generatedContent = content;
+
+              this.populate();
+
+              return (
+                <footer>
+                  <hr />
+                  <AuthorsList authors={fields.authors} />
+                  {parent && parent.relativePath && (
+                    <EditLink relativePath={parent.relativePath} />
+                  )}
+                </footer>
+              );
+            }}
+          />
+        </article>
+      </React.Fragment>
+    );
+  }
+}
 
 export default DemoTabs;

--- a/src/components/demo-tabs.tsx
+++ b/src/components/demo-tabs.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { StaticQuery, graphql } from 'gatsby';
+import { ContentPageData } from '../types';
+import AuthorsList from './authors-list';
+import EditLink from './edit-link';
+
+const query = graphql`
+  query DemoTabsContent {
+    content: markdownRemark(
+      frontmatter: {
+        title: { eq: "Installing via Package Manager" }
+        section: { eq: "Content" }
+      }
+    ) {
+      id
+      html
+      tableOfContents
+      frontmatter {
+        title
+        description
+      }
+      fields {
+        slug
+        authors
+      }
+      parent {
+        ... on File {
+          relativePath
+        }
+      }
+    }
+  }
+`;
+
+const DemoTabs = (): JSX.Element => (
+  <StaticQuery
+    query={query}
+    render={({
+      content: {
+        // frontmatter: { title, description },
+        parent: { relativePath } = { relativePath: '' },
+        html,
+        tableOfContents,
+        fields: { authors },
+      },
+    }: ContentPageData) => (
+      <article className="article-reader">
+        {/* <h1 className="article-reader__headline">{title}</h1> */}
+        <div dangerouslySetInnerHTML={{ __html: html }} />
+        <AuthorsList authors={authors} />
+        {relativePath && <EditLink relativePath={relativePath} />}
+      </article>
+    )}
+  ></StaticQuery>
+);
+
+export default DemoTabs;

--- a/src/content/0001-installing-via-package-manager/index.md
+++ b/src/content/0001-installing-via-package-manager/index.md
@@ -5,6 +5,8 @@ authors: fhemberger, XhmikosR, vsemozhetbyt, nschonni, kasicka, cassidyjames, Qa
 section: Content
 ---
 
+<section>
+
 # Installing Node.js via package manager
 
 **_Note:_** The packages on this page are maintained and supported by their respective packagers, **not** the Node.js core team. Please report any issues you encounter to the package maintainer. If it turns out your issue is a bug in Node.js itself, the maintainer will report the issue upstream.
@@ -32,6 +34,8 @@ section: Content
 
 ---
 
+</section><section name="Android">
+
 ## Android
 
 Android support is still experimental in Node.js, so precompiled binaries are not yet provided by Node.js developers.
@@ -44,6 +48,8 @@ pkg install nodejs
 
 Currently, Termux Node.js binaries are linked against `system-icu` (depending on `libicu` package).
 
+</section><section name="Arch Linux">
+
 ## Arch Linux
 
 Node.js and npm packages are available in the Community Repository.
@@ -52,9 +58,13 @@ Node.js and npm packages are available in the Community Repository.
 pacman -S nodejs npm
 ```
 
+</section><section name="Debian and Ubuntu based Linux distributions, Enterprise Linux/Fedora and Snap packages">
+
 ## Debian and Ubuntu based Linux distributions, Enterprise Linux/Fedora and Snap packages
 
 [Official Node.js binary distributions](https://github.com/nodesource/distributions/blob/master/README.md) are provided by NodeSource.
+
+</section><section name="FreeBSD">
 
 ## FreeBSD
 
@@ -72,6 +82,8 @@ Or compile it on your own using [ports](https://www.freebsd.org/cgi/man.cgi?port
 cd /usr/ports/www/node && make install
 ```
 
+</section><section name="Gentoo">
+
 ## Gentoo
 
 Node.js is available in the portage tree.
@@ -79,6 +91,8 @@ Node.js is available in the portage tree.
 ```bash
 emerge nodejs
 ```
+
+</section><section name="IBM i">
 
 ## IBM i
 
@@ -105,6 +119,8 @@ Or install a binary package (if available for your platform) using pkgin:
 ```bash
 pkgin -y install nodejs
 ```
+
+</section><section name="nvm">
 
 ## nvm
 
@@ -134,6 +150,8 @@ from source:
 nvm uninstall 8
 ```
 
+</section><section name="OpenBSD">
+
 ## OpenBSD
 
 Node.js is available through the ports system.
@@ -147,6 +165,8 @@ Using [pkg_add](https://man.openbsd.org/OpenBSD-current/man1/pkg_add.1) on OpenB
 ```bash
 pkg_add node
 ```
+
+</section><section name="openSUSE and SLE">
 
 ## openSUSE and SLE
 
@@ -164,6 +184,8 @@ For example, to install Node.js 4.x on openSUSE Leap 42.2, run the following as 
 zypper install nodejs4
 ```
 
+</section><section name="macOS">
+
 ## macOS
 
 Simply download the [macOS Installer](https://nodejs.org/en/#home-downloadhead) directly from the [nodejs.org](https://nodejs.org/) web site.
@@ -173,6 +195,8 @@ _If you want to download the package with bash:_
 ```bash
 curl "https://nodejs.org/dist/latest/node-${VERSION:-$(wget -qO- https://nodejs.org/dist/latest/ | sed -nE 's|.*>node-(.*)\.pkg</a>.*|\1|p')}.pkg" > "$HOME/Downloads/node-latest.pkg" && sudo installer -store -pkg "$HOME/Downloads/node-latest.pkg" -target "/"
 ```
+
+</section><section name="Alternatives">
 
 ### Alternatives
 
@@ -205,6 +229,8 @@ Or build manually from pkgsrc:
 cd pkgsrc/lang/nodejs && bmake install
 ```
 
+</section><section name="SmartOS and illumos">
+
 ## SmartOS and illumos
 
 SmartOS images come with pkgsrc pre-installed. On other illumos distributions, first install **[pkgsrc](https://pkgsrc.joyent.com/install-on-illumos/)**, then you may install the binary package as normal:
@@ -219,6 +245,8 @@ Or build manually from pkgsrc:
 cd pkgsrc/lang/nodejs && bmake install
 ```
 
+</section><section name="Solus">
+
 ## Solus
 
 Solus provides Node.js in its main repository.
@@ -226,6 +254,8 @@ Solus provides Node.js in its main repository.
 ```bash
 sudo eopkg install nodejs
 ```
+
+</section><section name="Void Linux">
 
 ## Void Linux
 
@@ -235,9 +265,13 @@ Void Linux ships Node.js stable in the main repository.
 xbps-install -Sy nodejs
 ```
 
+</section><section name="Windows">
+
 ## Windows
 
 Simply download the [Windows Installer](https://nodejs.org/en/#home-downloadhead) directly from the [nodejs.org](https://nodejs.org/) web site.
+
+</section><section name="Alternatives">
 
 ### Alternatives
 
@@ -254,3 +288,5 @@ Using **[Scoop](https://scoop.sh/)**:
 ```bash
 scoop install nodejs
 ```
+
+</section>

--- a/src/content/0001-installing-via-package-manager/index.md
+++ b/src/content/0001-installing-via-package-manager/index.md
@@ -1,0 +1,256 @@
+---
+title: Installing via Package Manager
+description: 'Quick guides for installing Node.js using popular third-party package managers'
+authors: fhemberger, XhmikosR, vsemozhetbyt, nschonni, kasicka, cassidyjames, Qantas94Heavy, pierreneter, 0mp, Megajin, MaledongGit, TheNuclearCat, yodeyer, geek, sudowork, strawbrary, ryanmurakami, rbnswartz, arkwright, oliversalzburg, mweagle, Mohamed3on, Ginden, kapouer, jperkin, ThePrez, jedsmith, sonicdoe, milosjevtovic, mcollina, fornwall, danbev, naskapal, awochna, ahmetanilgur, qbit
+section: Content
+---
+
+# Installing Node.js via package manager
+
+**_Note:_** The packages on this page are maintained and supported by their respective packagers, **not** the Node.js core team. Please report any issues you encounter to the package maintainer. If it turns out your issue is a bug in Node.js itself, the maintainer will report the issue upstream.
+
+---
+
+- [Installing Node.js via package manager](#installing-nodejs-via-package-manager)
+  - [Android](#android)
+  - [Arch Linux](#arch-linux)
+  - [Debian and Ubuntu based Linux distributions, Enterprise Linux/Fedora and Snap packages](#debian-and-ubuntu-based-linux-distributions-enterprise-linuxfedora-and-snap-packages)
+  - [FreeBSD](#freebsd)
+  - [Gentoo](#gentoo)
+  - [IBM i](#ibm-i)
+  - [NetBSD](#netbsd)
+  - [nvm](#nvm)
+  - [OpenBSD](#openbsd)
+  - [openSUSE and SLE](#opensuse-and-sle)
+  - [macOS](#macos)
+    - [Alternatives](#alternatives)
+  - [SmartOS and illumos](#smartos-and-illumos)
+  - [Solus](#solus)
+  - [Void Linux](#void-linux)
+  - [Windows](#windows)
+    - [Alternatives](#alternatives-1)
+
+---
+
+## Android
+
+Android support is still experimental in Node.js, so precompiled binaries are not yet provided by Node.js developers.
+
+However, there are some third-party solutions. For example, [Termux](https://termux.com/) community provides terminal emulator and Linux environment for Android, as well as own package manager and [extensive collection](https://github.com/termux/termux-packages) of many precompiled applications. This command in Termux app will install the last available Node.js version:
+
+```bash
+pkg install nodejs
+```
+
+Currently, Termux Node.js binaries are linked against `system-icu` (depending on `libicu` package).
+
+## Arch Linux
+
+Node.js and npm packages are available in the Community Repository.
+
+```bash
+pacman -S nodejs npm
+```
+
+## Debian and Ubuntu based Linux distributions, Enterprise Linux/Fedora and Snap packages
+
+[Official Node.js binary distributions](https://github.com/nodesource/distributions/blob/master/README.md) are provided by NodeSource.
+
+## FreeBSD
+
+The most recent release of Node.js is available via the [www/node](https://www.freshports.org/www/node) port.
+
+Install a binary package via [pkg](https://www.freebsd.org/cgi/man.cgi?pkg):
+
+```bash
+pkg install node
+```
+
+Or compile it on your own using [ports](https://www.freebsd.org/cgi/man.cgi?ports):
+
+```bash
+cd /usr/ports/www/node && make install
+```
+
+## Gentoo
+
+Node.js is available in the portage tree.
+
+```bash
+emerge nodejs
+```
+
+## IBM i
+
+LTS versions of Node.js are available from IBM, and are available via [the 'yum' package manager](https://ibm.biz/ibmi-rpms). The package name is `nodejs` followed by the major version number (for instance, `nodejs8`, `nodejs10`, `nodejs12`, etc)
+
+To install Node.js 12.x from the command line, run the following as a user with \*ALLOBJ special authority:
+
+```bash
+yum install nodejs12
+```
+
+Node.js can also be installed with the IBM i Access Client Solutions product. See [this support document](http://www-01.ibm.com/support/docview.wss?uid=nas8N1022619) for more details
+
+## NetBSD
+
+Node.js is available in the pkgsrc tree:
+
+```bash
+cd /usr/pkgsrc/lang/nodejs && make install
+```
+
+Or install a binary package (if available for your platform) using pkgin:
+
+```bash
+pkgin -y install nodejs
+```
+
+## nvm
+
+Node Version Manager is a bash script used to manage multiple released Node.js versions. It allows
+you to perform operations like install, uninstall, switch version, etc.
+To install nvm, use this [install script](https://github.com/creationix/nvm#install-script).
+
+On Unix / OS X systems Node.js built from source can be installed using
+[nvm](https://github.com/creationix/nvm) by installing into the location that nvm expects:
+
+```bash
+env VERSION=`python tools/getnodeversion.py` make install DESTDIR=`nvm_version_path v$VERSION` PREFIX=""
+```
+
+After this you can use `nvm` to switch between released versions and versions
+built from source.
+For example, if the version of Node.js is v8.0.0-pre:
+
+```bash
+nvm use 8
+```
+
+Once the official release is out you will want to uninstall the version built
+from source:
+
+```bash
+nvm uninstall 8
+```
+
+## OpenBSD
+
+Node.js is available through the ports system.
+
+```bash
+/usr/ports/lang/node
+```
+
+Using [pkg_add](https://man.openbsd.org/OpenBSD-current/man1/pkg_add.1) on OpenBSD:
+
+```bash
+pkg_add node
+```
+
+## openSUSE and SLE
+
+Node.js is available in the main repositories under the following packages:
+
+- **openSUSE Leap 42.2**: `nodejs4`
+- **openSUSE Leap 42.3**: `nodejs4`, `nodejs6`
+- **openSUSE Tumbleweed**: `nodejs4`, `nodejs6`, `nodejs8`
+- **SUSE Linux Enterprise Server (SLES) 12**: `nodejs4`, `nodejs6`
+  (The "Web and Scripting Module" must be [added before installing](https://www.suse.com/documentation/sles-12/book_sle_deployment/data/sec_add-ons_extensions.html).)
+
+For example, to install Node.js 4.x on openSUSE Leap 42.2, run the following as root:
+
+```bash
+zypper install nodejs4
+```
+
+## macOS
+
+Simply download the [macOS Installer](https://nodejs.org/en/#home-downloadhead) directly from the [nodejs.org](https://nodejs.org/) web site.
+
+_If you want to download the package with bash:_
+
+```bash
+curl "https://nodejs.org/dist/latest/node-${VERSION:-$(wget -qO- https://nodejs.org/dist/latest/ | sed -nE 's|.*>node-(.*)\.pkg</a>.*|\1|p')}.pkg" > "$HOME/Downloads/node-latest.pkg" && sudo installer -store -pkg "$HOME/Downloads/node-latest.pkg" -target "/"
+```
+
+### Alternatives
+
+Using **[Homebrew](https://brew.sh/)**:
+
+```bash
+brew install node
+```
+
+Using **[MacPorts](https://www.macports.org/)**:
+
+```bash
+port install nodejs<major version>
+
+# Example
+port install nodejs7
+```
+
+Using **[pkgsrc](https://pkgsrc.joyent.com/install-on-osx/)**:
+
+Install the binary package:
+
+```bash
+pkgin -y install nodejs
+```
+
+Or build manually from pkgsrc:
+
+```bash
+cd pkgsrc/lang/nodejs && bmake install
+```
+
+## SmartOS and illumos
+
+SmartOS images come with pkgsrc pre-installed. On other illumos distributions, first install **[pkgsrc](https://pkgsrc.joyent.com/install-on-illumos/)**, then you may install the binary package as normal:
+
+```bash
+pkgin -y install nodejs
+```
+
+Or build manually from pkgsrc:
+
+```bash
+cd pkgsrc/lang/nodejs && bmake install
+```
+
+## Solus
+
+Solus provides Node.js in its main repository.
+
+```bash
+sudo eopkg install nodejs
+```
+
+## Void Linux
+
+Void Linux ships Node.js stable in the main repository.
+
+```bash
+xbps-install -Sy nodejs
+```
+
+## Windows
+
+Simply download the [Windows Installer](https://nodejs.org/en/#home-downloadhead) directly from the [nodejs.org](https://nodejs.org/) web site.
+
+### Alternatives
+
+Using **[Chocolatey](https://chocolatey.org/)**:
+
+```bash
+cinst nodejs
+# or for full install with npm
+cinst nodejs.install
+```
+
+Using **[Scoop](https://scoop.sh/)**:
+
+```bash
+scoop install nodejs
+```

--- a/src/images/window-buttons-disabled.svg
+++ b/src/images/window-buttons-disabled.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 8 2" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="1" cy="1" r="1" fill="#9999"/>
+  <circle cx="4" cy="1" r="1" fill="#9999"/>
+  <circle cx="7" cy="1" r="1" fill="#9999"/>
+</svg>

--- a/src/images/window-buttons.svg
+++ b/src/images/window-buttons.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 8 2" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="1" cy="1" r="1" fill="rgb(255,90,82)"/>
+  <circle cx="4" cy="1" r="1" fill="rgb(230,192,40)"/>
+  <circle cx="7" cy="1" r="1" fill="rgb(83,194,44)"/>
+</svg>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'gatsby';
 import Hero from '../components/hero';
 import Layout from '../components/layout';
+import DemoTabs from '../components/demo-tabs';
 import '../util/konami';
 
 import '../styles/index.css';
@@ -56,7 +57,9 @@ export default function Index(): JSX.Element {
         <Hero title={title} subTitle={subTitle} />
 
         <section className="node-demo-container">
-          <div className="node-demo"></div>
+          <div className="node-demo">
+            <DemoTabs />
+          </div>
           <img className="leafs-front" src={leafsIllustrationFront} alt="" />
           <img className="leafs-middle" src={leafsIllustrationMiddle} alt="" />
           <img className="leafs-back" src={leafsIllustrationBack} alt="" />

--- a/src/styles/demo-tabs.css
+++ b/src/styles/demo-tabs.css
@@ -1,0 +1,13 @@
+.node-demo > article pre.language-bash:before {
+  display: block;
+  content:'';
+  position:absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  left: 0;
+  background: var(--color-text-accent);
+  border: 1px solid var(--color-text-accent);
+  opacity: 0.05;
+  /* outline: 1px solid var(--color-text-accent); */
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -98,18 +98,153 @@
     position: relative;
 }
 
+.node-demo:after {
+    display: block;
+    position: absolute;
+    left: 1px;
+    top: 1px;
+    right: 1px;
+    bottom: 1px;
+    content: '';
+    box-shadow: inset 1px 1px 0.75px #fff3;
+    pointer-events: none;
+    border-radius: inherit;
+    z-index: 1;
+}
+
 .node-demo {
+    position: relative;
+    --fill-color: var(--black9);
     width: 832px;
     margin: 0 auto;
     margin-bottom: 240px;
     height: 374px;
-    background: var(--black9);
+    background: var(--fill-color);
     border-radius: var(--space-04);
-    box-shadow: 5px 10px 50px rgba(0, 0, 0, .25);
+    box-shadow: 5px 10px 50px rgba(0, 0, 0, 0.25);
     color: var(--black0);
     z-index: 2;
-    /* TODO: We need to contain both content and scrolling  */
-    overflow: scroll;
+    overflow: hidden;
+    box-sizing: padding-box;
+    display: flex;
+    flex-flow: column;
+    place-content: stretch;
+    place-items: stretch;
+    padding: 0;
+    contain: paint;
+}
+
+.node-demo > article > section,
+.node-demo > article {
+    outline: 1px solid red;
+}
+
+.node-demo > article {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    width: calc(100% - 3em);
+    max-width: none;
+    margin: 0;
+    overflow-y: scroll;
+    display: block;
+    flex: 1;
+    padding: 1.5em;
+    overscroll-behavior: contain;
+    z-index: -1;
+    font-family: var(--mono);
+}
+
+.node-demo > label {
+    position: relative;
+    padding-left: 5em;
+    padding-right: 5em;
+    border-radius: inherit;
+    z-index: 1;
+    backdrop-filter: blur(5px);
+}
+
+.node-demo > label:before {
+    display: block;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    content: '';
+    background-color: var(--fill-color);
+    opacity: 0.9;
+    pointer-events: none;
+    border-radius: inherit;
+    z-index: -1;
+}
+.node-demo > label:after {
+    display: block;
+    position: absolute;
+    left: 0;
+    top: 0;
+    content: '';
+    background-image: url(../images/window-buttons.svg);
+    background-position: 5% 50%;
+    background-repeat: no-repeat;
+    background-size: auto 40%;
+    height: 100%;
+    width: 25%;
+    pointer-events: none;
+    border-radius: inherit;
+    /* width: 8em; */
+}
+
+.node-demo:not(:hover) > label:after {
+    background-image: url(../images/window-buttons-disabled.svg);
+}
+
+.node-demo footer {
+    margin-top: 5em;
+}
+
+.node-demo > label > select {
+    width: 100%;
+    text-align: center;
+    color: white;
+    background: transparent;
+    box-shadow: none;
+    border: none;
+    outline: none;
+    z-index: 1;
+}
+
+.node-demo > article > section[visible] {
+    display: contents;
+}
+.node-demo > article > section:not([visible]) {
+    display: none;
+}
+
+.node-demo > article pre {
+    white-space: pre-wrap;
+    position: relative;
+    width: inherit;
+    overflow-x: hidden;
+}
+
+pre > code.line {
+    -webkit-padding-start: 1em;
+    padding-inline-start: 1em;
+    text-indent: -1em;
+    display: inline-block;
+    white-space: pre-wrap;
+}
+
+pre > code.line.shell-command:before {
+    content: '\203A';
+    display: inline-block;
+    position: absolute;
+    text-indent: -0.75em;
+    color: var(--color-text-accent);
+    width: 0.75em;
 }
 
 .leafs-front {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -108,6 +108,8 @@
     box-shadow: 5px 10px 50px rgba(0, 0, 0, .25);
     color: var(--black0);
     z-index: 2;
+    /* TODO: We need to contain both content and scrolling  */
+    overflow: scroll;
 }
 
 .leafs-front {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,428 +1,436 @@
 .home-page {
-    max-width: 960px;
-    margin: 0 auto;
-    margin-bottom: var(--space-80);
-    position: relative;
+  max-width: 960px;
+  margin: 0 auto;
+  margin-bottom: var(--space-80);
+  position: relative;
 
-    --section-margin-bottom: 340px;
+  --section-margin-bottom: 340px;
 }
 
 .pentagon-illustration-big1 {
-    position: absolute;
-    top: 1200px;
-    z-index: -1;
-    right: 0;
+  position: absolute;
+  top: 1200px;
+  z-index: -1;
+  right: 0;
 }
 
 .pentagon-illustration-big2 {
-    position: absolute;
-    z-index: -2;
-    left: 0;
-    bottom: -2000px;
+  position: absolute;
+  z-index: -2;
+  left: 0;
+  bottom: -2000px;
 }
 
 .double-background {
-    position: absolute;
-    width: 100%;
-    height: 1954px;
-    top: 808px;
-    background: var(--color-fill-canvas);
-    z-index: -10;
+  position: absolute;
+  width: 100%;
+  height: 1954px;
+  top: 808px;
+  background: var(--color-fill-canvas);
+  z-index: -10;
 }
 
 .home-page-hero {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-direction: column;
-    text-align: center;
-    padding-top: var(--space-96);
-    margin-bottom: 160px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  text-align: center;
+  padding-top: var(--space-96);
+  margin-bottom: 160px;
 }
 
-.home-page-hero h1, p {
-    margin: 0;
+.home-page-hero h1,
+p {
+  margin: 0;
 }
 
 .home-page-hero h1 {
-    max-width: 840px;
+  max-width: 840px;
 }
 
 .home-page-hero .sub-title {
-    max-width: 780px;
-    color: var(--color-text-secondary);
-    margin: var(--space-32) 0 var(--space-80) 0;
-    font-weight: var(--font-weight-light);
+  max-width: 780px;
+  color: var(--color-text-secondary);
+  margin: var(--space-32) 0 var(--space-80) 0;
+  font-weight: var(--font-weight-light);
 }
 
 .download-lts-container {
-    position: relative;
+  position: relative;
 }
 
 .download-lts-container .links {
-    color: var(--color-text-secondary);
-    margin: var(--space-08) 0 0 0;
-    position: absolute;
-    left: calc(var(--space-16) * -1);
+  color: var(--color-text-secondary);
+  margin: var(--space-08) 0 0 0;
+  position: absolute;
+  left: calc(var(--space-16) * -1);
 }
 
 .home-page-hero .btn-ctas {
-    display: flex;
+  display: flex;
 }
 
 .home-page-hero .btn-ctas button {
-    border: none;
-    box-sizing: border-box;
-    width: 20rem;
-    height: 5.6rem;
-    padding: 0 var(--space-16);
-    font-weight: var(--font-weight-semibold);
-    margin: 0;
+  border: none;
+  box-sizing: border-box;
+  width: 20rem;
+  height: 5.6rem;
+  padding: 0 var(--space-16);
+  font-weight: var(--font-weight-semibold);
+  margin: 0;
 }
 
 .home-page-hero .btn-ctas .download-lts-cta {
-    border-radius: 5.6rem;
-    background: var(--color-fill-action);
-    color: var(--black0);
-    margin-right: var(--space-32);
-    position: relative;
+  border-radius: 5.6rem;
+  background: var(--color-fill-action);
+  color: var(--black0);
+  margin-right: var(--space-32);
+  position: relative;
 }
 
 .home-page-hero .btn-ctas .learn-cta {
-    border-radius: 5.6rem;
-    border: var(--color-fill-action) var(--space-02) solid;
-    color: var(--color-fill-action);
+  border-radius: 5.6rem;
+  border: var(--color-fill-action) var(--space-02) solid;
+  color: var(--color-fill-action);
 }
 
 .node-demo-container {
-    position: relative;
+  position: relative;
 }
 
 .node-demo:after {
-    display: block;
-    position: absolute;
-    left: 1px;
-    top: 1px;
-    right: 1px;
-    bottom: 1px;
-    content: '';
-    box-shadow: inset 1px 1px 0.75px #fff3;
-    pointer-events: none;
-    border-radius: inherit;
-    z-index: 1;
+  display: block;
+  position: absolute;
+  left: 1px;
+  top: 1px;
+  right: 1px;
+  bottom: 1px;
+  content: '';
+  box-shadow: inset 1px 1px 0.75px #fff3;
+  pointer-events: none;
+  border-radius: inherit;
+  z-index: 1;
 }
 
 .node-demo {
-    position: relative;
-    --fill-color: var(--black9);
-    width: 832px;
-    margin: 0 auto;
-    margin-bottom: 240px;
-    height: 374px;
-    background: var(--fill-color);
-    border-radius: var(--space-04);
-    box-shadow: 5px 10px 50px rgba(0, 0, 0, 0.25);
-    color: var(--black0);
-    z-index: 2;
-    overflow: hidden;
-    box-sizing: padding-box;
-    display: flex;
-    flex-flow: column;
-    place-content: stretch;
-    place-items: stretch;
-    padding: 0;
-    contain: paint;
+  position: relative;
+  --fill-color: var(--black9);
+  width: 832px;
+  margin: 0 auto;
+  margin-bottom: 240px;
+  height: 374px;
+  background: var(--fill-color);
+  border-radius: var(--space-04);
+  box-shadow: 5px 10px 50px rgba(0, 0, 0, 0.25);
+  color: var(--black0);
+  z-index: 2;
+  overflow: hidden;
+  box-sizing: padding-box;
+  display: flex;
+  flex-flow: column;
+  place-content: stretch;
+  place-items: stretch;
+  padding: 0;
+  contain: paint;
 }
 
 .node-demo > article > section,
 .node-demo > article {
-    outline: 1px solid red;
+  outline: 1px solid red;
 }
 
 .node-demo > article {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    width: calc(100% - 3em);
-    max-width: none;
-    margin: 0;
-    overflow-y: scroll;
-    display: block;
-    flex: 1;
-    padding: 1.5em;
-    overscroll-behavior: contain;
-    z-index: -1;
-    font-family: var(--mono);
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  width: calc(100% - 3em);
+  max-width: none;
+  margin: 0;
+  overflow-y: scroll;
+  display: block;
+  flex: 1;
+  padding: 1.5em;
+  /* overscroll-behavior: contain; */
+  z-index: -1;
+  font-family: var(--mono);
 }
 
 .node-demo > label {
-    position: relative;
-    padding-left: 5em;
-    padding-right: 5em;
-    border-radius: inherit;
-    z-index: 1;
-    backdrop-filter: blur(5px);
+  position: relative;
+  padding-left: 5em;
+  padding-right: 5em;
+  border-radius: inherit;
+  z-index: 1;
+  backdrop-filter: blur(5px);
 }
 
 .node-demo > label:before {
-    display: block;
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    content: '';
-    background-color: var(--fill-color);
-    opacity: 0.9;
-    pointer-events: none;
-    border-radius: inherit;
-    z-index: -1;
+  padding: 1.75ex 15% 0;
+  line-height: 0;
+  display: table-caption;
+  text-align: center;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  content: attr(aria-selected);
+  background-color: var(--fill-color);
+  opacity: 0.9;
+  pointer-events: none;
+  border-radius: inherit;
+  z-index: -1;
 }
 .node-demo > label:after {
-    display: block;
-    position: absolute;
-    left: 0;
-    top: 0;
-    content: '';
-    background-image: url(../images/window-buttons.svg);
-    background-position: 5% 50%;
-    background-repeat: no-repeat;
-    background-size: auto 40%;
-    height: 100%;
-    width: 25%;
-    pointer-events: none;
-    border-radius: inherit;
-    /* width: 8em; */
+  display: block;
+  position: absolute;
+  left: 0;
+  top: 0;
+  content: '';
+  background-image: url(../images/window-buttons.svg);
+  background-position: 5% 50%;
+  background-repeat: no-repeat;
+  background-size: auto 40%;
+  height: 100%;
+  width: 25%;
+  pointer-events: none;
+  border-radius: inherit;
 }
 
 .node-demo:not(:hover) > label:after {
-    background-image: url(../images/window-buttons-disabled.svg);
+  background-image: url(../images/window-buttons-disabled.svg);
 }
 
 .node-demo footer {
-    margin-top: 5em;
+  margin-top: 5em;
 }
 
 .node-demo > label > select {
-    width: 100%;
-    text-align: center;
-    color: white;
-    background: transparent;
-    box-shadow: none;
-    border: none;
-    outline: none;
-    z-index: 1;
+  width: 100%;
+  text-align: center;
+  color: white;
+  background: transparent;
+  box-shadow: none;
+  border: none;
+  outline: none;
+  z-index: 1;
+  opacity: 0;
 }
 
 .node-demo > article > section[visible] {
-    display: contents;
+  display: contents;
 }
 .node-demo > article > section:not([visible]) {
-    display: none;
+  display: none;
 }
 
 .node-demo > article pre {
-    white-space: pre-wrap;
-    position: relative;
-    width: inherit;
-    overflow-x: hidden;
+  white-space: pre-wrap;
+  position: relative;
+  width: inherit;
+  overflow-x: hidden;
 }
 
 pre > code.line {
-    -webkit-padding-start: 1em;
-    padding-inline-start: 1em;
-    text-indent: -1em;
-    display: inline-block;
-    white-space: pre-wrap;
+  -webkit-padding-start: 1em;
+  padding-inline-start: 1em;
+  text-indent: -1em;
+  display: inline-block;
+  white-space: pre-wrap;
 }
 
 pre > code.line.shell-command:before {
-    content: '\203A';
-    display: inline-block;
-    position: absolute;
-    text-indent: -0.75em;
-    color: var(--color-text-accent);
-    width: 0.75em;
+  content: '\203A';
+  display: inline-block;
+  position: absolute;
+  text-indent: -0.75em;
+  color: var(--color-text-accent);
+  width: 0.75em;
 }
 
 .leafs-front {
-    position: absolute;
-    top: 145px;
-    right: -16px;
-    z-index: -1;
-    animation: leafs-animation 10s infinite alternate ease-in-out;
-    filter: drop-shadow(10px 5px 50px rgba(0, 0, 0, .1));
+  position: absolute;
+  top: 145px;
+  right: -16px;
+  z-index: -1;
+  animation: leafs-animation 10s infinite alternate ease-in-out;
+  filter: drop-shadow(10px 5px 50px rgba(0, 0, 0, 0.1));
 }
 
 .leafs-middle {
-    position: absolute;
-    top: -32px;
-    right: 20px;
-    z-index: -2;
-    animation: leafs-animation 15s infinite alternate ease-in-out;
-    filter: drop-shadow(6px 5px 25px rgba(0, 0, 0, .1));
+  position: absolute;
+  top: -32px;
+  right: 20px;
+  z-index: -2;
+  animation: leafs-animation 15s infinite alternate ease-in-out;
+  filter: drop-shadow(6px 5px 25px rgba(0, 0, 0, 0.1));
 }
 
 .leafs-back {
-    position: absolute;
-    top: -48px;
-    left: -62px;
-    z-index: -3;
-    animation: leafs-animation 18s infinite alternate ease-in-out;
+  position: absolute;
+  top: -48px;
+  left: -62px;
+  z-index: -3;
+  animation: leafs-animation 18s infinite alternate ease-in-out;
 }
 
 .dots {
-    position: absolute;
-    top: 180px;
-    left: -24px;
-    z-index: -4;
+  position: absolute;
+  top: 180px;
+  left: -24px;
+  z-index: -4;
 }
 
 .node-features {
-    width: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: space-around;
-    margin-bottom: var(--section-margin-bottom);
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+  margin-bottom: var(--section-margin-bottom);
 }
 
 .node-features__feature {
-    max-width: 188px;
-    color: var(--color-text-secondary);
+  max-width: 188px;
+  color: var(--color-text-secondary);
 }
 
-.node-features__feature, p {
-    margin-top: var(--space-24);
+.node-features__feature,
+p {
+  margin-top: var(--space-24);
 }
 
 .join-node .accent {
-    color: var(--pink5);
+  color: var(--pink5);
 }
 
 .join-node {
-    width: 200%;
-    margin: 0 auto;
-    margin-bottom: var(--section-margin-bottom);
-    max-width: 851px;
+  width: 200%;
+  margin: 0 auto;
+  margin-bottom: var(--section-margin-bottom);
+  max-width: 851px;
 }
 
 .join-node-form-container {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
 }
 
 .input-subscribe {
-    box-sizing: border-box;
-    padding: var(--space-16) var(--space-24);
-    border-radius: 3px;
-    border: var(--space-02) solid var(--color-border-primary);
-    height: 5.6rem;
+  box-sizing: border-box;
+  padding: var(--space-16) var(--space-24);
+  border-radius: 3px;
+  border: var(--space-02) solid var(--color-border-primary);
+  height: 5.6rem;
 }
 
 .join-node p {
-    max-width: 390px;
-    color: var(--color-text-secondary);
+  max-width: 390px;
+  color: var(--color-text-secondary);
 }
 
 .see-more-events {
-    margin-top: var(--space-48);
-    color: var(--pink5);
-    display: block;
+  margin-top: var(--space-48);
+  color: var(--pink5);
+  display: block;
 }
 
 .see-more-events span {
-    margin-left: var(--space-08);
+  margin-left: var(--space-08);
 }
 
 .btn-subscribe {
-    border: none;
-    box-sizing: border-box;
-    height: 5.6rem;
-    padding: 0 var(--space-24);
-    font-weight: var(--font-weight-semibold);
-    background: var(--color-fill-action);
-    border-radius: var(--space-04);
-    color: var(--black0);
-    margin: 0;
-    margin-left: var(--space-08);
-    cursor: pointer;
+  border: none;
+  box-sizing: border-box;
+  height: 5.6rem;
+  padding: 0 var(--space-24);
+  font-weight: var(--font-weight-semibold);
+  background: var(--color-fill-action);
+  border-radius: var(--space-04);
+  color: var(--black0);
+  margin: 0;
+  margin-left: var(--space-08);
+  cursor: pointer;
 }
 
 .trusted-by {
-    margin-bottom: var(--section-margin-bottom);
-    text-align: center;
-    width: 100%;
+  margin-bottom: var(--section-margin-bottom);
+  text-align: center;
+  width: 100%;
 }
 
 .trusted-by p {
-    color: var(--color-text-secondary);
-    margin-bottom: var(--space-64);
+  color: var(--color-text-secondary);
+  margin-bottom: var(--space-64);
 }
 
 .trusted-by .logos-container {
-    display: flex;
-    align-items: center;
-    flex-direction: row;
-    justify-content: space-between;
-    filter: grayscale();
+  display: flex;
+  align-items: center;
+  flex-direction: row;
+  justify-content: space-between;
+  filter: grayscale();
 }
 
 .get-started-callouts {
-    width: 100%;
-    display: flex;
-    flex-direction: row;
-    text-align: center;
-    justify-content: space-between;
-    margin-bottom: var(--space-80);
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  text-align: center;
+  justify-content: space-between;
+  margin-bottom: var(--space-80);
 }
 
 .get-started-callout {
-    text-decoration: none;
-    display: flex;
-    flex-direction: column;
+  text-decoration: none;
+  display: flex;
+  flex-direction: column;
 }
 
 .get-started-callout h5 {
-    color: var(--color-text-primary);
-    margin: 0;
-    margin-top: var(--space-24);
+  color: var(--color-text-primary);
+  margin: 0;
+  margin-top: var(--space-24);
 }
 
 .get-started-callout p {
-    margin-top: var(--space-16);
-    color: var(--color-text-secondary);
-    width: 422px;
+  margin-top: var(--space-16);
+  color: var(--color-text-secondary);
+  width: 422px;
 }
 
 .btn-primary {
-    display: block;
-    width: 141px;
-    margin: 0 auto;
-    cursor: pointer;
-    border: none;
-    box-sizing: border-box;
-    padding: var(--space-08) var(--space-24);
-    font-weight: var(--font-weight-semibold);
-    background: var(--color-fill-action);
-    color: var(--black0);
-    border-radius: var(--space-04);
-    text-decoration: none;
-    line-height: var(--line-height-body1);
+  display: block;
+  width: 141px;
+  margin: 0 auto;
+  cursor: pointer;
+  border: none;
+  box-sizing: border-box;
+  padding: var(--space-08) var(--space-24);
+  font-weight: var(--font-weight-semibold);
+  background: var(--color-fill-action);
+  color: var(--black0);
+  border-radius: var(--space-04);
+  text-decoration: none;
+  line-height: var(--line-height-body1);
 }
 
-.btn-primary:hover, .btn-primary:focus {
-    color: var(--black0);
+.btn-primary:hover,
+.btn-primary:focus {
+  color: var(--black0);
 }
 
 @keyframes leafs-animation {
-    50% {
-        transform: rotate(5deg);
-    }
-    100% {
-        transform: rotate(8deg);
-    }
+  50% {
+    transform: rotate(5deg);
+  }
+  100% {
+    transform: rotate(8deg);
+  }
 }
-  

--- a/src/templates/learn.tsx
+++ b/src/templates/learn.tsx
@@ -41,7 +41,10 @@ export default LearnLayout;
 
 export const query = graphql`
   query DocBySlug($slug: String!) {
-    doc: markdownRemark(fields: { slug: { eq: $slug } }) {
+    doc: markdownRemark(
+      fields: { slug: { eq: $slug } }
+      frontmatter: { section: { ne: "Content" } }
+    ) {
       id
       html
       tableOfContents

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,18 +7,25 @@ export interface LearnPageContext {
 }
 
 export interface LearnPageData {
-  doc: {
-    id: string;
-    html: string;
-    tableOfContents: string;
-    frontmatter: {
-      title: string;
-      description: string;
-    };
-    fields: {
-      authors: string[];
-    };
+  doc: GeneratedPageDocument;
+}
+
+export interface ContentPageData {
+  content: GeneratedPageDocument;
+}
+
+interface GeneratedPageDocument {
+  id: string;
+  html: string;
+  tableOfContents: string;
+  frontmatter: {
+    title: string;
+    description: string;
   };
+  fields: {
+    authors: string[];
+  };
+  parent?: { relativePath: string };
 }
 
 export interface PaginationInfo {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -58,3 +58,16 @@ export interface SentinelObserverSetupOptions {
   headerRootMargin?: string;
   footerRootMargin?: string;
 }
+
+declare global {
+  interface NodeListOf<TNode extends Node> extends NodeList {
+    [Symbol.iterator](): Iterator<TNode>;
+  }
+  interface HTMLCollection {
+    [Symbol.iterator](): Iterator<HTMLElement>;
+  }
+
+  interface Element {
+    hidden: boolean;
+  }
+}

--- a/src/util/ParsedContent.js
+++ b/src/util/ParsedContent.js
@@ -71,38 +71,43 @@ export class ParsedContent {
     if (ownerDocument === null || template === null) return null;
     if (generatedContent == null) return document.createDocumentFragment();
 
+    // template.innerHTML = `<scope>${generatedContent.html}</scope>`;
     template.innerHTML = generatedContent.html;
     return template.content.cloneNode(true);
   }
 
   /** @param {ParsedContent} content */
   static parseFragment(content) {
-    if (!content || !ParsedContent[Symbol.hasInstance](content)) return null;
-
-    const parsedHTML = '';
+    if (!content || !ParsedContent[Symbol.hasInstance](content)) return;
 
     const { documentFragment: fragment, ownerDocument: document } = content;
 
-    if (!fragment || !document) return; // parsedHTML;
+    if (!fragment || !document) return;
 
     const { textContent: generatedHTML } = fragment;
 
-    if (!generatedHTML || !generatedHTML.trim()) return; // generatedHTML;
+    if (!generatedHTML || !generatedHTML.trim()) return;
 
     ParsedContent.processCodeBlocks(content);
     ParsedContent.processAnchorTargets(content);
     ParsedContent.processSections(content);
+
+    // return;
   }
 
   /** @param {ParsedContent} content */
   static processSections(content) {
+    // debugger;
     if (!content || !content.documentFragment || !content.ownerDocument) return;
     /* eslint-disable */
-    content.sections = Object.freeze(
-      /** @type {HTMLElement[]} */ ([
-        ...content.documentFragment.querySelectorAll(':scope > section[name]'),
-      ])
-    );
+
+    const parent = content.documentFragment.querySelector(':root > article:first-of-type:last-of-type') || content.documentFragment;
+    /** @type {HTMLElement[]} */
+    const sections = /** @type {HTMLElement[]} */ ([
+      ...content.documentFragment.querySelectorAll('section[name]:not(:empty)'),
+    ]).filter(section => section.parentNode === parent);
+
+    content.sections = Object.freeze(sections);
     /* eslint-enable */
   }
 
@@ -185,7 +190,8 @@ export class ParsedContent {
   /** @param {GeneratedContent} [content] @param {Document} [ownerDocument] */
   constructor(content, ownerDocument) {
     /* eslint-disable */
-    if (!ownerDocument) ownerDocument = typeof document === 'object' && document || undefined;
+    if (!ownerDocument)
+      ownerDocument = (typeof document === 'object' && document) || undefined;
     this.ownerDocument =
       /** @type {Document | null | undefined} */ ((ownerDocument != null &&
         typeof ownerDocument === 'object' &&
@@ -210,10 +216,10 @@ export class ParsedContent {
   }
   /* eslint-enable */
 
-  /** @type {string} */
-  get parsedHTML() {
-    return this[ParsedContent.HTML] || '';
-  }
+  // /** @type {string} */
+  // get parsedHTML() {
+  //   return this[ParsedContent.HTML] || '';
+  // }
 
   /** @type {DocumentFragment | undefined} */
   get documentFragment() {
@@ -236,7 +242,7 @@ export class ParsedContent {
     if (!value) {
       this[ParsedContent.CONTENT] = undefined;
       this[ParsedContent.FRAGMENT] = undefined;
-      this[ParsedContent.HTML] = undefined;
+      // this[ParsedContent.HTML] = undefined;
       this.sections = ParsedContent.empty;
       return;
     }
@@ -249,7 +255,8 @@ export class ParsedContent {
     }
     this[ParsedContent.CONTENT] = value;
     this[ParsedContent.FRAGMENT] = ParsedContent.createFragment(this);
-    this[ParsedContent.HTML] = ParsedContent.parseFragment(this) || undefined;
+    // this[ParsedContent.HTML] = ParsedContent.parseFragment(this) || undefined;
+    ParsedContent.parseFragment(this);
   }
 
   static get CONTENT() {
@@ -272,15 +279,15 @@ export class ParsedContent {
     return value;
   }
 
-  static get HTML() {
-    const value = Symbol('ParsedContent.html');
-    Object.defineProperty(ParsedContent, 'HTML', {
-      value,
-      enumerable: false,
-      writable: false,
-    });
-    return value;
-  }
+  // static get HTML() {
+  //   const value = Symbol('ParsedContent.html');
+  //   Object.defineProperty(ParsedContent, 'HTML', {
+  //     value,
+  //     enumerable: false,
+  //     writable: false,
+  //   });
+  //   return value;
+  // }
 }
 
 // @ts-ignore

--- a/src/util/ParsedContent.js
+++ b/src/util/ParsedContent.js
@@ -1,0 +1,289 @@
+﻿// @ts-check
+
+/**
+ * @typedef {typeof ParsedContent} Constructor
+ * @typedef {import('../types/').ContentPageData['content']} GeneratedContent
+ * @typedef {DocumentFragment & {ownerDocument: Document}} Fragment
+ * @typedef {HTMLElement[]} Sections
+ */
+export class ParsedContent {
+  /** @param {ParsedContent} content */
+  static createTemplate(content) {
+    /** @type {typeof ParsedContent} */
+    const constructor = this || ParsedContent;
+
+    /** @type {WeakMap<Document, HTMLTemplateElement | null>} */
+    let templates;
+
+    const { ownerDocument, template } = content;
+
+    if (template !== undefined) return template;
+
+    /* eslint-disable */
+
+    // IF initialized without DOM we do mutate
+    if (ownerDocument === null) content.template = null;
+    // IF uninitialized we don't mutate
+    if (ownerDocument == null) return null;
+
+    // SO initialized with DOM
+
+    // MAYBE Create constructor.templates
+    (constructor.hasOwnProperty('templates') &&
+      WeakMap[Symbol.hasInstance](constructor.templates)) ||
+      Object.defineProperty(constructor, 'templates', {
+        value: new WeakMap(),
+      });
+
+    // GET content.template is already catched
+    content.template = constructor.templates.get(ownerDocument);
+
+    // IF not catched at all (not even null)
+    if (content.template === undefined) {
+      try {
+        // Create content.template for content.ownerDocument
+        content.template = ownerDocument.createElement('template');
+      } catch (exception) {
+        // Set content.template to prevent destructuring fallbacks
+        content.template = null;
+      } finally {
+        // Update map entry regardless
+        constructor.templates.set(ownerDocument, content.template || null);
+      }
+    }
+
+    /* eslint-enable */
+
+    return content.template || null;
+  }
+
+  /** @param {ParsedContent} content */
+  static createFragment(content) {
+    if (!content || !ParsedContent[Symbol.hasInstance](content)) return null;
+
+    const {
+      ownerDocument,
+      template = ((this && this.createTemplate) ||
+        ParsedContent.createTemplate)(content),
+      generatedContent,
+    } = content;
+
+    if (ownerDocument === null || template === null) return null;
+    if (generatedContent == null) return document.createDocumentFragment();
+
+    template.innerHTML = generatedContent.html;
+    return template.content.cloneNode(true);
+  }
+
+  /** @param {ParsedContent} content */
+  static parseFragment(content) {
+    if (!content || !ParsedContent[Symbol.hasInstance](content)) return null;
+
+    const parsedHTML = '';
+
+    const { documentFragment: fragment, ownerDocument: document } = content;
+
+    if (!fragment || !document) return; // parsedHTML;
+
+    const { textContent: generatedHTML } = fragment;
+
+    if (!generatedHTML || !generatedHTML.trim()) return; // generatedHTML;
+
+    ParsedContent.processCodeBlocks(content);
+    ParsedContent.processAnchorTargets(content);
+    ParsedContent.processSections(content);
+  }
+
+  /** @param {ParsedContent} content */
+  static processSections(content) {
+    if (!content || !content.documentFragment || !content.ownerDocument) return;
+    /* eslint-disable */
+    content.sections = Object.freeze(
+      /** @type {HTMLElement[]} */ ([
+        ...content.documentFragment.querySelectorAll(':scope > section[name]'),
+      ])
+    );
+    /* eslint-enable */
+  }
+
+  /** @param {ParsedContent} content */
+  static processAnchorTargets(content) {
+    if (!content || !content.documentFragment || !content.ownerDocument) return;
+    /* eslint-disable */
+    const origin =
+      content.ownerDocument.origin ||
+      /** @type {Window} */ (content.ownerDocument.defaultView).location.origin;
+    for (const anchor of /** @type {Iterable<HTMLAnchorElement>} */ ([
+      ...content.documentFragment.querySelectorAll('a:not([target])'),
+    ])) {
+      if (anchor.origin !== origin) anchor.target = '_blank';
+    }
+    /* eslint-enable */
+  }
+
+  /** @param {ParsedContent} content */
+  static processCodeBlocks(content) {
+    if (!content || !content.documentFragment || !content.ownerDocument) return;
+    /* eslint-disable */
+
+    for (const code of [
+      ...content.documentFragment.querySelectorAll('pre > code'),
+    ]) {
+      /** @type {HTMLElement | undefined} */ let line;
+      let {
+        className,
+        TEXT_NODE,
+        parentElement,
+      } = /** @type {HTMLElement & {parentElement: HTMLElement}} */ (code);
+
+      if (parentElement.childElementCount > 1) continue;
+
+      const isShell = /\blanguage-(?:bash)\b/.test(className);
+
+      className = `${className || ''} ${'line'}`.trim();
+
+      for (const node of [...code.childNodes]) {
+        if (line === undefined) {
+          (line = parentElement.appendChild(
+            content.ownerDocument.createElement('code')
+          )).className = className;
+        }
+        if (node.nodeType === TEXT_NODE) {
+          for (const text of /** @type {Text} */ (node).wholeText.split(
+            /(\n)/
+          )) {
+            if (text === '\n') {
+              parentElement.appendChild(
+                content.ownerDocument.createElement('br')
+              );
+              (line = parentElement.appendChild(
+                content.ownerDocument.createElement('code')
+              )).className = className;
+            } else {
+              line.appendChild(new Text(text));
+            }
+          }
+          node.remove();
+        } else {
+          line.appendChild(node);
+        }
+      }
+      code.remove();
+      if (!isShell) continue;
+      for (const line of parentElement.querySelectorAll(':scope > code.line')) {
+        line.firstChild &&
+          (line.firstChild.nodeType === TEXT_NODE
+            ? /^\s*\w/.test(/** @type {Text } */ (line.firstChild).data)
+            : line.firstElementChild === line.firstChild &&
+              !line.firstElementChild.classList.contains('comment')) &&
+          line.classList.add('shell-command');
+      }
+    }
+    /* eslint-enable */
+  }
+
+  /** @param {GeneratedContent} [content] @param {Document} [document] */
+  constructor(content, document) {
+    /* eslint-disable */
+    if (!document) document = globalThis.document;
+    this.ownerDocument =
+      /** @type {Document | null | undefined} */ ((document != null &&
+        typeof document === 'object' &&
+        typeof document.createElement === 'function' &&
+        document) ||
+      null);
+    this.template = /** @type {HTMLTemplateElement | null | undefined} */ (undefined);
+    this.sections = ParsedContent.empty;
+    this.content = content || undefined;
+    /* eslint-enable */
+  }
+
+  /* eslint-disable */
+  /** @param {string | Error} reason @param {new (message: string) => Error} [type] */
+  throw(reason, type) {
+    throw new (typeof type === 'function' ? type : globalThis.Error)(
+      (reason &&
+        reason.toString !== Symbol.prototype.toString &&
+        `${reason}`.trim()) ||
+        `Exception thrown — ${Object.prototype.toString.call(reason)}`
+    );
+  }
+  /* eslint-enable */
+
+  /** @type {string} */
+  get parsedHTML() {
+    return this[ParsedContent.HTML] || '';
+  }
+
+  /** @type {DocumentFragment | undefined} */
+  get documentFragment() {
+    return this[ParsedContent.FRAGMENT];
+  }
+
+  /** @type {GeneratedContent | undefined} */
+  get generatedContent() {
+    return this[ParsedContent.CONTENT];
+  }
+
+  set generatedContent(value) {
+    if (
+      /* eslint-disable */
+      this.constructor.prototype === this ||
+      value == this[ParsedContent.CONTENT]
+      /* eslint-enable */
+    )
+      return;
+    if (!value) {
+      this[ParsedContent.CONTENT] = undefined;
+      this[ParsedContent.FRAGMENT] = undefined;
+      this[ParsedContent.HTML] = undefined;
+      this.sections = ParsedContent.empty;
+      return;
+    }
+    if (value !== null && typeof value !== 'object') {
+      this.throw(
+        new TypeError(
+          `‹ParsedContent›.content must be either ‹empty› or ‹object› — cannot be ‹${typeof value}›.`
+        )
+      );
+    }
+    this[ParsedContent.CONTENT] = value;
+    this[ParsedContent.FRAGMENT] = ParsedContent.createFragment(this);
+    this[ParsedContent.HTML] = ParsedContent.parseFragment(this) || undefined;
+  }
+
+  static get CONTENT() {
+    const value = Symbol('ParsedContent.content');
+    Object.defineProperty(ParsedContent, 'CONTENT', {
+      value,
+      enumerable: false,
+      writable: false,
+    });
+    return value;
+  }
+
+  static get FRAGMENT() {
+    const value = Symbol('ParsedContent.fragment');
+    Object.defineProperty(ParsedContent, 'FRAGMENT', {
+      value,
+      enumerable: false,
+      writable: false,
+    });
+    return value;
+  }
+
+  static get HTML() {
+    const value = Symbol('ParsedContent.html');
+    Object.defineProperty(ParsedContent, 'HTML', {
+      value,
+      enumerable: false,
+      writable: false,
+    });
+    return value;
+  }
+}
+
+// @ts-ignore
+ParsedContent.templates = /** @type {WeakMap<Document, HTMLTemplateElement | null>} */ (undefined);
+
+ParsedContent.empty = Object.freeze(/** @type {HTMLElement[]} */ ([]));

--- a/src/util/ParsedContent.js
+++ b/src/util/ParsedContent.js
@@ -182,15 +182,15 @@ export class ParsedContent {
     /* eslint-enable */
   }
 
-  /** @param {GeneratedContent} [content] @param {Document} [document] */
-  constructor(content, document) {
+  /** @param {GeneratedContent} [content] @param {Document} [ownerDocument] */
+  constructor(content, ownerDocument) {
     /* eslint-disable */
-    if (!document) document = globalThis.document;
+    if (!ownerDocument) ownerDocument = typeof document === 'object' && document || undefined;
     this.ownerDocument =
-      /** @type {Document | null | undefined} */ ((document != null &&
-        typeof document === 'object' &&
-        typeof document.createElement === 'function' &&
-        document) ||
+      /** @type {Document | null | undefined} */ ((ownerDocument != null &&
+        typeof ownerDocument === 'object' &&
+        typeof ownerDocument.createElement === 'function' &&
+        ownerDocument) ||
       null);
     this.template = /** @type {HTMLTemplateElement | null | undefined} */ (undefined);
     this.sections = ParsedContent.empty;
@@ -201,7 +201,7 @@ export class ParsedContent {
   /* eslint-disable */
   /** @param {string | Error} reason @param {new (message: string) => Error} [type] */
   throw(reason, type) {
-    throw new (typeof type === 'function' ? type : globalThis.Error)(
+    throw new (typeof type === 'function' ? type : Error)(
       (reason &&
         reason.toString !== Symbol.prototype.toString &&
         `${reason}`.trim()) ||

--- a/test/components/__snapshots__/header.test.tsx.snap
+++ b/test/components/__snapshots__/header.test.tsx.snap
@@ -4,46 +4,40 @@ exports[`Tests for Header component renders correctly 1`] = `
 <nav
   className="nav"
 >
-  <ul
-    css={
-      Object {
-        "map": undefined,
-        "name": "xzcnt4",
-        "next": undefined,
-        "styles": "
-  @media (max-width: 380px) {
-    padding: 0;
-  }
-  margin: 0 auto;
-  padding: 0 4.8rem;
-  display: flex;
-  align-items: center;
-  list-style: none;
-",
-      }
-    }
+  <div
+    className="logo"
   >
-    <li>
-      <a
-        href="/"
-        style={
-          Object {
-            "display": "block",
-          }
-        }
-      >
-        <img
-          alt="Node.js"
-          className="nav__logo"
-          src="test-file-stub"
-        />
-      </a>
-    </li>
+    <a
+      href="/"
+    >
+      <img
+        alt="Node.js"
+        className="nav__logo light-mode-only"
+        src="test-file-stub"
+      />
+      <img
+        alt="Node.js"
+        className="nav__logo dark-mode-only"
+        src="test-file-stub"
+      />
+    </a>
+  </div>
+  <ul
+    className="nav__tabs__container"
+  >
     <li
       className="nav__tabs"
     >
       <a
+        activeStyle={
+          Object {
+            "borderBottom": "var(--space-04) inset var(--color-text-accent)",
+            "color": "var(--color-text-accent)",
+            "fontWeight": "var(--font-weight-semibold)",
+          }
+        }
         href="/learn"
+        partiallyActive={true}
       >
         Learn
       </a>
@@ -52,36 +46,47 @@ exports[`Tests for Header component renders correctly 1`] = `
       className="nav__tabs"
     >
       <a
+        activeStyle={
+          Object {
+            "borderBottom": "var(--space-04) inset var(--color-text-accent)",
+            "color": "var(--color-text-accent)",
+            "fontWeight": "var(--font-weight-semibold)",
+          }
+        }
         href="/docs"
+        partiallyActive={true}
       >
-        Docs
+        Documentation
       </a>
     </li>
     <li
       className="nav__tabs"
     >
       <a
-        href="/community"
-      >
-        Community
-      </a>
-    </li>
-    <li
-      className="nav__tabs"
-    >
-      <a
+        activeStyle={
+          Object {
+            "borderBottom": "var(--space-04) inset var(--color-text-accent)",
+            "color": "var(--color-text-accent)",
+            "fontWeight": "var(--font-weight-semibold)",
+          }
+        }
         href="/download"
+        partiallyActive={true}
       >
         Download
       </a>
     </li>
-    <li
-      style={
-        Object {
-          "flexGrow": 1,
-        }
+  </ul>
+  <div
+    style={
+      Object {
+        "flexGrow": 1,
       }
-    />
+    }
+  />
+  <ul
+    className="right-container"
+  >
     <li
       className="nav__tabs nav__tabs--right"
     >
@@ -112,7 +117,7 @@ exports[`Tests for Header component renders correctly 1`] = `
     >
       <a
         href="https://github.com/nodejs/nodejs.dev"
-        rel="noreferrer noopener"
+        rel="noopener noreferrer"
         target="_blank"
       >
         <span
@@ -121,14 +126,14 @@ exports[`Tests for Header component renders correctly 1`] = `
           GitHub
         </span>
         <svg
-          height="2.0rem"
+          height="2.4rem"
           style={
             Object {
               "fill": "var(--color-text-accent)",
             }
           }
           viewBox="0 0 438.549 438.549"
-          width="2.0rem"
+          width="2.4rem"
         >
           <path
             d="M409.132,114.573c-19.608-33.596-46.205-60.194-79.798-79.8C295.736,15.166,259.057,5.365,219.271,5.365   c-39.781,0-76.472,9.804-110.063,29.408c-33.596,19.605-60.192,46.204-79.8,79.8C9.803,148.168,0,184.854,0,224.63   c0,47.78,13.94,90.745,41.827,128.906c27.884,38.164,63.906,64.572,108.063,79.227c5.14,0.954,8.945,0.283,11.419-1.996   c2.475-2.282,3.711-5.14,3.711-8.562c0-0.571-0.049-5.708-0.144-15.417c-0.098-9.709-0.144-18.179-0.144-25.406l-6.567,1.136   c-4.187,0.767-9.469,1.092-15.846,1c-6.374-0.089-12.991-0.757-19.842-1.999c-6.854-1.231-13.229-4.086-19.13-8.559   c-5.898-4.473-10.085-10.328-12.56-17.556l-2.855-6.57c-1.903-4.374-4.899-9.233-8.992-14.559   c-4.093-5.331-8.232-8.945-12.419-10.848l-1.999-1.431c-1.332-0.951-2.568-2.098-3.711-3.429c-1.142-1.331-1.997-2.663-2.568-3.997   c-0.572-1.335-0.098-2.43,1.427-3.289c1.525-0.859,4.281-1.276,8.28-1.276l5.708,0.853c3.807,0.763,8.516,3.042,14.133,6.851   c5.614,3.806,10.229,8.754,13.846,14.842c4.38,7.806,9.657,13.754,15.846,17.847c6.184,4.093,12.419,6.136,18.699,6.136   c6.28,0,11.704-0.476,16.274-1.423c4.565-0.952,8.848-2.383,12.847-4.285c1.713-12.758,6.377-22.559,13.988-29.41   c-10.848-1.14-20.601-2.857-29.264-5.14c-8.658-2.286-17.605-5.996-26.835-11.14c-9.235-5.137-16.896-11.516-22.985-19.126   c-6.09-7.614-11.088-17.61-14.987-29.979c-3.901-12.374-5.852-26.648-5.852-42.826c0-23.035,7.52-42.637,22.557-58.817   c-7.044-17.318-6.379-36.732,1.997-58.24c5.52-1.715,13.706-0.428,24.554,3.853c10.85,4.283,18.794,7.952,23.84,10.994   c5.046,3.041,9.089,5.618,12.135,7.708c17.705-4.947,35.976-7.421,54.818-7.421s37.117,2.474,54.823,7.421l10.849-6.849   c7.419-4.57,16.18-8.758,26.262-12.565c10.088-3.805,17.802-4.853,23.134-3.138c8.562,21.509,9.325,40.922,2.279,58.24   c15.036,16.18,22.559,35.787,22.559,58.817c0,16.178-1.958,30.497-5.853,42.966c-3.9,12.471-8.941,22.457-15.125,29.979   c-6.191,7.521-13.901,13.85-23.131,18.986c-9.232,5.14-18.182,8.85-26.84,11.136c-8.662,2.286-18.415,4.004-29.263,5.146   c9.894,8.562,14.842,22.077,14.842,40.539v60.237c0,3.422,1.19,6.279,3.572,8.562c2.379,2.279,6.136,2.95,11.276,1.995   c44.163-14.653,80.185-41.062,108.068-79.226c27.88-38.161,41.825-81.126,41.825-128.906   C438.536,184.851,428.728,148.168,409.132,114.573z"

--- a/test/components/__snapshots__/hero.test.tsx.snap
+++ b/test/components/__snapshots__/hero.test.tsx.snap
@@ -2,27 +2,55 @@
 
 exports[`Hero component renders correctly 1`] = `
 <div
-  className="hero"
+  className="home-page-hero"
 >
   <h1>
     Introduction to Node.js
   </h1>
+  <h2
+    className="sub-title t-subheading"
+  />
   <div
-    className="diagonal-hero-bg"
+    className="btn-ctas"
   >
     <div
-      className="stars"
+      className="download-lts-container"
     >
-      <div
-        className="small"
-      />
-      <div
-        className="medium"
-      />
-      <div
-        className="big"
-      />
+      <button
+        className="download-lts-cta t-body1"
+        type="button"
+      >
+        Download Node (LTS)
+      </button>
+      <p
+        className="links t-caption"
+      >
+        Version 10.15.3
+         - 
+        <a
+          href="/download"
+        >
+          What’s new
+        </a>
+         /
+         
+        <a
+          href="/download"
+        >
+          Get Current
+        </a>
+      </p>
     </div>
+    <a
+      href="/learn"
+    >
+      <button
+        className="learn-cta t-body1"
+        type="button"
+      >
+        Learn Node
+      </button>
+    </a>
   </div>
 </div>
 `;

--- a/test/templates/__snapshots__/learn.test.tsx.snap
+++ b/test/templates/__snapshots__/learn.test.tsx.snap
@@ -1,63 +1,65 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Learn Template renders correctly 1`] = `
-<Layout
-  description="test-description"
-  title="test-title"
->
-  <Navigation
-    currentSlug="test-slug"
-    sections={
-      Object {
-        "test-section": Array [
-          Object {
-            "section": "test-section",
-            "slug": "test-slug",
-            "title": "test-title",
-          },
-          Object {
-            "section": "test-section",
-            "slug": "test-slug",
-            "title": "test-title",
-          },
-        ],
-        "test-section2": Array [
-          Object {
-            "section": "test-section",
-            "slug": "test-slug",
-            "title": "test-title",
-          },
-          Object {
-            "section": "test-section",
-            "slug": "test-slug",
-            "title": "test-title",
-          },
-        ],
-      }
-    }
-  />
-  <Article
-    authors={
-      Array [
-        "test-user1",
-        "test-user2",
-      ]
-    }
-    html="<span>Test html</span>"
-    next={
-      Object {
-        "slug": "test-slug",
-        "title": "test-title",
-      }
-    }
-    previous={
-      Object {
-        "slug": "test-slug",
-        "title": "test-title",
-      }
-    }
-    relativePath="test-path"
+<main>
+  <Layout
+    description="test-description"
     title="test-title"
-  />
-</Layout>
+  >
+    <Navigation
+      currentSlug="test-slug"
+      sections={
+        Object {
+          "test-section": Array [
+            Object {
+              "section": "test-section",
+              "slug": "test-slug",
+              "title": "test-title",
+            },
+            Object {
+              "section": "test-section",
+              "slug": "test-slug",
+              "title": "test-title",
+            },
+          ],
+          "test-section2": Array [
+            Object {
+              "section": "test-section",
+              "slug": "test-slug",
+              "title": "test-title",
+            },
+            Object {
+              "section": "test-section",
+              "slug": "test-slug",
+              "title": "test-title",
+            },
+          ],
+        }
+      }
+    />
+    <Article
+      authors={
+        Array [
+          "test-user1",
+          "test-user2",
+        ]
+      }
+      html="<span>Test html</span>"
+      next={
+        Object {
+          "slug": "test-slug",
+          "title": "test-title",
+        }
+      }
+      previous={
+        Object {
+          "slug": "test-slug",
+          "title": "test-title",
+        }
+      }
+      relativePath="test-path"
+      title="test-title"
+    />
+  </Layout>
+</main>
 `;


### PR DESCRIPTION
## Description

This PR implements a `<DemoTabs>` components with `<section>` tabs populated `html` generated for the "Installing via Package Managers" section. It adds new `gatsby`-related configuration and updates filtering in "src/templates/learn.tsx" to introduce a parallel markdown pipeline for respective "src/content/" files.

## Progress

- [x] Add separate gatsby markdown "content" workflow
- [x] Create DemoTab component populated with markdown "content"
- [ ] Confirm that this strategy works
- [x] Fix parity support for all "Evergreen" browsers
- [ ] Fix responsive sizing (see below)
- [ ] Transform rendered markdown "content" into `<section>` tabs

## Live Build

**Latest** — https://storage.googleapis.com/staging.nodejs.dev/581cd92/index.html

https://storage.googleapis.com/staging.nodejs.dev/d00c479/index.html

<!-- globalThis reference https://storage.googleapis.com/staging.nodejs.dev/7a7610e/index.html -->

https://storage.googleapis.com/staging.nodejs.dev/2077200/index.html

## Related Issues

Addresses #333