### PR TITLE
fix(article): Throttle updating of history state under IntersectionOb…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6110,6 +6110,12 @@
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.6.tgz",
       "integrity": "sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA=="
     },
+    "@types/throttle-debounce": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/throttle-debounce/-/throttle-debounce-2.1.0.tgz",
+      "integrity": "sha512-5eQEtSCoESnh2FsiLTxE121IiE60hnMqcb435fShf4bpLRjEu1Eoekht23y6zXS9Ts3l+Szu3TARnTsA0GkOkQ==",
+      "dev": true
+    },
     "@types/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.0.33.tgz",
@@ -29682,9 +29688,9 @@
       "dev": true
     },
     "throttle-debounce": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-2.2.1.tgz",
-      "integrity": "sha512-i9hAVld1f+woAiyNGqWelpDD5W1tpMroL3NofTz9xzwq6acWBlO2dC8k5EFSZepU6oOINtV5Q3aSPoRg7o4+fA=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-2.3.0.tgz",
+      "integrity": "sha512-H7oLPV0P7+jgvrk+6mwwwBDmxTaxnu9HMXmloNLXwnNO0ZxZ31Orah2n8lU1eMPvsaowP2CX+USCgyovXfdOFQ=="
     },
     "through": {
       "version": "2.3.8",

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "@storybook/addons": "^5.3.19",
     "@storybook/react": "^5.3.19",
     "@types/react-tabs": "2.3.1",
-    "dompurify": "2.0.12",
     "babel-preset-react-app": "^9.1.2",
     "color": "^3.1.2",
     "color-string": "^1.5.3",
+    "dompurify": "2.0.12",
     "dotenv": "^8.2.0",
     "emotion": "^10.0.27",
     "emotion-server": "^10.0.27",
@@ -44,6 +44,7 @@
     "react-emotion": "^10.0.0",
     "react-helmet": "^6.0.0",
     "react-tabs": "3.1.0",
+    "throttle-debounce": "^2.3.0",
     "typescript": "3.9.2"
   },
   "keywords": [
@@ -75,9 +76,11 @@
     "@types/jest": "^25.2.1",
     "@types/react-helmet": "6.0.0",
     "@types/react-test-renderer": "^16.9.2",
+    "@types/throttle-debounce": "^2.1.0",
     "@typescript-eslint/eslint-plugin": "2.33.0",
     "@typescript-eslint/parser": "^2.28.0",
     "babel-jest": "26.0.1",
+    "babel-loader": "^8.1.0",
     "babel-preset-gatsby": "0.4.2",
     "codecov": "^3.7.1",
     "eslint": "7.0.0",
@@ -96,8 +99,7 @@
     "react-test-renderer": "^16.13.1",
     "remark-cli": "^8.0.0",
     "remark-frontmatter": "^2.0.0",
-    "remark-preset-lint-node": "^1.13.0",
-    "babel-loader": "^8.1.0"
+    "remark-preset-lint-node": "^1.13.0"
   },
   "repository": {
     "type": "git",

--- a/src/components/Article/index.tsx
+++ b/src/components/Article/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { throttle } from 'throttle-debounce';
 import { PaginationInfo } from '../../types';
 import AuthorsList from '../../containers/AuthorList';
 import EditLink from '../EditLink';
@@ -44,8 +45,9 @@ const Article = ({
     }
 
     if (element.current) {
-      observer = new IntersectionObserver(
-        (entries): void => {
+      const handleObserverThrottled = throttle(
+        300,
+        (entries: IntersectionObserverEntry[]) => {
           entries.forEach((entry): void => {
             // element is already hidden by the nav
             if (entry.boundingClientRect.y < NAV_HEIGHT) {
@@ -69,6 +71,12 @@ const Article = ({
               );
             }
           });
+        }
+      );
+
+      observer = new IntersectionObserver(
+        (entries): void => {
+          handleObserverThrottled(entries);
         },
         {
           threshold: [0.25, 0.5, 0.75],


### PR DESCRIPTION
## Description

This PR adds throttling to `window.history.replaceState()` calls during scrolling in Article component.
Throttle functionality provided by [throttle-debounce](https://github.com/niksy/throttle-debounce#readme) package.

## Related Issues

Fixes #917 