### PR TITLE
docs(contributing.md) removed staging note.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,8 +56,6 @@ In the case of an objection being raised in a pull request by another collaborat
 
 ## Getting Started
 
-For feature development you should be working from the staging branch.
-
 * Fork
 * Clone your fork `git clone git@github.com:<githubid>/nodejs.dev.git`
 * cd into your project

--- a/cloudbuild-staging.yaml
+++ b/cloudbuild-staging.yaml
@@ -1,9 +1,0 @@
-steps:
-- name: 'node:12'
-  entrypoint: npm
-  args: ['ci']
-- name: 'node:12'
-  entrypoint: npm
-  args: ['run', 'build']
-- name: 'gcr.io/cloud-builders/gsutil'
-  args: ['-m', 'rsync', '-R', 'public', 'gs://staging.nodejs.dev/']


### PR DESCRIPTION
## Description
The staging branch is no longer used for feature development. It's only purpose is for when a developer creates a pull request preview by doing `/preview`