### PR TITLE
Makes the footer stick to the bottom of the viewport

### DIFF
--- a/src/components/Footer/footer.scss
+++ b/src/components/Footer/footer.scss
@@ -3,6 +3,7 @@
   justify-content: space-between;
   flex-wrap: wrap;
   margin: 0;
+  margin-top: auto;
 
   .footer__left {
     display: flex;

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -32,9 +32,9 @@ const Layout = ({
     <>
       <SEO title={title} description={description} img={img} />
       <div id="layout-container">
-          <Header darkModeController={darkModeController} />
-          {children}
-          {showFooter && <Footer />}
+        <Header darkModeController={darkModeController} />
+        {children}
+        {showFooter && <Footer />}
       </div>
     </>
   );

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -31,7 +31,7 @@ const Layout = ({
   return (
     <>
       <SEO title={title} description={description} img={img} />
-      <div id="layout-container">
+      <div className="layout-container">
         <Header darkModeController={darkModeController} />
         {children}
         {showFooter && <Footer />}

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -31,9 +31,11 @@ const Layout = ({
   return (
     <>
       <SEO title={title} description={description} img={img} />
-      <Header darkModeController={darkModeController} />
-      {children}
-      {showFooter && <Footer />}
+      <div id="layout-container">
+          <Header darkModeController={darkModeController} />
+          {children}
+          {showFooter && <Footer />}
+      </div>
     </>
   );
 };

--- a/src/pages/docs.tsx
+++ b/src/pages/docs.tsx
@@ -624,8 +624,8 @@ export default function APIDocsPage(): JSX.Element {
 
   return (
     <>
-      <main className="grid-container">
-        <Layout title={title} description={description} showFooter={false}>
+      <Layout title={title} description={description} showFooter={false}>
+        <main className="grid-container">
           <nav aria-label="Secondary" className="api-nav">
             <ul className="api-nav__list">
               <li className="api-nav__list-item">
@@ -661,8 +661,8 @@ export default function APIDocsPage(): JSX.Element {
             </ul>
           </nav>
           {renderArticle(page, userOS, currentVersionSelected || '')}
-        </Layout>
-      </main>
+        </main>
+      </Layout>
       <Footer />
     </>
   );

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -500,7 +500,7 @@ details {
   }
 }
 
-#layout-container {
+.layout-container {
   display: flex;
   flex-direction: column;
   min-height: 100vh;

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -1,6 +1,7 @@
 html {
   margin: 0;
   box-sizing: border-box;
+  height: 100%;
 }
 
 body {
@@ -8,8 +9,9 @@ body {
   color: var(--color-text-primary);
   font-size: 1.6rem;
   font-family: var(--base-type-face);
-  margin: var(--nav-height) 0 0;
+  margin: 0 0;
   overflow-x: hidden;
+  height: 100%;
 
   /* Set in JavaScript */
   --banner-clip: polygon(0 0, 100% 0, 100% calc(100% - 72px), 0 100%);
@@ -254,7 +256,7 @@ select {
   background: var(--color-fill-app);
   border-bottom: var(--space-01) solid var(--black2);
   width: 100%;
-  position: fixed;
+  position: sticky;
   top: 0;
   z-index: 999;
 }
@@ -496,4 +498,10 @@ details {
   .right-container .nav__tabs > a:last-child {
     padding-right: 0;
   }
+}
+
+#layout-container {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
 }


### PR DESCRIPTION
## Description

This PR makes the footer stick to the bottom of the viewport when the content is less than the viewport height. When the content is greater than the viewport height, the footer will be right below the content.

## Related Issues

Addresses #972

## Manual test cases

- Large main content (`/download`)
- Small main content (`/404`)
- `Header` is always at the top of the viewport with/without scrolling
- `/docs`