### PR TITLE
Add margin-right to nav tabs on mobile

### DIFF
--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -452,6 +452,10 @@ details {
     display: flex;
     margin-left: 0;
 
+    &:not(:last-child) {
+      margin-right: 0.5rem;
+    }
+
     > a {
       padding: var(--space-10);
     }


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Currently, the "active"/current nav item has the same green underline styling as the nav item `:hover` state. (Side note: personally I think these styles should be different.)

As shown in #887, at mobile breakpoints there is no spacing between navigation tabs in the header. So, depending on which page you are currently on, hovering over another nav item make it appear as if the "active" nav item's underline is connected to the underline for the nav item you are hovering over.

This PR adds `margin-right: 0.5rem` to nav items at the mobile breakpoint (excluding the `:last-child`). The reason I opted for `margin-right`, instead of `margin-left`, is because the nav items' container already has a `margin-left` applied, so going with `margin-right` is less disruptive to the layout. 👍 


Screenshots of before and after:

BEFORE | AFTER
--- | ---
<img width="494" alt="Screen Shot 2020-08-18 at 4 08 45 PM" src="https://user-images.githubusercontent.com/9057921/90565836-2237f980-e16d-11ea-9630-4323c044d5a3.png"> | <img width="490" alt="Screen Shot 2020-08-18 at 4 08 27 PM" src="https://user-images.githubusercontent.com/9057921/90565841-22d09000-e16d-11ea-8525-a57f9284bb77.png">

I'm happy to adjust the margin-right value. Also, I'm happy to make the "active" nav item and `:hover` states appear different -- just let me know what you'd prefer! I think it would be a helpful experience for users if those styles were unique, particular because hovering over an "active" nav item doesn't any distinguishing styles. Thank you!


## Related Issues

Resolves #887 