### PR TITLE
Fix: Janky scrolling of filter drop-shadow

### DIFF
--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -17,7 +17,6 @@
   }
 }
 
-
 .node-demo-container {
   position: relative;
 }
@@ -42,7 +41,6 @@
   right: -16px;
   z-index: -1;
   animation: leafs-animation 10s infinite alternate ease-in-out;
-  filter: drop-shadow(10px 5px 50px rgba(0, 0, 0, 0.1));
 }
 
 .leafs-middle {
@@ -51,7 +49,6 @@
   right: 20px;
   z-index: -2;
   animation: leafs-animation 15s infinite alternate ease-in-out;
-  filter: drop-shadow(6px 5px 25px rgba(0, 0, 0, 0.1));
 }
 
 .leafs-back {


### PR DESCRIPTION
## Description

This PR fixes janky scrolling by removing filter drop-shadow CSS property. 

`Note:` Even after removing drop-shadow i didn't see any significant change in animation or difference in UI.

**Difference**:

`Existing:` https://nodejs.dev

`Staging`: https://staging.nodejs.dev/771/

## Related Issues

Fixes #770 
