### PR TITLE
Fix docs link so it is not nested in a button

### DIFF
--- a/src/components/InstallTabs/InstallTabs.scss
+++ b/src/components/InstallTabs/InstallTabs.scss
@@ -92,21 +92,18 @@
         user-select: none;
       }
     }
-    &__docs-button {
+    &__docs-link {
+      box-sizing: border-box;
+      display: block;
       border-radius: var(--space-04);
       padding: var(--space-08) var(--space-16);
       position: absolute;
       bottom: 2rem;
       right: 2rem;
-    }
-    &__docs-button-text {
       text-decoration: none;
-      box-sizing: border-box;
-      width: 17rem;
-      height: 4rem;
-      color: var(--black5);
-      font-weight: var(--font-weight-semibold);
+
       &:hover {
+        text-decoration: none;
         color: var(--pink5);
       }
     }

--- a/src/components/InstallTabs/__tests__/__snapshots__/index.js.snap
+++ b/src/components/InstallTabs/__tests__/__snapshots__/index.js.snap
@@ -136,19 +136,14 @@ exports[`Tests for InstallTabs component renders correctly 1`] = `
       </pre>
       <br />
       <br />
-      <button
-        className="install__docs-button"
-        type="button"
+      <a
+        className="install__docs-link"
+        href="https://nodejs.org/en/download/package-manager/#nvm"
+        rel="noopener noreferrer"
+        target="_blank"
       >
-        <a
-          className="install__docs-button-text"
-          href="https://nodejs.org/en/download/package-manager/#nvm"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          Read documentation
-        </a>
-      </button>
+        Read documentation
+      </a>
     </div>
   </div>
   <div

--- a/src/components/InstallTabs/index.tsx
+++ b/src/components/InstallTabs/index.tsx
@@ -32,16 +32,14 @@ const InstallTabs = (): JSX.Element => {
           </ShellBox>
           <br />
           <br />
-          <button type="button" className="install__docs-button">
-            <a
-              className="install__docs-button-text"
-              href="https://nodejs.org/en/download/package-manager/#nvm"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Read documentation
-            </a>
-          </button>
+          <a
+            className="install__docs-link"
+            href="https://nodejs.org/en/download/package-manager/#nvm"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Read documentation
+          </a>
         </div>
       </TabPanel>
       <TabPanel>
@@ -53,16 +51,14 @@ const InstallTabs = (): JSX.Element => {
           </ShellBox>
           <br />
           <br />
-          <button type="button" className="install__docs-button">
-            <a
-              className="install__docs-button-text"
-              href="https://nodejs.org/en/download/package-manager/#windows"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Read documentation
-            </a>
-          </button>
+          <a
+            className="install__docs-link"
+            href="https://nodejs.org/en/download/package-manager/#windows"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Read documentation
+          </a>
         </div>
       </TabPanel>
       <TabPanel>
@@ -89,16 +85,14 @@ g++ libgcc linux-headers grep util-linux binutils findutils"
           <br />
           <br />
           {/* TODO when the new docs page is ready link to that page.  */}
-          <button type="button" className="install__docs-button">
-            <a
-              className="install__docs-button-text"
-              href="https://nodejs.org/en/download/package-manager/#nvm"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Read documentation
-            </a>
-          </button>
+          <a
+            className="install__docs-link"
+            href="https://nodejs.org/en/download/package-manager/#nvm"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Read documentation
+          </a>
         </div>
       </TabPanel>
     </Tabs>


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description

On the homepage, there is a "Read Documentation" link inside the `Shell` component that links out to a docs page. 

This link is currently nested inside of a `<button>`. Unfortunately that nesting is not valid, and when a user is tabbing through the page, their focus will hit the `<button>` and then the nested `<a>`. (So they must tab twice to get past this interactive element.)

This PR proposes removing the wrapping `<button>` element entirely and instead styling the `<a>`. I believe it makes sense to use a link instead of a button because it is sending users to a new page & has an `href`. [Here's a great article that I refer to when deciding between a button vs a link.](https://marcysutton.com/links-vs-buttons-in-modern-web-applications)

## Questions / Follow-up 🤔 

1. **Additional Styling?**
  Currently the "Read Documentation" link has some browser-default button styling, like a border/box-shadow. Do you want those styles applied to this link?

2. **Extra unused file?**
  While making this fix, I noticed there is a file with similar styles, but this file is not imported or used anywhere:  [src/styles/install-tabs.scss](https://github.com/nodejs/nodejs.dev/blob/master/src/styles/install-tabs.scss) **Should I go ahead and remove that file in this PR?**