### PR TITLE
Update sentence for fs.openSync

### DIFF
--- a/src/documentation/0040b-node-file-descriptors/index.md
+++ b/src/documentation/0040b-node-file-descriptors/index.md
@@ -28,7 +28,7 @@ Other flags you'll commonly use are
 * `a` open the file for writing, positioning the stream at the end of the file. The file is created if not existing
 * `a+` open the file for reading and writing, positioning the stream at the end of the file. The file is created if not existing
 
-You can also open the file by using the `fs.openSync` method, which instead of providing the file descriptor object in a callback, it returns it:
+You can also open the file by using the `fs.openSync` method, which returns the file descriptor, instead of providing it in a callback:
 
 ```js
 const fs = require('fs')


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description

`..., which instead of providing the file descriptor object in a callback, it returns it:` - does not look like correct sentence. Maybe this change would make it more clear.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

<!--
  If you want to generate a preview of this PR on our staging server please
  make a comment on the Pull-Request with the text `/preview`
 -->