### PR TITLE
Fix topbanner dark mode

### DIFF
--- a/src/components/banner.tsx
+++ b/src/components/banner.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { css, SerializedStyles } from '@emotion/core';
+
+const banner: SerializedStyles = css`
+  position: relative;
+  font-weight: bold;
+  background-color: var(--info9);
+  font-size: var(--font-size-display2);
+  color: var(--black0);
+  border-radius: 5px;
+  text-align: center;
+  padding-top: 5px;
+`;
+
+const ticketsCta: SerializedStyles = css`
+  border-radius: 5.6rem;
+  background: var(--color-fill-action);
+  color: var(--black0);
+  margin-right: var(--space-32);
+  position: relative;
+`;
+
+const Banner = () => (
+  <div css={banner}>
+    <p>
+      <button css={ticketsCta} type="button">
+        Get Tickets
+      </button>
+      Some new event is happening on some date
+    </p>
+  </div>
+);
+
+export default Banner;

--- a/src/components/banner.tsx
+++ b/src/components/banner.tsx
@@ -3,10 +3,11 @@ import { css, SerializedStyles } from '@emotion/core';
 
 const bannerLink =
   'https://nodejs.org/en/blog/vulnerability/february-2020-security-releases/';
-const banner: SerializedStyles = css`
+
+const banner: SerializedStyles = css/*scss*/`
   position: relative;
   font-weight: bold;
-  background-color: var(--black3);
+  background-color: var(--color-fill-top-banner);
   font-size: var(--font-size-display2);
   color: var(--color-text-primary);
   border-radius: 5px;
@@ -14,20 +15,17 @@ const banner: SerializedStyles = css`
   padding-top: 5px;
 `;
 
-const bannerCta: SerializedStyles = css`
+const bannerButton: SerializedStyles = css/*scss*/`
+  position: relative;
+  margin-right: var(--space-32);
   border-radius: 5.6rem;
   background: var(--purple5);
-  color: var(--color-fill-top-nav);
-  margin-right: var(--space-32);
-  position: relative;
-`;
-const bannerButtonText: SerializedStyles = css`
   color: var(--color-fill-top-nav);
   line-height: var(--line-height-subheading);
   text-decoration: none;
   font-family: var(--sans);
   font-style: normal;
-  font-weight var(--font-weight-semibold);
+  font-weight: var(--font-weight-semibold);
 `;
 
 /**
@@ -54,11 +52,11 @@ const Banner = (): JSX.Element => {
           paddingBottom: 'var(--space-08)',
         }}
       >
-        <button css={bannerCta} type="button">
-          <a css={bannerButtonText} href={bannerLink}>
-            Blog post
-          </a>
-        </button>
+        <a href={bannerLink}>
+          <button css={bannerButton} type="button">
+              Blog post
+          </button>
+        </a>
         New security releases now available for all release lines
       </p>
     </div>

--- a/src/components/banner.tsx
+++ b/src/components/banner.tsx
@@ -1,34 +1,68 @@
 import React from 'react';
 import { css, SerializedStyles } from '@emotion/core';
 
+const bannerLink =
+  'https://nodejs.org/en/blog/vulnerability/february-2020-security-releases/';
 const banner: SerializedStyles = css`
   position: relative;
   font-weight: bold;
-  background-color: var(--info9);
+  background-color: var(--black3);
   font-size: var(--font-size-display2);
-  color: var(--black0);
+  color: var(--color-text-primary);
   border-radius: 5px;
   text-align: center;
   padding-top: 5px;
 `;
 
-const ticketsCta: SerializedStyles = css`
+const bannerCta: SerializedStyles = css`
   border-radius: 5.6rem;
-  background: var(--color-fill-action);
-  color: var(--black0);
+  background: var(--purple5);
+  color: var(--color-fill-top-nav);
   margin-right: var(--space-32);
   position: relative;
 `;
+const bannerButtonText: SerializedStyles = css`
+  color: var(--color-fill-top-nav);
+  line-height: var(--line-height-subheading);
+  text-decoration: none;
+  font-family: var(--sans);
+  font-style: normal;
+  font-weight var(--font-weight-semibold);
+`;
 
-const Banner = () => (
-  <div css={banner}>
-    <p>
-      <button css={ticketsCta} type="button">
-        Get Tickets
-      </button>
-      Some new event is happening on some date
-    </p>
-  </div>
-);
+/**
+ * The banner is used for displaying upcoming Nodejs events and important announcements ex. security updates
+ * Usage
+ * <p css={{
+ *     paddingTop: 'var(--space-08)',
+ *     paddingBottom: 'var(--space-08)',
+ *      }}>
+ *  <button css={bannerCta} type="button">
+ *    <a css={bannerButtonText} href={bannerLink}>
+ *      Blog post
+ *    </a>
+ *  </button>
+ *  New security releases now available for all release lines
+ *</p>
+ */
+const Banner = (): JSX.Element => {
+  return (
+    <div css={banner}>
+      <p
+        css={{
+          paddingTop: 'var(--space-08)',
+          paddingBottom: 'var(--space-08)',
+        }}
+      >
+        <button css={bannerCta} type="button">
+          <a css={bannerButtonText} href={bannerLink}>
+            Blog post
+          </a>
+        </button>
+        New security releases now available for all release lines
+      </p>
+    </div>
+  );
+};
 
 export default Banner;

--- a/src/components/banner.tsx
+++ b/src/components/banner.tsx
@@ -4,7 +4,7 @@ import { css, SerializedStyles } from '@emotion/core';
 const bannerLink =
   'https://nodejs.org/en/blog/vulnerability/february-2020-security-releases/';
 
-const banner: SerializedStyles = css/*scss*/`
+const banner: SerializedStyles = css/* scss */ `
   position: relative;
   font-weight: bold;
   background-color: var(--color-fill-top-banner);
@@ -15,7 +15,7 @@ const banner: SerializedStyles = css/*scss*/`
   padding-top: 5px;
 `;
 
-const bannerButton: SerializedStyles = css/*scss*/`
+const bannerButton: SerializedStyles = css/* scss */ `
   position: relative;
   margin-right: var(--space-32);
   border-radius: 5.6rem;
@@ -54,7 +54,7 @@ const Banner = (): JSX.Element => {
       >
         <a href={bannerLink}>
           <button css={bannerButton} type="button">
-              Blog post
+            Blog post
           </button>
         </a>
         New security releases now available for all release lines

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -53,8 +53,8 @@ export default function Index(): JSX.Element {
       description={description}
       style={{ overflow: 'hidden' }}
     >
+      <Banner />
       <div className="home-page">
-        <Banner />
         <Hero title={title} subTitle={subTitle} />
 
         <section className="node-demo-container">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -23,6 +23,7 @@ import leafsIllustrationFront from '../images/illustrations/leafs-front.svg';
 import leafsIllustrationMiddle from '../images/illustrations/leafs-middle.svg';
 import leafsIllustrationBack from '../images/illustrations/leafs-back.svg';
 import dotsIllustration from '../images/illustrations/dots.svg';
+import Banner from '../components/banner';
 
 const nodeFeature1 =
   'Lorem ipsum dolor amet pug vape +1 poke pour-over kitsch tacos meh. ';
@@ -53,6 +54,7 @@ export default function Index(): JSX.Element {
       style={{ overflow: 'hidden' }}
     >
       <div className="home-page">
+        <Banner />
         <Hero title={title} subTitle={subTitle} />
 
         <section className="node-demo-container">

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -95,6 +95,7 @@ body {
     --color-fill-canvas: var(--black1);
     --color-fill-side-nav: var(--black1);
     --color-fill-top-nav: var(--black0);
+    --color-fill-top-banner: #9992;
     --color-fill-action: var(--brand5); /*for actionable elements*/
 
     /* Typography */

--- a/test/components/__snapshots__/banner.test.tsx.snap
+++ b/test/components/__snapshots__/banner.test.tsx.snap
@@ -5,12 +5,12 @@ exports[`Tests for Header component renders correctly 1`] = `
   css={
     Object {
       "map": undefined,
-      "name": "1g9ii1p",
+      "name": "433qea",
       "next": undefined,
       "styles": "
   position: relative;
   font-weight: bold;
-  background-color: var(--black3);
+  background-color: var(--color-fill-top-banner);
   font-size: var(--font-size-display2);
   color: var(--color-text-primary);
   border-radius: 5px;
@@ -28,44 +28,34 @@ exports[`Tests for Header component renders correctly 1`] = `
       }
     }
   >
-    <button
-      css={
-        Object {
-          "map": undefined,
-          "name": "ihpspq",
-          "next": undefined,
-          "styles": "
-  border-radius: 5.6rem;
-  background: var(--purple5);
-  color: var(--color-fill-top-nav);
-  margin-right: var(--space-32);
-  position: relative;
-",
-        }
-      }
-      type="button"
+    <a
+      href="https://nodejs.org/en/blog/vulnerability/february-2020-security-releases/"
     >
-      <a
+      <button
         css={
           Object {
             "map": undefined,
-            "name": "10el6nn",
+            "name": "16knpov",
             "next": undefined,
             "styles": "
+  position: relative;
+  margin-right: var(--space-32);
+  border-radius: 5.6rem;
+  background: var(--purple5);
   color: var(--color-fill-top-nav);
   line-height: var(--line-height-subheading);
   text-decoration: none;
   font-family: var(--sans);
   font-style: normal;
-  font-weight var(--font-weight-semibold);
+  font-weight: var(--font-weight-semibold);
 ",
           }
         }
-        href="https://nodejs.org/en/blog/vulnerability/february-2020-security-releases/"
+        type="button"
       >
         Blog post
-      </a>
-    </button>
+      </button>
+    </a>
     New security releases now available for all release lines
   </p>
 </div>

--- a/test/components/__snapshots__/banner.test.tsx.snap
+++ b/test/components/__snapshots__/banner.test.tsx.snap
@@ -1,0 +1,60 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Tests for Header component renders correctly 1`] = `
+<div
+  css={
+    Object {
+      "map": undefined,
+      "name": "1vzy5x6",
+      "next": undefined,
+      "styles": "
+  position: relative;
+  font-weight: bold;
+  background-color: var(--info9);
+  font-size: var(--font-size-display2);
+  color: var(--black0);
+  border-radius: 5px;
+  text-align: center;
+  padding-top: 5px;
+",
+    }
+  }
+>
+  <p>
+    <button
+      css={
+        Object {
+          "map": undefined,
+          "name": "b1p96y",
+          "next": undefined,
+          "styles": "
+  border-radius: 5.6rem;
+  background: var(--color-fill-action);
+  margin-right: var(--space-32);
+  position: relative;
+",
+        }
+      }
+      type="button"
+    >
+      <a
+        css={
+          Object {
+            "map": undefined,
+            "name": "vh0gfp",
+            "next": undefined,
+            "styles": "
+  color: var(--black0);
+  text-decoration: none;
+",
+          }
+        }
+        href="https://nodejs.org/en/blog/vulnerability/february-2020-security-releases/"
+      >
+        Blog post
+      </a>
+    </button>
+    New security releases now available for all release lines
+  </p>
+</div>
+`;

--- a/test/components/__snapshots__/banner.test.tsx.snap
+++ b/test/components/__snapshots__/banner.test.tsx.snap
@@ -5,14 +5,14 @@ exports[`Tests for Header component renders correctly 1`] = `
   css={
     Object {
       "map": undefined,
-      "name": "1vzy5x6",
+      "name": "1g9ii1p",
       "next": undefined,
       "styles": "
   position: relative;
   font-weight: bold;
-  background-color: var(--info9);
+  background-color: var(--black3);
   font-size: var(--font-size-display2);
-  color: var(--black0);
+  color: var(--color-text-primary);
   border-radius: 5px;
   text-align: center;
   padding-top: 5px;
@@ -20,16 +20,24 @@ exports[`Tests for Header component renders correctly 1`] = `
     }
   }
 >
-  <p>
+  <p
+    css={
+      Object {
+        "paddingBottom": "var(--space-08)",
+        "paddingTop": "var(--space-08)",
+      }
+    }
+  >
     <button
       css={
         Object {
           "map": undefined,
-          "name": "b1p96y",
+          "name": "ihpspq",
           "next": undefined,
           "styles": "
   border-radius: 5.6rem;
-  background: var(--color-fill-action);
+  background: var(--purple5);
+  color: var(--color-fill-top-nav);
   margin-right: var(--space-32);
   position: relative;
 ",
@@ -41,11 +49,15 @@ exports[`Tests for Header component renders correctly 1`] = `
         css={
           Object {
             "map": undefined,
-            "name": "vh0gfp",
+            "name": "10el6nn",
             "next": undefined,
             "styles": "
-  color: var(--black0);
+  color: var(--color-fill-top-nav);
+  line-height: var(--line-height-subheading);
   text-decoration: none;
+  font-family: var(--sans);
+  font-style: normal;
+  font-weight var(--font-weight-semibold);
 ",
           }
         }

--- a/test/components/banner.test.tsx
+++ b/test/components/banner.test.tsx
@@ -1,0 +1,11 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import React from 'react';
+import renderer from 'react-test-renderer';
+import Banner from '../../src/components/banner';
+
+describe('Tests for Header component', () => {
+  it('renders correctly', () => {
+    const tree = renderer.create(<Banner />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
## Description

> **Note** This PR branches off #398

Add a new `--color-fill-top-banner` custom property in [tokens.css](https://github.com/SMotaal/nodejs.dev/blob/fix-topbanner-dark-mode/src/styles/tokens.css#L98) using alpha blending to match light and dark.

This also restructures the pill-button as `<a><button>` instead of `<button><a>` to avoid the clashing hover color of the text. As a result, it was possible to refactor its styling as a single `bannerButton` instead of `bannerCta` and `bannerButtonText`.

## Screen Shots

<img width="1392" alt="Screen Shot 2020-02-29 at 1 35 24 PM" src="https://user-images.githubusercontent.com/849613/75613221-345ba800-5af9-11ea-9073-b56a4c9fcd29.png">
<img width="1392" alt="Screen Shot 2020-02-29 at 1 35 29 PM" src="https://user-images.githubusercontent.com/849613/75613229-37ef2f00-5af9-11ea-82a9-19dcdc3666c8.png">


## Live Build

**`Feb29`** https://storage.googleapis.com/staging.nodejs.dev/a003e53/index.html


## Related Issues

#398