### PR TITLE
Install tabs on homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-hi
+test 2
 <p align="center">
   <br>
   <a href="https://nodejs.dev">

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-test 2
 <p align="center">
   <br>
   <a href="https://nodejs.dev">

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+hi
 <p align="center">
   <br>
   <a href="https://nodejs.dev">

--- a/package-lock.json
+++ b/package-lock.json
@@ -5522,6 +5522,14 @@
         "@types/react": "*"
       }
     },
+    "@types/react-tabs": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@types/react-tabs/-/react-tabs-2.3.1.tgz",
+      "integrity": "sha512-4SZXSF8ibQAtHUqqfoYLO+8Rn4F7Hj/IX3CJf1712dWeFvRxYY1HjjwSoN4MgUB0SB0dY4GrdlZwNhhIKuRoNQ==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/react-test-renderer": {
       "version": "16.9.2",
       "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-16.9.2.tgz",
@@ -8228,6 +8236,11 @@
         "isobject": "^3.0.0",
         "static-extend": "^0.1.1"
       }
+    },
+    "classnames": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
     },
     "clean-stack": {
       "version": "2.2.0",
@@ -25136,6 +25149,15 @@
       "requires": {
         "exenv": "^1.2.1",
         "shallowequal": "^1.0.1"
+      }
+    },
+    "react-tabs": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-3.1.0.tgz",
+      "integrity": "sha512-9RKc77HCPsjQDVPyZEw37g3JPtg26oSQ9o4mtaVXjJuLedDX5+TQcE+MRNKR+4aO3GMAY4YslCePGG1//MQ3Jg==",
+      "requires": {
+        "classnames": "^2.2.0",
+        "prop-types": "^15.5.0"
       }
     },
     "react-test-renderer": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@emotion/core": "^10.0.7",
     "@smotaal.io/dark-mode-controller": "<0.5",
     "@types/react-helmet": "^5.0.15",
+    "@types/react-tabs": "2.3.1",
     "dotenv": "^8.2.0",
     "emotion": "^10.0.27",
     "emotion-server": "^10.0.27",
@@ -33,7 +34,8 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-emotion": "^10.0.0",
-    "react-helmet": "^5.2.0"
+    "react-helmet": "^5.2.0",
+    "react-tabs": "3.1.0"
   },
   "keywords": [
     "gatsby",

--- a/src/components/installTabs.tsx
+++ b/src/components/installTabs.tsx
@@ -18,14 +18,14 @@ const InstallTabs = (): JSX.Element => {
           the nodejs.org web site.
           <h2>Alternatives</h2>
           <p>
-            Using
+            Using{' '}
             <a href="https://brew.sh" target="_blank" rel="noopener noreferrer">
               Homebrew
             </a>
           </p>
           <code>brew install node</code>
           <p>
-            Using
+            Using{' '}
             <a
               href="https://www.macports.org"
               target="_blank"
@@ -60,7 +60,7 @@ const InstallTabs = (): JSX.Element => {
           <p>
             <a href="https://github.com/nodesource/distributions/blob/master/README.md">
               Node.js binary distributions
-            </a>
+            </a>{' '}
             are available from NodeSource.
           </p>
         </div>

--- a/src/components/installTabs.tsx
+++ b/src/components/installTabs.tsx
@@ -14,8 +14,10 @@ const InstallTabs = (): JSX.Element => {
 
       <TabPanel>
         <div>
-          Download the <Link to="/download">macOS Installer</Link> directly from
-          the nodejs.org web site.
+          <p>
+            Download the <Link to="/download">macOS Installer</Link> directly
+            from the nodejs.org web site.
+          </p>
           <h2>Alternatives</h2>
           <p>
             Using{' '}
@@ -23,7 +25,7 @@ const InstallTabs = (): JSX.Element => {
               Homebrew
             </a>
           </p>
-          <code>brew install node</code>
+          <code className="install__text">brew install node</code>
           <p>
             Using{' '}
             <a
@@ -34,7 +36,7 @@ const InstallTabs = (): JSX.Element => {
               Macports
             </a>
           </p>
-          <code>port install nodejs14</code>
+          <code className="install__text">port install nodejs14</code>
         </div>
       </TabPanel>
       <TabPanel>
@@ -45,10 +47,9 @@ const InstallTabs = (): JSX.Element => {
           </p>
           <h2>Alternatives</h2>
           <p> Using Chocolatey:</p>
-          <code>
-            cinst nodejs # or for full install with npm cinst nodejs.install
-            Using Scoop: scoop install nodejs
-          </code>
+          <code className="install__text">cinst nodejs</code>
+          <p>Using Scoop:</p>
+          <code className="install__text">scoop install nodejs</code>
         </div>
       </TabPanel>
       <TabPanel>

--- a/src/components/installTabs.tsx
+++ b/src/components/installTabs.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
+import '../styles/install-tabs.scss';
+import { Link } from 'gatsby';
+
+const InstallTabs = (): JSX.Element => {
+  return (
+    <Tabs>
+      <TabList>
+        <Tab>Mac OS</Tab>
+        <Tab>Windows</Tab>
+        <Tab>Ubuntu / Debian</Tab>
+      </TabList>
+
+      <TabPanel>
+        <div>
+          Download the <Link to="/download">macOS Installer</Link> directly from
+          the nodejs.org web site.
+          <h2>Alternatives</h2>
+          <p>
+            Using
+            <a href="https://brew.sh" target="_blank" rel="noopener noreferrer">
+              Homebrew
+            </a>
+          </p>
+          <code>brew install node</code>
+          <p>
+            Using
+            <a
+              href="https://www.macports.org"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Macports
+            </a>
+          </p>
+          <code>port install nodejs14</code>
+        </div>
+      </TabPanel>
+      <TabPanel>
+        <div>
+          <p>
+            Download the <Link to="/download">Windows Installer</Link> directly
+            from the nodejs.org web site.
+          </p>
+          <h2>Alternatives</h2>
+          <p> Using Chocolatey:</p>
+          <code>
+            cinst nodejs # or for full install with npm cinst nodejs.install
+            Using Scoop: scoop install nodejs
+          </code>
+        </div>
+      </TabPanel>
+      <TabPanel>
+        <div>
+          <h2>
+            Debian and Ubuntu based Linux distributions, Enterprise Linux/Fedora
+            and Snap packages
+          </h2>
+          <p>
+            <a href="https://github.com/nodesource/distributions/blob/master/README.md">
+              Node.js binary distributions
+            </a>
+            are available from NodeSource.
+          </p>
+        </div>
+      </TabPanel>
+    </Tabs>
+  );
+};
+
+export default InstallTabs;

--- a/src/components/installTabs.tsx
+++ b/src/components/installTabs.tsx
@@ -36,7 +36,34 @@ const InstallTabs = (): JSX.Element => {
               Macports
             </a>
           </p>
+
           <code className="install__text">port install nodejs14</code>
+          <p>
+            Using{' '}
+            <a
+              href="https://github.com/nvm-sh/nvm"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              nvm
+            </a>
+          </p>
+          <code className="install__text">
+            curl -o-
+            https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh |
+            bash
+          </code>
+          {/* TODO when the new docs page is ready link to that page.  */}
+          <button type="button">
+            <a
+              className="install__docs-button"
+              href="https://nodejs.org/en/download/package-manager/#macos"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Read documentation
+            </a>
+          </button>
         </div>
       </TabPanel>
       <TabPanel>
@@ -50,6 +77,16 @@ const InstallTabs = (): JSX.Element => {
           <code className="install__text">cinst nodejs</code>
           <p>Using Scoop:</p>
           <code className="install__text">scoop install nodejs</code>
+          <button type="button">
+            <a
+              className="install__docs-button"
+              href="https://nodejs.org/en/download/package-manager/#windows"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Read documentation
+            </a>
+          </button>
         </div>
       </TabPanel>
       <TabPanel>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -15,6 +15,7 @@ import logoImg2 from '../images/logos/linkedin-logo.svg';
 import logoImg3 from '../images/logos/microsoft-logo.svg';
 import logoImg4 from '../images/logos/netflix-logo.svg';
 import logoImg5 from '../images/logos/paypal-logo.svg';
+import InstallTabs from '../components/installTabs';
 
 export default function Index(): JSX.Element {
   const title = 'Run JavaScript Everywhere.';
@@ -28,7 +29,9 @@ export default function Index(): JSX.Element {
         <Hero title={title} subTitle={subTitle} />
 
         <section className="node-demo-container">
-          <div className="node-demo" />
+          <div className="node-demo">
+            <InstallTabs />
+          </div>
           <img className="leafs-front" src={leafsIllustrationFront} alt="" />
           <img className="leafs-middle" src={leafsIllustrationMiddle} alt="" />
           <img className="leafs-back" src={leafsIllustrationBack} alt="" />

--- a/src/styles/install-tabs.scss
+++ b/src/styles/install-tabs.scss
@@ -1,0 +1,56 @@
+.react-tabs {
+  -webkit-tap-highlight-color: transparent;
+
+  &__tab-list {
+    margin: 0 0 10px;
+    padding: 0;
+  }
+
+  &__tab {
+    display: inline-block;
+    border: 1px solid transparent;
+    border-bottom: none;
+    bottom: -1px;
+    position: relative;
+    list-style: none;
+    padding: 6px 12px;
+    background: lighten($color: #2c3437, $amount: 20);
+    cursor: pointer;
+
+    &--selected {
+      background: #2c3437;
+      border-color: #aaa;
+      color: #fff;
+      border-radius: 5px 5px 0 0;
+    }
+
+    &--disabled {
+      color: #ccc;
+      cursor: default;
+    }
+
+    &:focus {
+      box-shadow: 0 0 5px hsl(208, 99%, 50%);
+      border-color: hsl(208, 99%, 50%);
+      outline: none;
+
+      &:after {
+        content: '';
+        position: absolute;
+        height: 5px;
+        left: -4px;
+        right: -4px;
+        bottom: -5px;
+        background: #fff;
+      }
+    }
+  }
+
+  &__tab-panel {
+    display: none;
+
+    &--selected {
+      display: block;
+    }
+  }
+}

--- a/src/styles/install-tabs.scss
+++ b/src/styles/install-tabs.scss
@@ -4,6 +4,7 @@
   &__tab-list {
     margin: 0 0 10px;
     padding: 0;
+    text-align: center;
   }
 
   &__tab {
@@ -16,6 +17,9 @@
     padding: 6px 12px;
     background: lighten($color: #2c3437, $amount: 20);
     cursor: pointer;
+    height: 32px;
+    width: 167px;
+    text-align: center;
 
     &--selected {
       background: var(--black9);
@@ -51,8 +55,24 @@
 
   p {
     margin-bottom: 5px;
+    padding-left: 10px;
+    padding-top: 3px;
   }
   .install__text {
     color: var(--pink6);
+    padding-left: 6px;
+  }
+  .install__docs-button,
+  .install__docs-button:hover {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-decoration: none;
+    box-sizing: border-box;
+    width: 17rem;
+    height: 4rem;
+    color: var(--black6);
+    margin: 0 var(--space-16);
+    font-weight: var(--font-weight-semibold);
   }
 }

--- a/src/styles/install-tabs.scss
+++ b/src/styles/install-tabs.scss
@@ -48,4 +48,11 @@
       display: block;
     }
   }
+
+  p {
+    margin-bottom: 5px;
+  }
+  .install__text {
+    color: var(--pink6);
+  }
 }

--- a/src/styles/install-tabs.scss
+++ b/src/styles/install-tabs.scss
@@ -18,15 +18,10 @@
     cursor: pointer;
 
     &--selected {
-      background: #2c3437;
-      border-color: #aaa;
+      background: var(--black9);
+      border-color: var(--color-border-primary);
       color: #fff;
       border-radius: 5px 5px 0 0;
-    }
-
-    &--disabled {
-      color: #ccc;
-      cursor: default;
     }
 
     &:focus {
@@ -41,7 +36,7 @@
         left: -4px;
         right: -4px;
         bottom: -5px;
-        background: #fff;
+        background: var(--black0);
       }
     }
   }

--- a/test/components/__snapshots__/installTabs.test.tsx.snap
+++ b/test/components/__snapshots__/installTabs.test.tsx.snap
@@ -96,6 +96,34 @@ exports[`Tests for InstallTabs component renders correctly 1`] = `
       >
         port install nodejs14
       </code>
+      <p>
+        Using
+         
+        <a
+          href="https://github.com/nvm-sh/nvm"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          nvm
+        </a>
+      </p>
+      <code
+        className="install__text"
+      >
+        curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
+      </code>
+      <button
+        className="install__docs-button"
+        type="button"
+      >
+        <a
+          href="https://nodejs.org/en/download/package-manager"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Read documentation
+        </a>
+      </button>
     </div>
   </div>
   <div

--- a/test/components/__snapshots__/installTabs.test.tsx.snap
+++ b/test/components/__snapshots__/installTabs.test.tsx.snap
@@ -113,11 +113,11 @@ exports[`Tests for InstallTabs component renders correctly 1`] = `
         curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
       </code>
       <button
-        className="install__docs-button"
         type="button"
       >
         <a
-          href="https://nodejs.org/en/download/package-manager"
+          className="install__docs-button"
+          href="https://nodejs.org/en/download/package-manager/#macos"
           rel="noopener noreferrer"
           target="_blank"
         >

--- a/test/components/__snapshots__/installTabs.test.tsx.snap
+++ b/test/components/__snapshots__/installTabs.test.tsx.snap
@@ -1,0 +1,108 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Tests for InstallTabs component renders correctly 1`] = `
+<div
+  className="react-tabs"
+  data-tabs={true}
+  onClick={[Function]}
+  onKeyDown={[Function]}
+>
+  <ul
+    className="react-tabs__tab-list"
+    role="tablist"
+  >
+    <li
+      aria-controls="react-tabs-1"
+      aria-disabled="false"
+      aria-selected="true"
+      className="react-tabs__tab react-tabs__tab--selected"
+      id="react-tabs-0"
+      role="tab"
+      tabIndex="0"
+    >
+      Mac OS
+    </li>
+    <li
+      aria-controls="react-tabs-3"
+      aria-disabled="false"
+      aria-selected="false"
+      className="react-tabs__tab"
+      id="react-tabs-2"
+      role="tab"
+      tabIndex={null}
+    >
+      Windows
+    </li>
+    <li
+      aria-controls="react-tabs-5"
+      aria-disabled="false"
+      aria-selected="false"
+      className="react-tabs__tab"
+      id="react-tabs-4"
+      role="tab"
+      tabIndex={null}
+    >
+      Ubuntu / Debian
+    </li>
+  </ul>
+  <div
+    aria-labelledby="react-tabs-0"
+    className="react-tabs__tab-panel react-tabs__tab-panel--selected"
+    id="react-tabs-1"
+    role="tabpanel"
+  >
+    <div>
+      Download the 
+      <a
+        href="/download"
+      >
+        macOS Installer
+      </a>
+       directly from the nodejs.org web site.
+      <h2>
+        Alternatives
+      </h2>
+      <p>
+        Using
+         
+        <a
+          href="https://brew.sh"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Homebrew
+        </a>
+      </p>
+      <code>
+        brew install node
+      </code>
+      <p>
+        Using
+         
+        <a
+          href="https://www.macports.org"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Macports
+        </a>
+      </p>
+      <code>
+        port install nodejs14
+      </code>
+    </div>
+  </div>
+  <div
+    aria-labelledby="react-tabs-2"
+    className="react-tabs__tab-panel"
+    id="react-tabs-3"
+    role="tabpanel"
+  />
+  <div
+    aria-labelledby="react-tabs-4"
+    className="react-tabs__tab-panel"
+    id="react-tabs-5"
+    role="tabpanel"
+  />
+</div>
+`;

--- a/test/components/__snapshots__/installTabs.test.tsx.snap
+++ b/test/components/__snapshots__/installTabs.test.tsx.snap
@@ -52,13 +52,15 @@ exports[`Tests for InstallTabs component renders correctly 1`] = `
     role="tabpanel"
   >
     <div>
-      Download the 
-      <a
-        href="/download"
-      >
-        macOS Installer
-      </a>
-       directly from the nodejs.org web site.
+      <p>
+        Download the 
+        <a
+          href="/download"
+        >
+          macOS Installer
+        </a>
+         directly from the nodejs.org web site.
+      </p>
       <h2>
         Alternatives
       </h2>
@@ -73,7 +75,9 @@ exports[`Tests for InstallTabs component renders correctly 1`] = `
           Homebrew
         </a>
       </p>
-      <code>
+      <code
+        className="install__text"
+      >
         brew install node
       </code>
       <p>
@@ -87,7 +91,9 @@ exports[`Tests for InstallTabs component renders correctly 1`] = `
           Macports
         </a>
       </p>
-      <code>
+      <code
+        className="install__text"
+      >
         port install nodejs14
       </code>
     </div>

--- a/test/components/installTabs.test.tsx
+++ b/test/components/installTabs.test.tsx
@@ -1,0 +1,11 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import React from 'react';
+import renderer from 'react-test-renderer';
+import InstallTabs from '../../src/components/installTabs';
+
+describe('Tests for InstallTabs component', () => {
+  it('renders correctly', () => {
+    const tree = renderer.create(<InstallTabs />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
## Description
This PR is for the install tabs on the homepage. See my demo link
~~https://install-tabs--staging-nodejsdev.netlify.app/~~
https://staging.nodejs.dev/612/

I think we want the most popular Operating systems displayed and not what we see in the design. 

Outside of Mac OS, Windows and Ubuntu what else should be included. We can fit 5 
For reference 
![Screen Shot 2020-04-26 at 8 29 44 PM](https://user-images.githubusercontent.com/7907232/80331351-b6680480-87fc-11ea-87aa-985fbfb94264.png)

Where should the read documentation button go? Right now my PR does not include this button.
## Related Issues
#333 