### PR TITLE
Add label to API version select form control on Docs page

### DIFF
--- a/src/pages/docs.tsx
+++ b/src/pages/docs.tsx
@@ -575,7 +575,15 @@ export default function APIDocsPage(): JSX.Element {
           <nav className="api-nav">
             <ul className="api-nav__list">
               <li className="api-nav__list-item">
+                {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+                <label
+                  className="visually-hidden"
+                  htmlFor="api-nav__version__select-id"
+                >
+                  Select API version
+                </label>
                 <select
+                  id="api-nav__version__select-id"
                   className="api-nav__version"
                   onChange={(e): void => {
                     setPage(null);

--- a/src/pages/docs.tsx
+++ b/src/pages/docs.tsx
@@ -577,7 +577,7 @@ export default function APIDocsPage(): JSX.Element {
               <li className="api-nav__list-item">
                 {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
                 <label
-                  className="visually-hidden"
+                  className="sr-only"
                   htmlFor="api-nav__version__select-id"
                 >
                   Select API version

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -441,13 +441,3 @@ details {
     }
   }
 }
-
-.visually-hidden {
-  clip: rect(0 0 0 0);
-  clip-path: inset(50%);
-  height: 1px;
-  overflow: hidden;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -441,3 +441,13 @@ details {
     }
   }
 }
+
+.visually-hidden {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description

The [Docs page](https://nodejs.dev/docs/) has an API version `<select>` form control that is missing a corresponding `<label>`, so it is missing important context about what the form control does and means.

<img width="574" alt="Screenshot of the API version form control without any associated label." src="https://user-images.githubusercontent.com/9057921/89965516-abea4300-dc12-11ea-8c2c-3a45dac44de4.png">


I suggest adding a `<label>` following [WCAG 2.0 guidance on form controls](https://www.w3.org/TR/WCAG20-TECHS/H44).

To make this happen, I made two other related changes:

 **Visually hide the `<label>` with new `.visually-hidden` utility class.**
  - [The A11yProject has tips for hiding content so it's still detectable by a screen reader](https://www.a11yproject.com/posts/2013-01-11-how-to-hide-content/). The PR adds a `.visually-hidden` utility class that keeps the `<label>` in the DOM .
  - Generally I think it's ideal to show form control `<label>`s (not hide visually hide them), but that depends if you want to keep the page design/layout as-is or not. Just let me know what you prefer! 👍 

**Disabled [`jsx-a11y/label-has-associated-control` rule](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-associated-control.md)** for the `<label>`.
  - The `jsx-a11y/label-has-associated-control` rule asserts that a `<label>` should use `htmlFor` connected to a form control id *and* that the form control should be nested in the `<label>`. This PR uses `htmlFor` & doesn't nest since the `<label>` is being visually hidden. 
  - If you decide that you prefer to show the `<label>`, this will be changed to remove the comment & also nest the form control inside the `<label>`. 👍 



Let me know what you think or if you have questions/concerns. Thank you! 💖 