### PR TITLE
docs(docs): Added title to iframe for a11y

### DIFF
--- a/src/documentation/0001-node-introduction/index.md
+++ b/src/documentation/0001-node-introduction/index.md
@@ -28,7 +28,7 @@ npm with its simple structure helped the ecosystem of Node.js proliferate, and n
 The most common example Hello World of Node.js is a web server:
 
 <iframe
-  allow="geolocation; microphone; camera; midi; encrypted-media"
+  title="Hello world web server"
   src="https://glitch.com/embed/#!/embed/nodejs-dev-0001-01?path=server.js&previewSize=30&attributionHidden=true&sidebarCollapsed=true"
   alt="nodejs-dev-0001-01 on Glitch"
   style="height: 400px; width: 100%; border: 0;">

--- a/src/documentation/0013-node-output-to-cli/index.md
+++ b/src/documentation/0013-node-output-to-cli/index.md
@@ -55,7 +55,7 @@ console.log('%o', Number)
 Take this code:
 
 <iframe
-  allow="geolocation; microphone; camera; midi; encrypted-media"
+  title="Output to the command line using Node.js"
   src="https://glitch.com/embed/#!/embed/nodejs-dev-0013-02?path=server.js&previewSize=40&attributionHidden=true&sidebarCollapsed=true"
   alt="nodejs-dev-0013-02 on Glitch"
   style="height: 400px; width: 100%; border: 0;">

--- a/src/documentation/0029-node-event-loop/index.md
+++ b/src/documentation/0029-node-event-loop/index.md
@@ -46,7 +46,7 @@ You know the error stack trace you might be familiar with, in the debugger or in
 Let's pick an example:
 
 <iframe
-  allow="geolocation; microphone; camera; midi; encrypted-media"
+  title="A simple event loop explanation"
   src="https://glitch.com/embed/#!/embed/nodejs-dev-0029-01?path=server.js&previewSize=20&attributionHidden=true&sidebarCollapsed=true"
   alt="nodejs-dev-0029-01 on Glitch"
   style="height: 400px; width: 100%; border: 0;">
@@ -99,7 +99,7 @@ The use case of `setTimeout(() => {}, 0)` is to call a function, but execute it 
 Take this example:
 
 <iframe
-  allow="geolocation; microphone; camera; midi; encrypted-media"
+  title="Queuing function execution"
   src="https://glitch.com/embed/#!/embed/nodejs-dev-0029-02?path=server.js&previewSize=20&attributionHidden=true&sidebarCollapsed=true"
   alt="nodejs-dev-0029-02 on Glitch"
   style="height: 400px; width: 100%; border: 0;">
@@ -160,7 +160,7 @@ I find nice the analogy of a rollercoaster ride at an amusement park: the messag
 Example:
 
 <iframe
-  allow="geolocation; microphone; camera; midi; encrypted-media"
+  title="ECMAScript 2015 Job Queue"
   src="https://glitch.com/embed/#!/embed/nodejs-dev-0029-03?path=server.js&previewSize=35&attributionHidden=true&sidebarCollapsed=true"
   alt="nodejs-dev-0029-03 on Glitch"
   style="height: 400px; width: 100%; border: 0;">

--- a/src/documentation/0034-javascript-promises/index.md
+++ b/src/documentation/0034-javascript-promises/index.md
@@ -8,7 +8,7 @@ section: Getting Started
 ## Introduction to promises
 
 <iframe
-  allow="geolocation; microphone; camera; midi; encrypted-media"
+  title="Introduction to promises"
   src="https://glitch.com/embed/#!/embed/nodejs-dev-0034-01?path=server.js&previewSize=35&attributionHidden=true&sidebarCollapsed=true"
   alt="nodejs-dev-0034-01 on Glitch"
   style="height: 400px; width: 100%; border: 0;">

--- a/src/documentation/0035-javascript-async-await/index.md
+++ b/src/documentation/0035-javascript-async-await/index.md
@@ -48,7 +48,7 @@ const doSomething = async () => {
 This is a simple example of async/await used to run a function asynchronously:
 
 <iframe
-  allow="geolocation; microphone; camera; midi; encrypted-media"
+  title="Modern Asynchronous JavaScript with Async and Await"
   src="https://glitch.com/embed/#!/embed/nodejs-dev-0035-01?path=server.js&previewSize=25&attributionHidden=true&sidebarCollapsed=true"
   alt="nodejs-dev-0035-01 on Glitch"
   style="height: 400px; width: 100%; border: 0;">
@@ -144,7 +144,7 @@ getFirstUserData()
 Async functions can be chained very easily, and the syntax is much more readable than with plain promises:
 
 <iframe
-  allow="geolocation; microphone; camera; midi; encrypted-media"
+  title="Multiple async functions in series"
   src="https://glitch.com/embed/#!/embed/nodejs-dev-0035-02?path=server.js&previewSize=30&attributionHidden=true&sidebarCollapsed=true"
   alt="nodejs-dev-0035-02 on Glitch"
   style="height: 400px; width: 100%; border: 0;">

--- a/src/documentation/0037-node-http-server/index.md
+++ b/src/documentation/0037-node-http-server/index.md
@@ -8,7 +8,7 @@ section: Getting Started
 Here is a sample Hello World HTTP web server:
 
 <iframe
-  allow="geolocation; microphone; camera; midi; encrypted-media"
+  title="Build an HTTP Server"
   src="https://glitch.com/embed/#!/embed/nodejs-dev-0037-01?path=server.js&previewSize=33&attributionHidden=true&sidebarCollapsed=true"
   alt="nodejs-dev-0037-01 on Glitch"
   style="height: 400px; width: 100%; border: 0;">


### PR DESCRIPTION
## Description
This PR adds the title attribute to the embed iframe and removes `allow="geolocation; microphone; camera; midi; encrypted-media"` boilerplate from glitch.
Closes #1004
