### PR TITLE
chore: GH Action to clean closed/merged previews

### DIFF
--- a/.github/workflows/cleanup-staging.yml
+++ b/.github/workflows/cleanup-staging.yml
@@ -1,0 +1,20 @@
+name: Cleanup staging deploy
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup GCloud
+        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
+
+      - name: Remove folder from GCS
+        run: gsutil rm gs://staging.nodejs.dev/${{ github.event.pull_request.number }}/**


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
When a PR is merged or closed this should cleanup the files from the Google Storage that hosts the staging site. 

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
Closes #636
<!--
  If you want to generate a preview of this PR on our staging server please
  make a comment on the Pull-Request with the text `/preview`
 -->

Looked at https://cloud.google.com/storage/docs/gsutil/commands/rm but wasn't sure if the `-m` and `-f` flags would be required for this or not