### PR TITLE
docs: Fix Promise error handling examples

### DIFF
--- a/src/documentation/0054-node-exceptions/index.md
+++ b/src/documentation/0054-node-exceptions/index.md
@@ -75,8 +75,8 @@ Using promises you can chain different operations, and handle errors at the end:
 
 ```js
 doSomething1()
-  .then(doSomething2())
-  .then(doSomething3())
+  .then(doSomething2)
+  .then(doSomething3)
   .catch(err => console.error(err))
 ```
 
@@ -98,14 +98,14 @@ const doSomething1 = () => {
 To be able to handle errors locally without handling them in the function we call, we can break the chain you can create a function in each `then()` and process the exception:
 
 ```js
-doSomething1
-  .then((() => {
+doSomething1()
+  .then(() => {
     return doSomething2().catch(err => {
       //handle error
       throw err //break the chain!
     })
   })
-  .then((() => {
+  .then(() => {
     return doSomething2().catch(err => {
       //handle error
       throw err //break the chain!


### PR DESCRIPTION
## Description

Tweaked function calls in examples in "Exceptions with promises" section to reduce possible confusion vectors: 
1. `doSomething1` is a function that returns a `Promise` in both examples
2. `doSomething2` and `doSomething3` should not be called until the `doSomething1` promise resolves if they return a `Promise` or the chain will be broken.
3. In examples of mid-chain handling, there is an extra parenthesis in first `then`

This will result in correct order: AA (after 2s) -> BB (after 3s)
````
new Promise(
    (r, j) => setTimeout(() => {
        console.log("AA");
        r();
    }, 2000)
).then(
    () => new Promise(
        (r, j) => setTimeout(() => {
            console.log("BB");
            r();
        }, 1000)
    )
);
````

But this won't (as promise is scheduled immediately): BB (after 1s) -> AA (after 2s)
````
new Promise(
    (r, j) => setTimeout(() => {
        console.log("AA");
        r();
    }, 2000)
).then(
    (() => new Promise(
        (r, j) => setTimeout(() => {
            console.log("BB");
            r();
        }, 1000)
    ))()
)
````
