### PR TITLE
tools: automate deployment of staging branch

### DIFF
--- a/cloudbuild-staging.yaml
+++ b/cloudbuild-staging.yaml
@@ -1,0 +1,9 @@
+steps:
+- name: 'node:12'
+  entrypoint: npm
+  args: ['ci']
+- name: 'node:12'
+  entrypoint: npm
+  args: ['run', 'build']
+- name: 'gcr.io/cloud-builders/gsutil'
+  args: ['-m', 'rsync', '-R', 'public', 'gs://staging.nodejs.dev/']


### PR DESCRIPTION
This should have 0 affect on master but will make eventually reconciling staging with master easier. Cherrypicking the single unique commit from https://github.com/nodejs/nodejs.dev/pull/661