### PR TITLE
style: Install Tabs text changes

### DIFF
--- a/src/components/InstallTabs/__tests__/__snapshots__/index.js.snap
+++ b/src/components/InstallTabs/__tests__/__snapshots__/index.js.snap
@@ -42,7 +42,7 @@ exports[`Tests for InstallTabs component renders correctly 1`] = `
       role="tab"
       tabIndex="0"
     >
-      Chocolatey (Windows)
+      Windows (Chocolatey)
     </li>
     <li
       aria-controls="react-tabs-3"
@@ -53,7 +53,7 @@ exports[`Tests for InstallTabs component renders correctly 1`] = `
       role="tab"
       tabIndex={null}
     >
-      nvm (macOS)
+      macOS (nvm)
     </li>
     <li
       aria-controls="react-tabs-5"
@@ -64,7 +64,7 @@ exports[`Tests for InstallTabs component renders correctly 1`] = `
       role="tab"
       tabIndex={null}
     >
-      nvm (Linux)
+      Linux (nvm)
     </li>
   </ul>
   <div

--- a/src/components/InstallTabs/index.tsx
+++ b/src/components/InstallTabs/index.tsx
@@ -10,11 +10,17 @@ import LinuxPanel from './LinuxPanel';
 const InstallTabs = (): JSX.Element => {
   const userOS = detectOS();
 
-  const systems = {
-    WIN: ['Chocolatey (Windows)', 'nvm (macOS)', 'nvm (Linux)'],
-    MAC: ['nvm (macOS)', 'Chocolatey (Windows)', 'nvm (Linux)'],
-    LINUX: ['nvm (Linux)', 'nvm (macOS)', 'Chocolatey (Windows)'],
-    UNKNOWN: ['Chocolatey (Windows)', 'nvm (macOS)', 'nvm (Linux)'],
+  const os = {
+    win: 'Windows (Chocolatey)',
+    mac: 'macOS (nvm)',
+    linux: 'Linux (nvm)',
+  };
+
+  const installTabSystems = {
+    WIN: [os.win, os.mac, os.linux],
+    MAC: [os.mac, os.win, os.linux],
+    LINUX: [os.linux, os.mac, os.win],
+    UNKNOWN: [os.win, os.mac, os.linux],
   };
 
   function panelSwitch(): JSX.Element {
@@ -64,7 +70,7 @@ const InstallTabs = (): JSX.Element => {
     }
   }
 
-  return systems[userOS] !== undefined ? (
+  return installTabSystems[userOS] !== undefined ? (
     <Tabs>
       <div className="install__header">
         <div className="install__header-circles">
@@ -75,7 +81,7 @@ const InstallTabs = (): JSX.Element => {
         <div className="install__header-text">bash</div>
       </div>
       <TabList>
-        {systems[userOS].map((system: string) => (
+        {installTabSystems[userOS].map((system: string) => (
           <Tab key={system.toString()}>{system}</Tab>
         ))}
       </TabList>

--- a/src/components/InstallTabs/index.tsx
+++ b/src/components/InstallTabs/index.tsx
@@ -78,7 +78,9 @@ const InstallTabs = (): JSX.Element => {
           <div className="install__header-grey-circle" />
           <div className="install__header-grey-circle" />
         </div>
-        <div className="install__header-text">bash</div>
+        <div className="install__header-text">
+          {userOS === 'MAC' ? 'zsh' : 'bash'}
+        </div>
       </div>
       <TabList>
         {installTabSystems[userOS].map((system: string) => (


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Changed it so that the operating system of the user is displayed before the package manager 

i.e: nvm (macOS) => macOS (nvm)

Also show zsh instead of bash as the default shell header if the user is using macOS, since as of Catalina zsh has replaced bash as macOS's default terminal shell.