### PR TITLE
Updated node-history index.md

### DIFF
--- a/src/documentation/0002-node-history/index.md
+++ b/src/documentation/0002-node-history/index.md
@@ -81,3 +81,16 @@ Node.js happened to be built in the right place and right time, but luck isn't t
 
 * Node.js 10
 * [ES modules](https://nodejs.org/api/esm.html) .mjs experimental support
+* Node.js 11
+
+## 2019
+
+* Node.js 12
+* Node.js 13
+
+## 2020
+
+* Node.js 14
+
+
+


### PR DESCRIPTION
Added Node.js releases for years 2019 and 2020

I was reading over the history of Node.js and found that 2019 and 2020 were not included so I decided to add them