### PR TITLE
chore: Run PR cleanup in parallel with force

### DIFF
--- a/.github/workflows/cleanup-staging.yml
+++ b/.github/workflows/cleanup-staging.yml
@@ -19,4 +19,4 @@ jobs:
           export_default_credentials: true
 
       - name: Remove folder from GCS
-        run: gsutil rm gs://staging.nodejs.dev/${{ github.event.pull_request.number }}/**
+        run: gsutil -m rm -f gs://staging.nodejs.dev/${{ github.event.pull_request.number }}/**


### PR DESCRIPTION
Force to avoid failed build for non-previewed PRs

<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Should speedup the cleanup by running in parallel, and avoid false failures for PRs closed with no previews

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

<!--
  If you want to generate a preview of this PR on our staging server please
  make a comment on the Pull-Request with the text `/preview`
 -->