### PR TITLE
fix: Stream.Readable example

### DIFF
--- a/src/documentation/0052-nodejs-streams/index.md
+++ b/src/documentation/0052-nodejs-streams/index.md
@@ -112,7 +112,7 @@ There are four classes of streams:
 
 ## How to create a readable stream
 
-We get the Readable stream from the [`stream` module](https://nodejs.org/api/stream.html), and we initialize it and implement the readable._read() method.
+We get the Readable stream from the [`stream` module](https://nodejs.org/api/stream.html), and we initialize it and implement the `readable._read()` method.
 
 First create a stream object:
 

--- a/src/documentation/0052-nodejs-streams/index.md
+++ b/src/documentation/0052-nodejs-streams/index.md
@@ -112,11 +112,27 @@ There are four classes of streams:
 
 ## How to create a readable stream
 
-We get the Readable stream from the [`stream` module](https://nodejs.org/api/stream.html), and we initialize it
+We get the Readable stream from the [`stream` module](https://nodejs.org/api/stream.html), and we initialize it and implement the readable._read() method.
+
+First create a stream object:
 
 ```js
 const Stream = require('stream')
 const readableStream = new Stream.Readable()
+```
+
+then implement `_read`:
+
+```js
+readableStream._read = () => {}
+```
+
+You can also implement `_read` using the `read` option:
+
+```js
+const readableStream = new Stream.Readable({
+  read() {}
+})
 ```
 
 Now that the stream is initialized, we can send data to it:
@@ -160,7 +176,9 @@ How do we read data from a readable stream? Using a writable stream:
 ```js
 const Stream = require('stream')
 
-const readableStream = new Stream.Readable()
+const readableStream = new Stream.Readable({
+  read() {}
+})
 const writableStream = new Stream.Writable()
 
 writableStream._write = (chunk, encoding, next) => {
@@ -197,7 +215,9 @@ Use the `end()` method:
 ```js
 const Stream = require('stream')
 
-const readableStream = new Stream.Readable()
+const readableStream = new Stream.Readable({
+  read() {}
+})
 const writableStream = new Stream.Writable()
 
 writableStream._write = (chunk, encoding, next) => {


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

stream.Readable examples on https://nodejs.dev/nodejs-streams cannot run and error `Error [ERR_METHOD_NOT_IMPLEMENTED]: The _read() method is not implemented` occurs. 
This PR fixes the examples to run them correctly. They need `readableStream._read = () => {}`. According to [api doc for `readable._read`](https://nodejs.org/api/stream.html#stream_readable_read_size_1), `_read()` must be implemented in all readable stream.

> All Readable stream implementations must provide an implementation of the readable._read() method to fetch data from the underlying resource.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
Fix #365

