### PR TITLE
Ensure that primary page content is wrapped in <main> for accessibility

### DIFF
--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -9,7 +9,7 @@ export default function NotFoundPage(): JSX.Element {
   return (
     <Layout title={title} description={description}>
       <Hero title={title} />
-      <article style={{ width: '100%' }} className="article-reader">
+      <main style={{ width: '100%' }} className="article-reader">
         <p>
           The page you&apos;re trying to access does not exist. Go back to the
           Homepage or find what you&apos;re looking for in the menu.
@@ -18,7 +18,7 @@ export default function NotFoundPage(): JSX.Element {
           Take me back to the
           <a href="/">Homepage</a>
         </p>
-      </article>
+      </main>
     </Layout>
   );
 }

--- a/src/pages/docs.tsx
+++ b/src/pages/docs.tsx
@@ -570,7 +570,7 @@ export default function APIDocsPage(): JSX.Element {
 
   return (
     <>
-      <main>
+      <main className="grid-container">
         <Layout title={title} description={description} showFooter={false}>
           <nav className="api-nav">
             <ul className="api-nav__list">

--- a/src/pages/download.tsx
+++ b/src/pages/download.tsx
@@ -24,7 +24,7 @@ export default function DownloadPage(): JSX.Element {
 
   return (
     <Layout title={title} description={description}>
-      <article style={{ width: '100%' }} className="article-reader">
+      <main style={{ width: '100%' }} className="article-reader">
         <p>
           Download the Node.js source code, a pre-built installer for your
           platform, or install via package manager.
@@ -33,7 +33,7 @@ export default function DownloadPage(): JSX.Element {
         <ReleaseToggle selected={ltsSelected} onToggle={setLtsSelected} />
         <ReleaseCards line={selectedLine} />
         <ReleaseTable releases={releaseHistory} />
-      </article>
+      </main>
     </Layout>
   );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -51,7 +51,7 @@ export default function Index(): JSX.Element {
 
   return (
     <Layout title={title} description={description}>
-      <div className="home-page">
+      <main className="home-page">
         <Hero title={title} subTitle={subTitle} />
 
         <section className="node-demo-container">
@@ -87,7 +87,7 @@ export default function Index(): JSX.Element {
             Get Started
           </Link>
         </div>
-      </div>
+      </main>
     </Layout>
   );
 }

--- a/src/pages/style-guide.tsx
+++ b/src/pages/style-guide.tsx
@@ -3,7 +3,7 @@ import '../styles/layout.scss';
 
 const StyleGuidePage = (): JSX.Element => {
   return (
-    <div style={{ maxWidth: `940px`, margin: `0 auto` }}>
+    <main style={{ maxWidth: `940px`, margin: `0 auto` }}>
       <div className="t-display1">Display1</div>
       <div className="t-display2">Display2</div>
       <div className="t-display3">Display3</div>
@@ -28,7 +28,7 @@ const StyleGuidePage = (): JSX.Element => {
       </p>
       {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
       <a href="#">This is a link</a>
-    </div>
+    </main>
   );
 };
 

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -303,60 +303,6 @@ select {
   border-bottom: 4px solid green;
 }
 
-/* Footer */
-
-.footer {
-  display: flex;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  margin: 0;
-
-  .footer__left {
-    display: flex;
-    justify-content: space-between;
-    flex-wrap: wrap;
-    list-style: none;
-    height: 100%;
-  }
-
-  .footer__right {
-    display: flex;
-    justify-content: space-between;
-    flex-wrap: wrap;
-    list-style: none;
-    height: 100%;
-    margin-right: 20px;
-  }
-
-  .footer__left > li,
-  .footer__right > li {
-    font-size: 12px;
-    margin-right: 32px;
-    height: 24px;
-  }
-
-  .footer__left {
-    li a {
-      color: var(--color-text-primary);
-
-      &:hover {
-        color: var(--color-brand-primary);
-      }
-    }
-
-    > li:first-of-type {
-      padding-right: 12px;
-      padding-top: 0;
-      margin-right: 12px;
-      border-right: 1px solid var(--black5);
-    }
-  }
-
-  .footer__link {
-    text-decoration: none;
-  }
-}
-
 /* Start: Article Reader HTML Reset */
 
 .article-reader {
@@ -492,46 +438,6 @@ details {
 
     > a {
       padding: var(--space-12);
-    }
-  }
-
-  .footer {
-    flex-direction: column;
-
-    .footer__left {
-      flex-direction: column;
-      height: 10rem;
-      justify-content: center;
-      align-items: center;
-      > li:first-of-type {
-        padding-right: 0;
-        margin-right: 0;
-        border-right: none;
-      }
-    }
-
-    .footer__right {
-      margin: 0;
-
-      > li:first-of-type {
-        margin-right: auto;
-        margin-left: 0;
-      }
-
-      > li {
-        margin-left: 18px;
-      }
-    }
-
-    .footer__left,
-    .footer__right {
-      padding: 6px 18px;
-    }
-
-    .footer__left > li,
-    .footer__right > li {
-      margin-right: 0;
-      padding: 6px 0;
     }
   }
 }

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -232,6 +232,11 @@ select {
   outline: none;
 }
 
+.grid-container {
+  display: grid;
+  grid-template-columns: 28.8rem auto;
+}
+
 .nav {
   display: flex;
   align-items: center;

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -224,17 +224,17 @@ select {
   }
 }
 
+.grid-container {
+  display: grid;
+  grid-template-columns: 28.8rem auto;
+}
+
 :focus {
   outline: var(--brand3) dotted 2px;
 }
 
 [data-is-focused='true'] {
   outline: none;
-}
-
-.grid-container {
-  display: grid;
-  grid-template-columns: 28.8rem auto;
 }
 
 .nav {
@@ -301,6 +301,60 @@ select {
 
 .active {
   border-bottom: 4px solid green;
+}
+
+/* Footer */
+
+.footer {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  margin: 0;
+
+  .footer__left {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    list-style: none;
+    height: 100%;
+  }
+
+  .footer__right {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    list-style: none;
+    height: 100%;
+    margin-right: 20px;
+  }
+
+  .footer__left > li,
+  .footer__right > li {
+    font-size: 12px;
+    margin-right: 32px;
+    height: 24px;
+  }
+
+  .footer__left {
+    li a {
+      color: var(--color-text-primary);
+
+      &:hover {
+        color: var(--color-brand-primary);
+      }
+    }
+
+    > li:first-of-type {
+      padding-right: 12px;
+      padding-top: 0;
+      margin-right: 12px;
+      border-right: 1px solid var(--black5);
+    }
+  }
+
+  .footer__link {
+    text-decoration: none;
+  }
 }
 
 /* Start: Article Reader HTML Reset */
@@ -438,6 +492,46 @@ details {
 
     > a {
       padding: var(--space-12);
+    }
+  }
+
+  .footer {
+    flex-direction: column;
+
+    .footer__left {
+      flex-direction: column;
+      height: 10rem;
+      justify-content: center;
+      align-items: center;
+      > li:first-of-type {
+        padding-right: 0;
+        margin-right: 0;
+        border-right: none;
+      }
+    }
+
+    .footer__right {
+      margin: 0;
+
+      > li:first-of-type {
+        margin-right: auto;
+        margin-left: 0;
+      }
+
+      > li {
+        margin-left: 18px;
+      }
+    }
+
+    .footer__left,
+    .footer__right {
+      padding: 6px 18px;
+    }
+
+    .footer__left > li,
+    .footer__right > li {
+      margin-right: 0;
+      padding: 6px 0;
     }
   }
 }

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -224,11 +224,6 @@ select {
   }
 }
 
-main {
-  display: grid;
-  grid-template-columns: 28.8rem auto;
-}
-
 :focus {
   outline: var(--brand3) dotted 2px;
 }

--- a/src/templates/learn.tsx
+++ b/src/templates/learn.tsx
@@ -25,7 +25,7 @@ const LearnLayout = ({
   pageContext: { slug, next, previous, relativePath, navigationData },
 }: Props): React.ReactNode => (
   <>
-    <main>
+    <main className="grid-container">
       <Layout title={title} description={description} showFooter={false}>
         <Navigation currentSlug={slug} sections={navigationData} />
         <Article

--- a/test/pages/__snapshots__/404.test.tsx.snap
+++ b/test/pages/__snapshots__/404.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`404 page renders correctly 1`] = `
   <Hero
     title="PAGE NOT FOUND"
   />
-  <article
+  <main
     className="article-reader"
     style={
       Object {
@@ -27,6 +27,6 @@ exports[`404 page renders correctly 1`] = `
         Homepage
       </a>
     </p>
-  </article>
+  </main>
 </Layout>
 `;

--- a/test/templates/__snapshots__/learn.test.tsx.snap
+++ b/test/templates/__snapshots__/learn.test.tsx.snap
@@ -2,7 +2,9 @@
 
 exports[`Learn Template renders correctly 1`] = `
 <React.Fragment>
-  <main>
+  <main
+    className="grid-container"
+  >
     <Layout
       description="test-description"
       showFooter={false}


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Hello there! 😅
 
I noticed that a couple pages on the site are not wrapped in a [`<main>` sectioning element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main), so the goal of this PR is to ensure that each page includes this semantic markup.

**The `<main>` landmark element is part of the [WCAG 2.0 checkpoint: 4.2.1 - Name, Role, Value](https://www.w3.org/TR/UNDERSTANDING-WCAG20/ensure-compat-rsv.html)**, and it improves accessibility of a page by [helping assistive tech quickly identify the primary content of the page](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main#Accessibility_concerns).

Also, I noticed that 2 pages -- the 404 page and the [Download page](https://nodejs.dev/download/) -- were specifically using `<article>` elements to wrap page content; in both cases, I believe a `<main>` wrapping element is more appropriate. It's possible I'm missing some context though, so please let me know if I'm overlooking something -- thank you! 🎉 

### Summary of changes
- **404 page:** replace `article` element with `main` landmark, update snapshot
- **Download page:** replace `article` element with `main` landmark
- **Homepage:** using `main` landmark
- **Style guide page:** using `main` landmark
- ~Remove 2 CSS grid style rules for `main`~ UPDATE: I realized that these styles were important for the Docs and Learn pages, so I stored them & applied them selectively via a class name. 👍 