### PR TITLE
Fix anchors nested in buttons in panel components on homepage

### DIFF
--- a/src/components/InstallTabs/InstallTabs.scss
+++ b/src/components/InstallTabs/InstallTabs.scss
@@ -92,21 +92,17 @@
         user-select: none;
       }
     }
-    &__docs-button {
-      border-radius: var(--space-04);
+    &__docs-link {
+      box-sizing: border-box;
+      display: block;
       padding: var(--space-08) var(--space-16);
       position: absolute;
       bottom: 2rem;
       right: 2rem;
-    }
-    &__docs-button-text {
       text-decoration: none;
-      box-sizing: border-box;
-      width: 17rem;
-      height: 4rem;
-      color: var(--black5);
-      font-weight: var(--font-weight-semibold);
+
       &:hover {
+        text-decoration: none;
         color: var(--pink5);
       }
     }

--- a/src/components/InstallTabs/LinuxPanel/index.tsx
+++ b/src/components/InstallTabs/LinuxPanel/index.tsx
@@ -27,16 +27,14 @@ g++ libgcc linux-headers grep util-linux binutils findutils"
       <br />
       <br />
       {/* TODO when the new docs page is ready link to that page.  */}
-      <button type="button" className="install__docs-button">
-        <a
-          className="install__docs-button-text"
-          href="https://nodejs.org/en/download/package-manager/#nvm"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Read documentation
-        </a>
-      </button>
+      <a
+        className="install__docs-link"
+        href="https://nodejs.org/en/download/package-manager/#nvm"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Read documentation
+      </a>
     </div>
   );
 };

--- a/src/components/InstallTabs/MacOSPanel/index.tsx
+++ b/src/components/InstallTabs/MacOSPanel/index.tsx
@@ -16,16 +16,14 @@ const MacOSPanel = (): JSX.Element => {
       </ShellBox>
       <br />
       <br />
-      <button type="button" className="install__docs-button">
-        <a
-          className="install__docs-button-text"
-          href="https://nodejs.org/en/download/package-manager/#nvm"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Read documentation
-        </a>
-      </button>
+      <a
+        className="install__docs-link"
+        href="https://nodejs.org/en/download/package-manager/#nvm"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Read documentation
+      </a>
     </div>
   );
 };

--- a/src/components/InstallTabs/WindowsPanel/index.tsx
+++ b/src/components/InstallTabs/WindowsPanel/index.tsx
@@ -11,16 +11,14 @@ const WindowsPanel = (): JSX.Element => {
       </ShellBox>
       <br />
       <br />
-      <button type="button" className="install__docs-button">
-        <a
-          className="install__docs-button-text"
-          href="https://nodejs.org/en/download/package-manager/#windows"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Read documentation
-        </a>
-      </button>
+      <a
+        className="install__docs-link"
+        href="https://nodejs.org/en/download/package-manager/#windows"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Read documentation
+      </a>
     </div>
   );
 };

--- a/src/components/InstallTabs/__tests__/__snapshots__/index.js.snap
+++ b/src/components/InstallTabs/__tests__/__snapshots__/index.js.snap
@@ -106,19 +106,14 @@ exports[`Tests for InstallTabs component renders correctly 1`] = `
       </pre>
       <br />
       <br />
-      <button
-        className="install__docs-button"
-        type="button"
+      <a
+        className="install__docs-link"
+        href="https://nodejs.org/en/download/package-manager/#windows"
+        rel="noopener noreferrer"
+        target="_blank"
       >
-        <a
-          className="install__docs-button-text"
-          href="https://nodejs.org/en/download/package-manager/#windows"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          Read documentation
-        </a>
-      </button>
+        Read documentation
+      </a>
     </div>
   </div>
   <div


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR fixes an accessibility and invalid markup issue where anchor elements are nested inside button elements in the "Panel" components on the homepage.

This PR proposes removing the wrapping `<button>` element entirely and instead styling the `<a>`. I believe it makes sense to use a link instead of a button because it is sending users to a new page & has an `href`. [Here's a great article that I refer to when deciding between a button vs a link.](https://marcysutton.com/links-vs-buttons-in-modern-web-applications)

Please let me know if you'd like any additional styling. Even though this element is now just an `<a>` instead of a `<button>`, the anchor can be styled to appear "button-like", including some of the browser-default styling that was present before. Just let me know what you prefer -- thank you! 

## Related Issues

Resolves #863 

<!--
  If you want to generate a preview of this PR on our staging server please
  make a comment on the Pull-Request with the text `/preview`
 -->