### PR TITLE
fix: figma link (again)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <br>
 </p>
 
-**You can find the latest [Figma design protype here](https://www.figma.com/proto/lOxAGGg5KXb6nwie7zXkz6/NJ---Design-System?node-id=3546%3A12092&viewport=-232%2C-1378%2C0.21998274326324463&scaling=min-zoom).**
+**You can find the latest [Figma design protype here](https://www.figma.com/file/lOxAGGg5KXb6nwie7zXkz6/NJ---Design-System?node-id=22%3A6086).**
 
 ## 🚀 Get Started
 


### PR DESCRIPTION
# Description

fixes the (still) broken figma link. the other PR that did this apparently didn't actually fix it.
