### PR TITLE
fix: Use CI target for Gastby build

### DIFF
--- a/.github/workflows/gatsby.yml
+++ b/.github/workflows/gatsby.yml
@@ -20,4 +20,4 @@ jobs:
         run: npm ci
 
       - name: Run Gatsby Build
-        run: npm run build
+        run: npm run build-ci


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

There is a `build-ci` rather than `build` in the package.json to pass in the `--prefix-paths` option while building

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
