### PR TITLE
doc: add link to V8 and Standard ECMA-262

### DIFF
--- a/src/documentation/0006-v8/index.md
+++ b/src/documentation/0006-v8/index.md
@@ -23,13 +23,13 @@ Other browsers have their own JavaScript engine:
 
 and many others exist as well.
 
-All those engines implement the ECMA ES-262 standard, also called ECMAScript, the standard used by JavaScript.
+All those engines implement the [ECMA ES-262 standard](https://www.ecma-international.org/publications/standards/Ecma-262.htm), also called ECMAScript, the standard used by JavaScript.
 
 ## The quest for performance
 
 V8 is written in C++, and it's continuously improved. It is portable and runs on Mac, Windows, Linux and several other systems.
 
-In this V8 introduction, we will ignore the implementation details of V8: they can be found on more authoritative sites (e.g. the V8 official site), and they change over time, often radically.
+In this V8 introduction, we will ignore the implementation details of V8: they can be found on more authoritative sites (e.g. the [V8 official site](https://v8.dev/)), and they change over time, often radically.
 
 V8 is always evolving, just like the other JavaScript engines around, to speed up the Web and the Node.js ecosystem.
 

--- a/src/documentation/0006-v8/index.md
+++ b/src/documentation/0006-v8/index.md
@@ -1,7 +1,7 @@
 ---
 title: The V8 JavaScript Engine
 description: "V8 is the name of the JavaScript engine that powers Google Chrome. It's the thing that takes our JavaScript and executes it while browsing with Chrome. V8 provides the runtime environment in which JavaScript executes. The DOM and the other Web Platform APIs are provided by the browser."
-authors: flaviocopes, smfoote, co16353sidak, MylesBorins, LaRuaNa, andys8, ahmadawais, karlhorky
+authors: flaviocopes, smfoote, co16353sidak, MylesBorins, LaRuaNa, andys8, ahmadawais, karlhorky, aymen94
 section: Getting Started
 ---
 


### PR DESCRIPTION
add link to [V8 website](https://v8.dev/) and [Standard ECMA-262](https://www.ecma-international.org/publications/standards/Ecma-262.htm)
to go directly to the site, without having to search the web
