### PR TITLE
Style: Add hover style to shell box documentation button

### DIFF
--- a/src/components/InstallTabs/InstallTabs.scss
+++ b/src/components/InstallTabs/InstallTabs.scss
@@ -99,14 +99,16 @@
       bottom: 2rem;
       right: 2rem;
     }
-    &__docs-button-text,
-    &__docs-button-text:hover {
+    &__docs-button-text {
       text-decoration: none;
       box-sizing: border-box;
       width: 17rem;
       height: 4rem;
-      color: var(--black6);
+      color: var(--black5);
       font-weight: var(--font-weight-semibold);
+      &:hover {
+        color: var(--pink5);
+      }
     }
   }
   .shell-box {


### PR DESCRIPTION
## Description

Looks like the CSS for this button hover was not working correctly. This adds correctly hover functionality that matches the same pink color used in the shell box.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

<!--
  If you want to generate a preview of this PR on our staging server please
  make a comment on the Pull-Request with the text `/preview`
 -->