### PR TITLE
hide mobile navigation until menu is  open

### DIFF
--- a/src/styles/learn.scss
+++ b/src/styles/learn.scss
@@ -208,6 +208,12 @@
 
   .side-nav__list {
     top: 24px;
+    height: 0;
+    overflow: hidden;
+    .side-nav--open & {
+      overflow: visible;
+      height: auto;
+    }
   }
 
   .side-nav__title {


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Fixes #780 

If side navigation is scrolled when user changes window size to mobile, the contents of the navigation show behind the hamburger button.

![node](https://user-images.githubusercontent.com/1434956/89859901-ebebf000-db56-11ea-8eb2-50194f42f3c0.gif)


This PR reduces the height of the nav__list until the side nav is open.



## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

<!--
  If you want to generate a preview of this PR on our staging server please
  make a comment on the Pull-Request with the text `/preview`
 -->