### PR TITLE
fix(InstallTabs): docs button to WCAG2 AA contrast

### DIFF
--- a/src/components/InstallTabs/InstallTabs.scss
+++ b/src/components/InstallTabs/InstallTabs.scss
@@ -96,7 +96,7 @@
     &__docs-button,
     &__docs-button:hover {
       border-radius: var(--space-04);
-      border: 1px solid var(--color-text-secondary);
+      border: 1px solid var(--black3);
       padding: var(--space-08) var(--space-16);
       position: absolute;
       bottom: 2rem;
@@ -104,7 +104,7 @@
       text-decoration: none;
       box-sizing: border-box;
       height: 4rem;
-      color: var(--color-text-secondary);
+      color: var(--black3);
       font-weight: var(--font-weight-semibold);
     }
   }


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Improves colour contrast between tab background and 'read documentation' button to [WCAG 2 AA compliance](https://snook.ca/technical/colour_contrast/colour.html#fg=D9E1E4,bg=2C3437).

I used the background colour of the 'SHELL' block, so hopefully that will keep the theme intact.

## Related Issues

Resolves: #993