### PR TITLE
Removing duplicate Node.js framework.

### DIFF
--- a/src/documentation/0001-node-introduction/index.md
+++ b/src/documentation/0001-node-introduction/index.md
@@ -103,7 +103,6 @@ Many of those established over time as popular options. Here is a non-comprehens
 - [**Loopback.io**](https://loopback.io/): Makes it easy to build modern applications that require complex integrations.
 - [**Meteor**](https://meteor.com): An incredibly powerful full-stack framework, powering you with an isomorphic approach to building apps with JavaScript, sharing code on the client and the server. Once an off-the-shelf tool that provided everything, now integrates with frontend libs [React](https://reactjs.org/), [Vue](https://vuejs.org/), and [Angular](https://angular.io). Can be used to create mobile apps as well.
 - [**Micro**](https://github.com/zeit/micro): It provides a very lightweight server to create asynchronous HTTP microservices.
-- [**NestJS**](https://nestjs.com/): A TypeScript based progressive Node.js framework for building enterprise-grade efficient, reliable and scalable server-side applications.
 - [**Next.js**](https://nextjs.org/): A framework to render server-side rendered [React](https://reactjs.org/) applications.
 - [**Nx**](https://nx.dev/): It powers the Angular CLI which allows building full-stack applications using NestJS, Express, and [Angular](https://angular.io) and easily share code between backends and frontends.
 - [**Socket.io**](https://socket.io/): A real-time communication engine to build network applications.


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

There are two entries for Next.js. (although I do also think its cool enough for two entries), I removed the line with the less-official domain name. Although both links worked.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

None At the moment.

This was caught looking at https://nodejs.dev