### PR TITLE
fix: Image background in remark-images

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -99,6 +99,7 @@ module.exports = {
             resolve: 'gatsby-remark-images',
             options: {
               maxWidth: 590,
+              backgroundColor: 'transparent'
             },
           },
         ],

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -99,7 +99,7 @@ module.exports = {
             resolve: 'gatsby-remark-images',
             options: {
               maxWidth: 590,
-              backgroundColor: 'transparent'
+              backgroundColor: 'transparent',
             },
           },
         ],


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

The images in `/learn` has a white background even in the dark mode when ideally it should be transparent.

How it looks currently in Dark Mode:

![image](https://user-images.githubusercontent.com/54291836/95881659-6ffc6700-0d96-11eb-80d5-d58cea16aac1.png)

How it looks in the PR

![image](https://user-images.githubusercontent.com/54291836/95881704-7db1ec80-0d96-11eb-8d68-0f0f639aca70.png)

## Related Issues
None
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

<!--
  If you want to generate a preview of this PR on our staging server please
  make a comment on the Pull-Request with the text `/preview`
 -->