### PR TITLE
fix: order of nav items

### DIFF
--- a/src/components/Header/__tests__/__snapshots__/header.test.tsx.snap
+++ b/src/components/Header/__tests__/__snapshots__/header.test.tsx.snap
@@ -26,17 +26,6 @@ exports[`Tests for Header component renders correctly 1`] = `
     className="nav__tabs__container"
   >
     <li
-      className="nav__tabs"
-    >
-      <a
-        className="activeStyleTab"
-        href="/learn"
-        partiallyActive={true}
-      >
-        Learn
-      </a>
-    </li>
-    <li
       className="nav__tabs only-desktop"
     >
       <a
@@ -46,6 +35,17 @@ exports[`Tests for Header component renders correctly 1`] = `
         target="_blank"
       >
         Documentation
+      </a>
+    </li>
+    <li
+      className="nav__tabs"
+    >
+      <a
+        className="activeStyleTab"
+        href="/learn"
+        partiallyActive={true}
+      >
+        Learn
       </a>
     </li>
     <li

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -28,11 +28,6 @@ const Header = ({
     </div>
 
     <ul className="nav__tabs__container">
-      <li className="nav__tabs">
-        <Link to="/learn" className="activeStyleTab" partiallyActive>
-          Learn
-        </Link>
-      </li>
       <li className="nav__tabs only-desktop">
         <a
           className="activeStyleTab"
@@ -42,6 +37,11 @@ const Header = ({
         >
           Documentation
         </a>
+      </li>
+      <li className="nav__tabs">
+        <Link to="/learn" className="activeStyleTab" partiallyActive>
+          Learn
+        </Link>
       </li>
       <li className="nav__tabs">
         <a


### PR DESCRIPTION
Hi! This is my first time contributing to Node.js :) 

## Description

The Figma design comps show an ordering of: Documentation -> Learn -> Downloads. The current nodejs.dev site shows: Learn -> Documentation -> Downloads.

Here's what is shown in the comp: 
![Screen Shot 2020-08-11 at 5 38 06 PM](https://user-images.githubusercontent.com/22847924/89951516-91f03680-dbf9-11ea-8fb6-34a2d88a38a5.png)
