### PR TITLE
chore(styles): breadcrumb a11y compliant

### DIFF
--- a/src/components/DownloadHeader/DownloadHeader.scss
+++ b/src/components/DownloadHeader/DownloadHeader.scss
@@ -2,7 +2,7 @@
   display: flex;
   justify-content: space-between;
   text-transform: uppercase;
-  color: var(--black7);
+  color: var(--color-text-primary);
   font-size: var(--font-size-overline);
   line-height: var(--line-height-overline);
   letter-spacing: var(--space-02);

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -83,7 +83,7 @@ p {
   font-size: var(--font-size-overline);
   line-height: var(--line-height-overline);
   font-weight: var(--font-weight-normal);
-  color: var(--color-text-secondary);
+  color: var(--color-text-primary);
   text-transform: uppercase;
   letter-spacing: 0.1rem;
   margin: 0 0 var(--space-4) 0;

--- a/src/styles/tokens.scss
+++ b/src/styles/tokens.scss
@@ -106,7 +106,7 @@ body {
   --font-size-body2: 1.4rem;
   --font-size-body3: 1.3rem;
   --font-size-caption: 1.2rem;
-  --font-size-overline: 1rem;
+  --font-size-overline: 1.2rem;
   --font-size-code: 1.6rem;
   --line-height-display1: 7.2rem;
   --line-height-display2: 5.7rem;

--- a/src/styles/tokens.scss
+++ b/src/styles/tokens.scss
@@ -106,7 +106,7 @@ body {
   --font-size-body2: 1.4rem;
   --font-size-body3: 1.3rem;
   --font-size-caption: 1.2rem;
-  --font-size-overline: 1.2rem;
+  --font-size-overline: 1rem;
   --font-size-code: 1.6rem;
   --line-height-display1: 7.2rem;
   --line-height-display2: 5.7rem;


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description

I started the PR by changing the `font-size` to 1.2rem which would mantain the color structure of the page, but [the size must be 18pt+](https://snook.ca/technical/colour_contrast/colour.html#fg=6E7B83,bg=FFFFFF).

So, in order to be [fully compliant](https://snook.ca/technical/colour_contrast/colour.html#fg=2C3437,bg=FFFFFF), I changed the color to use the primary text one.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

fixes #995 

<!--
  If you want to generate a preview of this PR on our staging server please
  make a comment on the Pull-Request with the text `/preview`
 -->