### PR TITLE
build: Switch dark-mode-controller to <0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Adam Miller <ammiller@linkedin.com>",
   "private": true,
   "dependencies": {
-    "@smotaal.io/dark-mode-controller": "^0.0.4",
+    "@smotaal.io/dark-mode-controller": "<0.5",
     "@emotion/core": "^10.0.7",
     "@types/react-helmet": "^5.0.7",
     "dotenv": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1547,10 +1547,10 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
-"@smotaal.io/dark-mode-controller@^0.0.4":
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/@smotaal.io/dark-mode-controller/-/dark-mode-controller-0.0.4.tgz#0412651850db97c8f9ca3e2f269042aae6a01755"
-  integrity sha512-BUU3rNWh8VAvpJgMzz/WTk7PdlA5tI+ys4XveO5Q5Zk6xgB0utWZZSGcbSP2rk+TlUvUsLKCzNDA3t3UTLsy2A==
+"@smotaal.io/dark-mode-controller@<0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@smotaal.io/dark-mode-controller/-/dark-mode-controller-0.0.5.tgz#c0da92e7ac65142ec5b78eb6d6b960cb17d1ceb8"
+  integrity sha512-azULQd2yQJN1rRu/YpQ5cfDRJhMLUJAxS9FCeWI2Zj1tQmoSG5iOIcGWlwr+zZjUtJuFaqToQYDVCa1mb3P9xw==
 
 "@types/babel__core@^7.1.0":
   version "7.1.2"


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Using `@smotaal.io/dark-mode-controller` to `<0.5` is preferred in this case since this package is authored primarily for this project and is going through lots of changes under the hood that affect other projects.

> **Note** — Version range `^0.0.4` did not pick up `v0.0.5` in development when `v0.0.4` was already cached by `yarn` even when the `yarn.lock` entry was removed (issue pending).

## Live Build

**`Mar11`** https://storage.googleapis.com/staging.nodejs.dev/0b662e0/index.html 

## Related Issues

Relates to #336.

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
