### PR TITLE
docs: Changed "Node.js start the timer" to "starts"

### DIFF
--- a/src/documentation/0029-node-event-loop/index.md
+++ b/src/documentation/0029-node-event-loop/index.md
@@ -141,7 +141,7 @@ Why is this happening?
 
 ## The Message Queue
 
-When setTimeout() is called, the Browser or Node.js start the timer. Once the timer expires, in this case immediately as we put 0 as the timeout, the callback function is put in the **Message Queue**.
+When setTimeout() is called, the Browser or Node.js starts the timer. Once the timer expires, in this case immediately as we put 0 as the timeout, the callback function is put in the **Message Queue**.
 
 The Message Queue is also where user-initiated events like click or keyboard events, or fetch responses are queued before your code has the opportunity to react to them. Or also DOM events like `onLoad`.
 


### PR DESCRIPTION
A small grammatical correction to an otherwise perfect explanation

<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description

In the learn page, under Message Queue in the Node.js Event loop section, it says "When setTimeout() is called, the Browser or Node.js **start** the timer". It has been changed to **starts** to make it grammatically correct.


<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

<!--
  If you want to generate a preview of this PR on our staging server please
  make a comment on the Pull-Request with the text `/preview`
 -->