### PR TITLE
Fix: Make documentation button hit area the whole button in Shell box

### DIFF
--- a/src/components/InstallTabs/InstallTabs.scss
+++ b/src/components/InstallTabs/InstallTabs.scss
@@ -92,23 +92,19 @@
         user-select: none;
       }
     }
-    &__docs-button {
+    &__docs-button,
+    &__docs-button:hover {
       border-radius: var(--space-04);
+      border: 1px solid var(--color-text-secondary);
       padding: var(--space-08) var(--space-16);
       position: absolute;
       bottom: 2rem;
       right: 2rem;
-    }
-    &__docs-button-text {
       text-decoration: none;
       box-sizing: border-box;
-      width: 17rem;
       height: 4rem;
-      color: var(--black5);
+      color: var(--color-text-secondary);
       font-weight: var(--font-weight-semibold);
-      &:hover {
-        color: var(--pink5);
-      }
     }
   }
   .shell-box {

--- a/src/components/InstallTabs/LinuxPanel/index.tsx
+++ b/src/components/InstallTabs/LinuxPanel/index.tsx
@@ -27,16 +27,14 @@ g++ libgcc linux-headers grep util-linux binutils findutils"
       <br />
       <br />
       {/* TODO when the new docs page is ready link to that page.  */}
-      <button type="button" className="install__docs-button">
-        <a
-          className="install__docs-button-text"
-          href="https://nodejs.org/en/download/package-manager/#nvm"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Read documentation
-        </a>
-      </button>
+      <a
+        className="install__docs-button"
+        href="https://nodejs.org/en/download/package-manager/#nvm"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Read documentation
+      </a>
     </div>
   );
 };

--- a/src/components/InstallTabs/MacOSPanel/index.tsx
+++ b/src/components/InstallTabs/MacOSPanel/index.tsx
@@ -17,16 +17,14 @@ const MacOSPanel = (): JSX.Element => {
       </ShellBox>
       <br />
       <br />
-      <button type="button" className="install__docs-button">
-        <a
-          className="install__docs-button-text"
-          href="https://nodejs.org/en/download/package-manager/#nvm"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Read documentation
-        </a>
-      </button>
+      <a
+        className="install__docs-button"
+        href="https://nodejs.org/en/download/package-manager/#nvm"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Read documentation
+      </a>
     </div>
   );
 };

--- a/src/components/InstallTabs/WindowsPanel/index.tsx
+++ b/src/components/InstallTabs/WindowsPanel/index.tsx
@@ -11,16 +11,14 @@ const WindowsPanel = (): JSX.Element => {
       </ShellBox>
       <br />
       <br />
-      <button type="button" className="install__docs-button">
-        <a
-          className="install__docs-button-text"
-          href="https://nodejs.org/en/download/package-manager/#windows"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Read documentation
-        </a>
-      </button>
+      <a
+        className="install__docs-button"
+        href="https://nodejs.org/en/download/package-manager/#windows"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Read documentation
+      </a>
     </div>
   );
 };

--- a/src/components/InstallTabs/__tests__/__snapshots__/index.js.snap
+++ b/src/components/InstallTabs/__tests__/__snapshots__/index.js.snap
@@ -106,19 +106,14 @@ exports[`Tests for InstallTabs component renders correctly 1`] = `
       </pre>
       <br />
       <br />
-      <button
+      <a
         className="install__docs-button"
-        type="button"
+        href="https://nodejs.org/en/download/package-manager/#windows"
+        rel="noopener noreferrer"
+        target="_blank"
       >
-        <a
-          className="install__docs-button-text"
-          href="https://nodejs.org/en/download/package-manager/#windows"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          Read documentation
-        </a>
-      </button>
+        Read documentation
+      </a>
     </div>
   </div>
   <div


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description

No visual changes were made. The "Read documentation" button was a `button` with an `a` inside. This reduces the hit area of the button that results in an action (opening the documentation) only the text bounds.

The fix is to apply the button styles directly to the `a`. This PR also makes keyboard/AT navigation a lot better, an accessibility win!

This PR also updates the button's styles to match the mockup in Figma.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

<!--
  If you want to generate a preview of this PR on our staging server please
  make a comment on the Pull-Request with the text `/preview`
 -->