### PR TITLE
Added prefers-reduced-motion media query for accessibility

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -63,9 +63,21 @@ export default function Index({
           <div className="node-demo">
             <InstallTabs />
           </div>
-          <img className="leafs-front" src={leafsIllustrationFront} alt="" />
-          <img className="leafs-middle" src={leafsIllustrationMiddle} alt="" />
-          <img className="leafs-back" src={leafsIllustrationBack} alt="" />
+          <img
+            className="leafs-front animations"
+            src={leafsIllustrationFront}
+            alt=""
+          />
+          <img
+            className="leafs-middle animations"
+            src={leafsIllustrationMiddle}
+            alt=""
+          />
+          <img
+            className="leafs-back animations"
+            src={leafsIllustrationBack}
+            alt=""
+          />
           <img className="dots" src={dotsIllustration} alt="" />
         </section>
 

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -60,10 +60,8 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .leafs-front,
-  .leafs-middle,
-  .leafs-back {
-    animation-name: dissolve;
+  .animations {
+    animation-name: none;
   }
 }
 

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -59,6 +59,12 @@
   animation: leafs-animation 18s infinite alternate ease-in-out;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .leafs-front, .leafs-middle, .leafs-back {
+    animation-name: dissolve;
+  }
+}
+
 .dots {
   position: absolute;
   top: 180px;

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -60,7 +60,9 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .leafs-front, .leafs-middle, .leafs-back {
+  .leafs-front,
+  .leafs-middle,
+  .leafs-back {
     animation-name: dissolve;
   }
 }


### PR DESCRIPTION

## Description

Adds `prefers-reduced-motion` media query for the leaves animation to help with accessibility. Tested on Firefox and Google Chrome after disabling Settings > Ease of Access Display Settings > **Show animations on Windows**. 

## Related Issues

Addresses #964 