### PR TITLE
Changed font color for Downloads header and tabs , Resolves #971

### DIFF
--- a/src/components/DownloadHeader/DownloadHeader.scss
+++ b/src/components/DownloadHeader/DownloadHeader.scss
@@ -15,7 +15,7 @@
 
 .download-page__navigation--title {
   text-transform: capitalize;
-  color: var(--black9);
+  color: var(--color-text-primary);
   font-size: var(--font-size-display3);
   line-height: var(--line-height-display3);
 }

--- a/src/components/InstallTabs/InstallTabs.scss
+++ b/src/components/InstallTabs/InstallTabs.scss
@@ -13,6 +13,7 @@
     border: 1px solid transparent;
     border-bottom: none;
     bottom: -1px;
+    color:var(--black4);
     position: relative;
     list-style: none;
     padding: 10px 12px;

--- a/src/components/InstallTabs/InstallTabs.scss
+++ b/src/components/InstallTabs/InstallTabs.scss
@@ -13,7 +13,7 @@
     border: 1px solid transparent;
     border-bottom: none;
     bottom: -1px;
-    color:var(--black4);
+    color: var(--black4);
     position: relative;
     list-style: none;
     padding: 10px 12px;


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR changes the font color of Downloads header in Dark mode and the fonts in inactive tabs in light mode.

## Related Issues
Addresses #971 

<!--
  If you want to generate a preview of this PR on our staging server please
  make a comment on the Pull-Request with the text `/preview`
 -->