### PR TITLE
Styling for 404 page

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -8,7 +8,6 @@ import { useMediaQuery } from '../../hooks/useMediaQuery';
 interface Props {
   darkModeController?: typeof defaultDarkModeController;
 }
-var isCurrentUrl= window.location.href
 
 const Header = ({
   darkModeController = defaultDarkModeController,
@@ -55,18 +54,22 @@ const Header = ({
                 {isMobile ? 'Docs' : 'Documentation'}
               </a>
             </li>
-          
-            <li className="nav__tabs">
-              <a
-                href="https://nodejs.org/en/download/"
-                className="activeStyleTab"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-              {isCurrentUrl =="https://nodejs.dev/404/" ?'':<div>Download</div>}
-               
-              </a>
-            </li>
+            {window.location.pathname === '/404/' ? (
+              ''
+            ) : (
+              <div>
+                <li className="nav__tabs">
+                  <a
+                    href="https://nodejs.org/en/download/"
+                    className="activeStyleTab"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Download
+                  </a>
+                </li>
+              </div>
+            )}
           </ul>
         </div>
 

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -8,11 +8,13 @@ import { useMediaQuery } from '../../hooks/useMediaQuery';
 interface Props {
   darkModeController?: typeof defaultDarkModeController;
 }
+var isCurrentUrl= window.location.href
 
 const Header = ({
   darkModeController = defaultDarkModeController,
 }: Props): JSX.Element => {
   const isMobile = useMediaQuery('(max-width: 870px)');
+
   return (
     <nav aria-label="Primary" className="nav">
       <div className="nav__container">
@@ -53,6 +55,7 @@ const Header = ({
                 {isMobile ? 'Docs' : 'Documentation'}
               </a>
             </li>
+          
             <li className="nav__tabs">
               <a
                 href="https://nodejs.org/en/download/"
@@ -60,7 +63,8 @@ const Header = ({
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                Download
+              {isCurrentUrl =="https://nodejs.dev/404/" ?'':<div>Download</div>}
+               
               </a>
             </li>
           </ul>

--- a/src/components/Hero/Hero.scss
+++ b/src/components/Hero/Hero.scss
@@ -29,6 +29,7 @@
   align-items: flex-start;
   flex-wrap: wrap;
   justify-content: center;
+  text-transform: none;
 }
 
 .download-lts-container {

--- a/src/components/Hero/index.tsx
+++ b/src/components/Hero/index.tsx
@@ -34,8 +34,8 @@ const Hero = ({ title, subTitle }: Props): JSX.Element => {
     <div className="home-page-hero">
       <h1>{title}</h1>
       <h2 className="sub-title t-subheading">{subTitle}</h2>
-      <div className="btn-ctas">
-        <div className="download-lts-container">
+      <div className="btn-ctas" style={{textTransform:'none'}} >
+        <div className="download-lts-container" >
           <a className="circular-container" href={ltsVersionUrl}>
             Download Node (LTS)
           </a>

--- a/src/components/Hero/index.tsx
+++ b/src/components/Hero/index.tsx
@@ -34,8 +34,8 @@ const Hero = ({ title, subTitle }: Props): JSX.Element => {
     <div className="home-page-hero">
       <h1>{title}</h1>
       <h2 className="sub-title t-subheading">{subTitle}</h2>
-      <div className="btn-ctas" style={{textTransform:'none'}} >
-        <div className="download-lts-container" >
+      <div className="btn-ctas">
+        <div className="download-lts-container">
           <a className="circular-container" href={ltsVersionUrl}>
             Download Node (LTS)
           </a>

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,20 +1,19 @@
 import React from 'react';
 import Hero from '../components/Hero';
 import Layout from '../components/Layout';
+import '../styles/404.scss';
 
 export default function NotFoundPage(): JSX.Element {
   const title = 'page not found';
   const description = 'You have hit a route that does not exist.';
 
   return (
+    <Layout title={title} description={description}>
+      <div className="uppercase">
+        <Hero title={title} />
+      </div>
 
-    <Layout title={title} description={description} >
-
-      <div style={{textTransform:'uppercase'}} >
-      <Hero title={title} />
-      </div> 
-      
-      <main style={{ width:'60%', textAlign :'center', margin:'auto'}} className="article-reader"  >
+      <main className="article-reader">
         <p>
           The page you&apos;re trying to access does not exist. Go back to the
           Homepage or find what you&apos;re looking for in the menu.
@@ -23,7 +22,6 @@ export default function NotFoundPage(): JSX.Element {
           Take me back to the <a href="/"> Homepage</a>
         </p>
       </main>
-     
-      </Layout>
+    </Layout>
   );
 }

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -3,22 +3,27 @@ import Hero from '../components/Hero';
 import Layout from '../components/Layout';
 
 export default function NotFoundPage(): JSX.Element {
-  const title = 'PAGE NOT FOUND';
+  const title = 'page not found';
   const description = 'You have hit a route that does not exist.';
 
   return (
-    <Layout title={title} description={description}>
+
+    <Layout title={title} description={description} >
+
+      <div style={{textTransform:'uppercase'}} >
       <Hero title={title} />
-      <main style={{ width: '100%' }} className="article-reader">
+      </div> 
+      
+      <main style={{ width:'60%', textAlign :'center', margin:'auto'}} className="article-reader"  >
         <p>
           The page you&apos;re trying to access does not exist. Go back to the
           Homepage or find what you&apos;re looking for in the menu.
         </p>
         <p>
-          Take me back to the
-          <a href="/">Homepage</a>
+          Take me back to the <a href="/"> Homepage</a>
         </p>
       </main>
-    </Layout>
+     
+      </Layout>
   );
 }

--- a/src/styles/404.scss
+++ b/src/styles/404.scss
@@ -1,0 +1,9 @@
+.article-reader {
+  width: 60%;
+  text-align: center;
+  margin: auto;
+}
+
+.uppercase {
+  text-transform: uppercase;
+}


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
This PR makes the content of the 404-page center, remove the download section from it and add a blank space before Homepage. The text PAGE NOT FOUND is capitalized using CSS.
## Related Issues

Addresses #969

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

<!--
  If you want to generate a preview of this PR on our staging server please
  make a comment on the Pull-Request with the text `/preview`
 -->