### PR TITLE
Fix: Learn Page Layout

### DIFF
--- a/src/templates/learn.tsx
+++ b/src/templates/learn.tsx
@@ -34,8 +34,8 @@ const LearnLayout = ({
 
   return (
     <>
-      <main className="grid-container">
-        <Layout title={title} description={description} showFooter={false}>
+      <Layout title={title} description={description} showFooter={false}>
+        <main className="grid-container">
           <Navigation
             currentSlug={slug}
             previousSlug={previousSlug}
@@ -51,8 +51,8 @@ const LearnLayout = ({
             previous={previous}
             relativePath={relativePath}
           />
-        </Layout>
-      </main>
+        </main>
+      </Layout>
       <Footer />
     </>
   );

--- a/test/templates/__snapshots__/learn.test.tsx.snap
+++ b/test/templates/__snapshots__/learn.test.tsx.snap
@@ -2,13 +2,13 @@
 
 exports[`Learn Template renders correctly 1`] = `
 <React.Fragment>
-  <main
-    className="grid-container"
+  <Layout
+    description="test-description"
+    showFooter={false}
+    title="test-title"
   >
-    <Layout
-      description="test-description"
-      showFooter={false}
-      title="test-title"
+    <main
+      className="grid-container"
     >
       <Navigation
         currentSlug="test-slug"
@@ -66,8 +66,8 @@ exports[`Learn Template renders correctly 1`] = `
         relativePath="test-path"
         title="test-title"
       />
-    </Layout>
-  </main>
+    </main>
+  </Layout>
   <Footer />
 </React.Fragment>
 `;


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Main content frame is empty and header doesn't fill up the parent width(100%) in the Learn Page because the main tag is nested outside the Layout. Done fixing it and made sure it doesn't break anything else (including the mobile view). 
## Related Issues
Addresses #982 & #983.
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

<!--
  If you want to generate a preview of this PR on our staging server please
  make a comment on the Pull-Request with the text `/preview`
 -->
![image](https://user-images.githubusercontent.com/22348410/95576615-53dd8a80-0a63-11eb-9f51-046a6a82bea8.png)
![image](https://user-images.githubusercontent.com/22348410/95576630-5b9d2f00-0a63-11eb-9cc5-1041ac346c10.png)
