### PR TITLE
Update hover border color for header nav items

### DIFF
--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -343,7 +343,7 @@ select {
 }
 
 .activeStyleTab:hover {
-  border-bottom: 4px solid green;
+  border-bottom: 4px solid var(--color-text-primary);
   margin-bottom: -4px;
 }
 


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Follow up to this conversation: https://github.com/nodejs/nodejs.dev/issues/887#issuecomment-675724363
And this: https://github.com/nodejs/nodejs.dev/pull/888#pullrequestreview-469897668

This PR updates the color of the primary nav border whenever you hover over a nav item. As discussed in https://github.com/nodejs/nodejs.dev/issues/887#issuecomment-675724363, currently the hover color and the "active" or current page color are the same.

Ideally hover states should have a border of some kind, rather than just relying on color alone (source: [WCAG 2.0 - 1.4.1 Use of Color](https://www.w3.org/TR/WCAG20/#visual-audio-contrast-without-color). So considering that, I didn't want to just remove the border for hover states. Instead, I have opted to keep the hover border & update the color:

**NOTE:** In both screenshots below, "Learn" is the current page and "Documentation" has `hover` state.

light theme | dark theme
--- | ---
<img width="381" alt="light theme demo" src="https://user-images.githubusercontent.com/9057921/91389769-d20d0700-e7fe-11ea-8cba-4f2d6b734bd1.png"> | <img width="380" alt="Dark theme demo" src="https://user-images.githubusercontent.com/9057921/91389778-d2a59d80-e7fe-11ea-8cf8-c9e5e8517b57.png">
<img width="626" alt="Light theme 12.7:1 foreground-to-background contrast ratio" src="https://user-images.githubusercontent.com/9057921/91389785-d2a59d80-e7fe-11ea-826d-8c4b77935ba5.png"><br/> [Link to light theme color contrast test.](https://webaim.org/resources/contrastchecker/?fcolor=2C3437&bcolor=FFFFFF) | <img width="633" alt="Dark theme 12.98:1 foreground-to-background contrast ratio" src="https://user-images.githubusercontent.com/9057921/91389794-d33e3400-e7fe-11ea-99e7-013388541df3.png"><br/>[Link to dark theme color contrast test.](https://webaim.org/resources/contrastchecker/?fcolor=CBD4D9&bcolor=090C15)


Both themes are using the `--color-text-primary` variable, which has a WCAG AAA contrast ratio between foreground (border color) and background color. 🎉 