### PR TITLE
fix(releases-page): download selection a11y

### DIFF
--- a/src/components/DownloadCards/__tests__/__snapshots__/download-cards.test.tsx.snap
+++ b/src/components/DownloadCards/__tests__/__snapshots__/download-cards.test.tsx.snap
@@ -3,6 +3,9 @@
 exports[`DownloadCards component renders correctly 1`] = `
 <ul
   className="download-card__row"
+  onKeyDown={[Function]}
+  role="tablist"
+  tabIndex={0}
 >
   <li
     className="download-card--inactive"

--- a/src/components/DownloadCards/index.tsx
+++ b/src/components/DownloadCards/index.tsx
@@ -50,7 +50,26 @@ export default function DownloadCards({ line, userOS }: Props): JSX.Element {
   ];
 
   return (
-    <ul className="download-card__row">
+    <ul
+      className="download-card__row"
+      role="tablist"
+      tabIndex={0}
+      onKeyDown={(e: React.KeyboardEvent): void => {
+        let key = null;
+        if (e.which === 37) key = 'left';
+        if (e.which === 39) key = 'right';
+        if (!key) return;
+
+        const currentIndex = downloadTypes.findIndex(d => d.name === selected);
+        let nextIndex = currentIndex;
+        nextIndex += key === 'left' ? -1 : 1;
+        if (nextIndex < 0) nextIndex = downloadTypes.length - 1;
+        if (nextIndex >= downloadTypes.length) nextIndex = 0;
+
+        const nextItem = downloadTypes[nextIndex].name;
+        setSelected(nextItem);
+      }}
+    >
       {downloadTypes.map(
         (os): JSX.Element => (
           <li

--- a/src/components/DownloadCards/index.tsx
+++ b/src/components/DownloadCards/index.tsx
@@ -55,16 +55,24 @@ export default function DownloadCards({ line, userOS }: Props): JSX.Element {
       role="tablist"
       tabIndex={0}
       onKeyDown={(e: React.KeyboardEvent): void => {
-        let key = null;
-        if (e.which === 37) key = 'left';
-        if (e.which === 39) key = 'right';
-        if (!key) return;
-
         const currentIndex = downloadTypes.findIndex(d => d.name === selected);
+
+        let direction = null;
+        if (e.key === 'ArrowLeft') {
+          direction = 'left';
+        }
+        if (e.key === 'ArrowRight') {
+          direction = 'right';
+        }
+        if (!direction) return;
+
         let nextIndex = currentIndex;
-        nextIndex += key === 'left' ? -1 : 1;
-        if (nextIndex < 0) nextIndex = downloadTypes.length - 1;
-        if (nextIndex >= downloadTypes.length) nextIndex = 0;
+        nextIndex += direction === 'left' ? -1 : 1;
+        if (nextIndex < 0) {
+          nextIndex = downloadTypes.length - 1;
+        } else if (nextIndex >= downloadTypes.length) {
+          nextIndex = 0;
+        }
 
         const nextItem = downloadTypes[nextIndex].name;
         setSelected(nextItem);

--- a/src/components/DownloadToggle/DownloadToggle.scss
+++ b/src/components/DownloadToggle/DownloadToggle.scss
@@ -11,6 +11,13 @@
   justify-content: center;
 }
 
+.download-toogle__switch {
+  width: 236px;
+  height: 42px;
+  border: none;
+  padding: 0;
+}
+
 .download-toogle__button {
   background: var(--black2);
   box-shadow: inset 1px -1px 1px rgba(0, 0, 0, 0.08),
@@ -23,6 +30,11 @@
   font-size: var(--font-size-body2);
   line-height: var(--line-height-body2);
   color: var(--black7);
+  padding: 1px 6px;
+  line-height: 40px;
+  box-sizing: border-box;
+  display: inline-block;
+  position: relative;
 }
 
 .download-toogle__button.-active,

--- a/src/components/DownloadToggle/__tests__/__snapshots__/download-toggle.test.tsx.snap
+++ b/src/components/DownloadToggle/__tests__/__snapshots__/download-toggle.test.tsx.snap
@@ -9,16 +9,22 @@ exports[`DownloadToggle component renders correctly 1`] = `
       class="download-toogle__selector"
     >
       <button
-        class="download-toogle__button -active"
+        aria-checked="true"
+        aria-label="Show LTS versions"
+        class="download-toogle__switch"
+        role="switch"
         type="button"
       >
-        LTS
-      </button>
-      <button
-        class="download-toogle__button -current"
-        type="button"
-      >
-        Current
+        <span
+          class="download-toogle__button -active"
+        >
+          LTS
+        </span>
+        <span
+          class="download-toogle__button -current"
+        >
+          Current
+        </span>
       </button>
     </div>
     <p

--- a/src/components/DownloadToggle/index.tsx
+++ b/src/components/DownloadToggle/index.tsx
@@ -15,26 +15,33 @@ export default function DownloadToggle({
     <div className="download-toogle">
       <div className="download-toogle__selector">
         <button
+          className="download-toogle__switch"
           type="button"
-          className={
-            selected === 'LTS'
-              ? 'download-toogle__button -active'
-              : 'download-toogle__button'
+          role="switch"
+          aria-label="Show LTS versions"
+          aria-checked={selected === 'LTS'}
+          onClick={(): void =>
+            handleClick(selected === 'CURRENT' ? 'LTS' : 'CURRENT')
           }
-          onClick={(): void => handleClick('LTS')}
         >
-          LTS
-        </button>
-        <button
-          type="button"
-          className={
-            selected === 'CURRENT'
-              ? 'download-toogle__button -current -active'
-              : 'download-toogle__button -current'
-          }
-          onClick={(): void => handleClick('CURRENT')}
-        >
-          Current
+          <span
+            className={
+              selected === 'LTS'
+                ? 'download-toogle__button -active'
+                : 'download-toogle__button'
+            }
+          >
+            LTS
+          </span>
+          <span
+            className={
+              selected === 'CURRENT'
+                ? 'download-toogle__button -current -active'
+                : 'download-toogle__button -current'
+            }
+          >
+            Current
+          </span>
         </button>
       </div>
       <p className="download-toogle__description">


### PR DESCRIPTION
## Description

Improves a11y on downloads page by:

- Replacing two-button LTS/Current with aria-check implementing toggle
- Adding keyboard navigation to select distro

## Related Issues

Resolves #996