### PR TITLE
style: Update styles for intall-tabs

### DIFF
--- a/src/components/installTabs.tsx
+++ b/src/components/installTabs.tsx
@@ -22,20 +22,23 @@ const InstallTabs = (): JSX.Element => {
 
       <TabPanel>
         <div>
-          <p>
+          <h4>
             Download the <Link to="/download">macOS Installer</Link> directly
             from the nodejs.org website.
-          </p>
-          <h2>Alternatives</h2>
-          <p>
-            Using{' '}
+          </h4>
+          <h4>Alternatives</h4>
+          <code className="install__comments">
+            #Using{' '}
             <a href="https://brew.sh" target="_blank" rel="noopener noreferrer">
               Homebrew
             </a>
-          </p>
+          </code>
+          <br />
           <code className="install__text">brew install node</code>
-          <p>
-            Using{' '}
+          <br />
+          <br />
+          <code className="install__comments">
+            #Using{' '}
             <a
               href="https://www.macports.org"
               target="_blank"
@@ -43,11 +46,13 @@ const InstallTabs = (): JSX.Element => {
             >
               Macports
             </a>
-          </p>
-
+          </code>
+          <br />
           <code className="install__text">port install nodejs14</code>
-          <p>
-            Using{' '}
+          <br />
+          <br />
+          <code className="install__comments">
+            #Using{' '}
             <a
               href="https://github.com/nvm-sh/nvm"
               target="_blank"
@@ -55,7 +60,8 @@ const InstallTabs = (): JSX.Element => {
             >
               nvm
             </a>
-          </p>
+          </code>
+          <br />
           <code className="install__text">
             curl -o-
             https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh |
@@ -77,14 +83,18 @@ const InstallTabs = (): JSX.Element => {
       </TabPanel>
       <TabPanel>
         <div>
-          <p>
+          <h4>
             Download the <Link to="/download">Windows Installer</Link> directly
             from the nodejs.org web site.
-          </p>
-          <h2>Alternatives</h2>
-          <p> Using Chocolatey:</p>
+          </h4>
+          <h4>Alternatives</h4>
+          <code className="install__comments">#Using Chocolatey:</code>
+          <br />
           <code className="install__text">cinst nodejs</code>
-          <p>Using Scoop:</p>
+          <br />
+          <br />
+          <code className="install__comments">#Using Scoop</code>
+          <br />
           <code className="install__text">scoop install nodejs</code>
           <br />
           <button type="button" className="install__docs-button">
@@ -101,10 +111,10 @@ const InstallTabs = (): JSX.Element => {
       </TabPanel>
       <TabPanel>
         <div>
-          <h2>
+          <h4>
             Debian and Ubuntu based Linux distributions, Enterprise Linux/Fedora
             and Snap packages
-          </h2>
+          </h4>
           <p>
             <a href="https://github.com/nodesource/distributions/blob/master/README.md">
               Node.js binary distributions

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -3,7 +3,7 @@
   margin: 0 auto;
   margin-bottom: var(--space-80);
   position: relative;
-  --section-margin-bottom: 340px;
+  --section-margin-bottom: 80px;
 }
 
 .node-demo-container {
@@ -11,6 +11,7 @@
 }
 
 .node-demo {
+  position: relative;
   max-width: 832px;
   width: 90vw;
   margin: 0 auto;

--- a/src/styles/install-tabs.scss
+++ b/src/styles/install-tabs.scss
@@ -1,6 +1,10 @@
 .react-tabs {
   -webkit-tap-highlight-color: transparent;
 
+  h4 {
+    margin-top: 0;
+  }
+
   &__tab-list {
     margin: 0;
     padding: 0;
@@ -28,18 +32,19 @@
     }
 
     &:focus {
-      box-shadow: 0 0 5px hsl(208, 99%, 50%);
-      border-color: hsl(208, 99%, 50%);
+      box-shadow: 0 0 5px var(--pink5);
+      border-color: var(--pink5);
+      border-bottom: none;
       outline: none;
 
       &:after {
         content: '';
         position: absolute;
         height: 5px;
-        left: -4px;
-        right: -4px;
+        left: 0;
+        right: 0;
         bottom: -5px;
-        background: var(--black0);
+        background: var(--black9);
       }
     }
   }
@@ -84,14 +89,23 @@
         line-height: 30px;
       }
     }
+    &__comments {
+      color: var(--black8);
+      font-style: italic;
+      a {
+        color: var(--color-fill-action);
+      }
+    }
     &__text {
-      color: var(--pink6);
+      color: var(--pink5);
       padding-left: 6px;
     }
     &__docs-button {
       border-radius: var(--space-04);
       padding: var(--space-08) var(--space-16);
-      margin-top: var(--space-20);
+      position: absolute;
+      bottom: 2rem;
+      right: 2rem;
     }
     &__docs-button-text,
     &__docs-button-text:hover {

--- a/test/components/__snapshots__/installTabs.test.tsx.snap
+++ b/test/components/__snapshots__/installTabs.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`Tests for InstallTabs component renders correctly 1`] = `
     role="tabpanel"
   >
     <div>
-      <p>
+      <h4>
         Download the 
         <a
           href="/download"
@@ -82,12 +82,14 @@ exports[`Tests for InstallTabs component renders correctly 1`] = `
           macOS Installer
         </a>
          directly from the nodejs.org website.
-      </p>
-      <h2>
+      </h4>
+      <h4>
         Alternatives
-      </h2>
-      <p>
-        Using
+      </h4>
+      <code
+        className="install__comments"
+      >
+        #Using
          
         <a
           href="https://brew.sh"
@@ -96,14 +98,19 @@ exports[`Tests for InstallTabs component renders correctly 1`] = `
         >
           Homebrew
         </a>
-      </p>
+      </code>
+      <br />
       <code
         className="install__text"
       >
         brew install node
       </code>
-      <p>
-        Using
+      <br />
+      <br />
+      <code
+        className="install__comments"
+      >
+        #Using
          
         <a
           href="https://www.macports.org"
@@ -112,14 +119,19 @@ exports[`Tests for InstallTabs component renders correctly 1`] = `
         >
           Macports
         </a>
-      </p>
+      </code>
+      <br />
       <code
         className="install__text"
       >
         port install nodejs14
       </code>
-      <p>
-        Using
+      <br />
+      <br />
+      <code
+        className="install__comments"
+      >
+        #Using
          
         <a
           href="https://github.com/nvm-sh/nvm"
@@ -128,7 +140,8 @@ exports[`Tests for InstallTabs component renders correctly 1`] = `
         >
           nvm
         </a>
-      </p>
+      </code>
+      <br />
       <code
         className="install__text"
       >


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Styling improves of Install tabs 

## Related Issues

Addresses  #719

Before

<img width="1241" alt="Screenshot 2020-05-15 at 9 50 47 PM" src="https://user-images.githubusercontent.com/11137394/82072988-2da30100-96f6-11ea-91e5-f3f306af97b4.png">

<img width="906" alt="Screenshot 2020-05-15 at 9 53 19 PM" src="https://user-images.githubusercontent.com/11137394/82073214-90949800-96f6-11ea-9868-2ba0b2e75474.png">



After

<img width="1203" alt="Screenshot 2020-05-15 at 9 50 25 PM" src="https://user-images.githubusercontent.com/11137394/82072940-1b28c780-96f6-11ea-87bb-36a5d3b8f616.png">

<img width="1014" alt="Screenshot 2020-05-15 at 9 53 35 PM" src="https://user-images.githubusercontent.com/11137394/82073226-94c0b580-96f6-11ea-997f-1fada0818a7e.png">


<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

<!--
  If you want to generate a preview of this PR on our staging server please
  make a comment on the Pull-Request with the text `/preview`
 -->