### PR TITLE
feat: upcoming releases tabs

### DIFF
--- a/src/components/DownloadReleases/DownloadReleases.scss
+++ b/src/components/DownloadReleases/DownloadReleases.scss
@@ -1,51 +1,12 @@
-.download-releases {
-  margin-top: 126px;
-  width: 100%;
-}
-
 .download-releases__title {
+  margin: 126px 0 50px;
   font-weight: var(--font-weight-semibold);
   font-size: var(--font-size-display4);
   line-height: var(--line-height-display4);
-}
-
-.node {
-  display: grid;
-  grid-template-columns: repeat(5, 1fr);
-  grid-template-rows: 1fr;
-  grid-column-gap: 0px;
-  grid-row-gap: 0px;
-  text-align: center;
-}
-
-.current {
-  grid-area: 1 / 1 / 2 / 2;
-}
-.lts {
-  grid-area: 1 / 2 / 2 / 3;
-}
-.maintenance {
-  grid-area: 1 / 3 / 2 / 4;
-}
-.endoflife {
-  grid-area: 1 / 4 / 2 / 5;
-}
-.div5 {
-  grid-area: 1 / 5 / 2 / 6;
-}
-.release-title {
-  font-weight: 600;
-}
-.release-date {
-  font-size: 12px;
 }
 
 .lts__text {
   font-weight: var(--font-weight-regular);
   font-size: var(--font-size-display5);
   line-height: var(--line-height-body1);
-}
-
-.react-tabs__tab--selected {
-  border-bottom: 2px solid #5fa04e;
 }

--- a/src/components/DownloadReleases/__tests__/__snapshots__/download-releases.test.tsx.snap
+++ b/src/components/DownloadReleases/__tests__/__snapshots__/download-releases.test.tsx.snap
@@ -3,29 +3,26 @@
 exports[`DownloadReleases component renders correctly 1`] = `
 <div>
   <div
-    class="download-releases"
+    className="upcoming-releases"
   >
-    <h2
-      class="download-releases__title"
-    >
-      Upcoming Releases
-    </h2>
     <div
-      class="react-tabs"
-      data-tabs="true"
+      className="react-tabs"
+      data-tabs={true}
+      onClick={[Function]}
+      onKeyDown={[Function]}
     >
       <ul
-        class="react-tabs__tab-list"
+        className="react-tabs__tab-list"
         role="tablist"
       >
         <li
           aria-controls="react-tabs-1"
           aria-disabled="false"
           aria-selected="true"
-          class="react-tabs__tab react-tabs__tab--selected"
+          className="react-tabs__tab react-tabs__tab--selected"
           id="react-tabs-0"
           role="tab"
-          tabindex="0"
+          tabIndex="0"
         >
           Node.js 12
         </li>
@@ -33,9 +30,10 @@ exports[`DownloadReleases component renders correctly 1`] = `
           aria-controls="react-tabs-3"
           aria-disabled="false"
           aria-selected="false"
-          class="react-tabs__tab"
+          className="react-tabs__tab"
           id="react-tabs-2"
           role="tab"
+          tabIndex={null}
         >
           Node.js 13
         </li>
@@ -43,9 +41,10 @@ exports[`DownloadReleases component renders correctly 1`] = `
           aria-controls="react-tabs-5"
           aria-disabled="false"
           aria-selected="false"
-          class="react-tabs__tab"
+          className="react-tabs__tab"
           id="react-tabs-4"
           role="tab"
+          tabIndex={null}
         >
           Node.js 14
         </li>
@@ -53,170 +52,124 @@ exports[`DownloadReleases component renders correctly 1`] = `
           aria-controls="react-tabs-7"
           aria-disabled="false"
           aria-selected="false"
-          class="react-tabs__tab"
+          className="react-tabs__tab"
           id="react-tabs-6"
           role="tab"
+          tabIndex={null}
         >
           Node.js 15
         </li>
       </ul>
       <div
         aria-labelledby="react-tabs-0"
-        class="react-tabs__tab-panel react-tabs__tab-panel--selected"
+        className="react-tabs__tab-panel react-tabs__tab-panel--selected"
         id="react-tabs-1"
         role="tabpanel"
       >
         <div
-          class="node"
+          className="upcoming-releases__panel"
         >
           <div
-            class="current"
+            className="upcoming-releases__item--current"
           >
             <img
-              alt=""
+              alt="hexagon icon"
               src="test-file-stub"
             />
             <p
-              class="release-title"
+              className="release-title"
             >
               Current
             </p>
             <p
-              class="release-date"
+              className="release-date"
             >
-              Released 2019-04-23
+              Released
+               
+              2019-04-23
             </p>
           </div>
           <div
-            class="lts"
+            className="upcoming-releases__item--lts"
           >
             <img
-              alt=""
+              alt="hexagon icon"
               src="test-file-stub"
             />
             <p
-              class="release-title"
+              className="release-title"
             >
-              Active LTS
+              LTS
             </p>
             <p
-              class="release-date"
+              className="release-date"
             >
-              Released 2019-10-21
+              Released
+               
+              2019-10-21
             </p>
           </div>
           <div
-            class="maintenance"
+            className="upcoming-releases__item--maintenance"
           >
             <img
-              alt=""
+              alt="hexagon icon"
               src="test-file-stub"
             />
             <p
-              class="release-title"
+              className="release-title"
             >
               Maintenance Release
             </p>
             <p
-              class="release-date"
+              className="release-date"
             >
-              Released 2020-10-20 
+              Released
+               
+              2020-10-20
             </p>
           </div>
           <div
-            class="endoflife"
+            className="upcoming-releases__item--endoflife"
           >
             <img
-              alt=""
+              alt="hexagon icon"
               src="test-file-stub"
             />
             <p
-              class="release-title"
+              className="release-title"
             >
               End-of-life Release
             </p>
             <p
-              class="release-date"
+              className="release-date"
             >
-              Released 2022-04-30
+              Released
+               
+              2022-04-30
             </p>
           </div>
         </div>
       </div>
       <div
         aria-labelledby="react-tabs-2"
-        class="react-tabs__tab-panel"
+        className="react-tabs__tab-panel"
         id="react-tabs-3"
         role="tabpanel"
       />
       <div
         aria-labelledby="react-tabs-4"
-        class="react-tabs__tab-panel"
+        className="react-tabs__tab-panel"
         id="react-tabs-5"
         role="tabpanel"
       />
       <div
         aria-labelledby="react-tabs-6"
-        class="react-tabs__tab-panel"
+        className="react-tabs__tab-panel"
         id="react-tabs-7"
         role="tabpanel"
       />
     </div>
-    <p
-      class="lts__text"
-    >
-      Major Node.js versions enter Current release status for six months, which gives library authors time to add support for them. After six months, odd-numbered releases (9, 11, etc.) become unsupported, and even-numbered releases (10, 12, etc.) move to Active LTS status and are ready for general use. LTS release status is "long-term support", which typically guarantees that critical bugs will be fixed for a total of 30 months. Production applications should only use Active LTS or Maintenance LTS releases.
-    </p>
-    <table
-      class="downloads-table"
-    >
-      <thead>
-        <tr>
-          <th>
-            Release
-          </th>
-          <th>
-            Status
-          </th>
-          <th>
-            Codename
-          </th>
-          <th>
-            Initial Release
-          </th>
-          <th>
-            Active LTS Start
-          </th>
-          <th>
-            Maintainance LTS Start
-          </th>
-          <th>
-            End of Life
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>
-            v15
-          </td>
-          <td>
-            Pending
-          </td>
-          <td />
-          <td>
-            2020-10-20
-          </td>
-          <td />
-          <td>
-            2021-04-01
-          </td>
-          <td>
-            2021-06-01
-          </td>
-        </tr>
-      </tbody>
-    </table>
   </div>
 </div>
 `;

--- a/src/components/DownloadReleases/__tests__/__snapshots__/download-releases.test.tsx.snap
+++ b/src/components/DownloadReleases/__tests__/__snapshots__/download-releases.test.tsx.snap
@@ -3,173 +3,232 @@
 exports[`DownloadReleases component renders correctly 1`] = `
 <div>
   <div
-    className="upcoming-releases"
+    class="download-releases"
   >
-    <div
-      className="react-tabs"
-      data-tabs={true}
-      onClick={[Function]}
-      onKeyDown={[Function]}
+    <h2
+      class="download-releases__title"
     >
-      <ul
-        className="react-tabs__tab-list"
-        role="tablist"
-      >
-        <li
-          aria-controls="react-tabs-1"
-          aria-disabled="false"
-          aria-selected="true"
-          className="react-tabs__tab react-tabs__tab--selected"
-          id="react-tabs-0"
-          role="tab"
-          tabIndex="0"
-        >
-          Node.js 12
-        </li>
-        <li
-          aria-controls="react-tabs-3"
-          aria-disabled="false"
-          aria-selected="false"
-          className="react-tabs__tab"
-          id="react-tabs-2"
-          role="tab"
-          tabIndex={null}
-        >
-          Node.js 13
-        </li>
-        <li
-          aria-controls="react-tabs-5"
-          aria-disabled="false"
-          aria-selected="false"
-          className="react-tabs__tab"
-          id="react-tabs-4"
-          role="tab"
-          tabIndex={null}
-        >
-          Node.js 14
-        </li>
-        <li
-          aria-controls="react-tabs-7"
-          aria-disabled="false"
-          aria-selected="false"
-          className="react-tabs__tab"
-          id="react-tabs-6"
-          role="tab"
-          tabIndex={null}
-        >
-          Node.js 15
-        </li>
-      </ul>
+      Upcoming Releases
+    </h2>
+    <div
+      class="upcoming-releases"
+    >
       <div
-        aria-labelledby="react-tabs-0"
-        className="react-tabs__tab-panel react-tabs__tab-panel--selected"
-        id="react-tabs-1"
-        role="tabpanel"
+        class="react-tabs"
+        data-tabs="true"
       >
+        <ul
+          class="react-tabs__tab-list"
+          role="tablist"
+        >
+          <li
+            aria-controls="react-tabs-1"
+            aria-disabled="false"
+            aria-selected="true"
+            class="react-tabs__tab react-tabs__tab--selected"
+            id="react-tabs-0"
+            role="tab"
+            tabindex="0"
+          >
+            Node.js 12
+          </li>
+          <li
+            aria-controls="react-tabs-3"
+            aria-disabled="false"
+            aria-selected="false"
+            class="react-tabs__tab"
+            id="react-tabs-2"
+            role="tab"
+          >
+            Node.js 13
+          </li>
+          <li
+            aria-controls="react-tabs-5"
+            aria-disabled="false"
+            aria-selected="false"
+            class="react-tabs__tab"
+            id="react-tabs-4"
+            role="tab"
+          >
+            Node.js 14
+          </li>
+          <li
+            aria-controls="react-tabs-7"
+            aria-disabled="false"
+            aria-selected="false"
+            class="react-tabs__tab"
+            id="react-tabs-6"
+            role="tab"
+          >
+            Node.js 15
+          </li>
+        </ul>
         <div
-          className="upcoming-releases__panel"
+          aria-labelledby="react-tabs-0"
+          class="react-tabs__tab-panel react-tabs__tab-panel--selected"
+          id="react-tabs-1"
+          role="tabpanel"
         >
           <div
-            className="upcoming-releases__item--current"
+            class="upcoming-releases__panel"
           >
-            <img
-              alt="hexagon icon"
-              src="test-file-stub"
-            />
-            <p
-              className="release-title"
+            <div
+              class="upcoming-releases__item--current"
             >
-              Current
-            </p>
-            <p
-              className="release-date"
+              <img
+                alt="hexagon icon"
+                src="test-file-stub"
+              />
+              <p
+                class="release-title"
+              >
+                Current
+              </p>
+              <p
+                class="release-date"
+              >
+                Released
+                 
+                2019-04-23
+              </p>
+            </div>
+            <div
+              class="upcoming-releases__item--lts"
             >
-              Released
-               
-              2019-04-23
-            </p>
-          </div>
-          <div
-            className="upcoming-releases__item--lts"
-          >
-            <img
-              alt="hexagon icon"
-              src="test-file-stub"
-            />
-            <p
-              className="release-title"
+              <img
+                alt="hexagon icon"
+                src="test-file-stub"
+              />
+              <p
+                class="release-title"
+              >
+                LTS
+              </p>
+              <p
+                class="release-date"
+              >
+                Released
+                 
+                2019-10-21
+              </p>
+            </div>
+            <div
+              class="upcoming-releases__item--maintenance"
             >
-              LTS
-            </p>
-            <p
-              className="release-date"
+              <img
+                alt="hexagon icon"
+                src="test-file-stub"
+              />
+              <p
+                class="release-title"
+              >
+                Maintenance Release
+              </p>
+              <p
+                class="release-date"
+              >
+                Released
+                 
+                2020-10-20
+              </p>
+            </div>
+            <div
+              class="upcoming-releases__item--endoflife"
             >
-              Released
-               
-              2019-10-21
-            </p>
-          </div>
-          <div
-            className="upcoming-releases__item--maintenance"
-          >
-            <img
-              alt="hexagon icon"
-              src="test-file-stub"
-            />
-            <p
-              className="release-title"
-            >
-              Maintenance Release
-            </p>
-            <p
-              className="release-date"
-            >
-              Released
-               
-              2020-10-20
-            </p>
-          </div>
-          <div
-            className="upcoming-releases__item--endoflife"
-          >
-            <img
-              alt="hexagon icon"
-              src="test-file-stub"
-            />
-            <p
-              className="release-title"
-            >
-              End-of-life Release
-            </p>
-            <p
-              className="release-date"
-            >
-              Released
-               
-              2022-04-30
-            </p>
+              <img
+                alt="hexagon icon"
+                src="test-file-stub"
+              />
+              <p
+                class="release-title"
+              >
+                End-of-life Release
+              </p>
+              <p
+                class="release-date"
+              >
+                Released
+                 
+                2022-04-30
+              </p>
+            </div>
           </div>
         </div>
+        <div
+          aria-labelledby="react-tabs-2"
+          class="react-tabs__tab-panel"
+          id="react-tabs-3"
+          role="tabpanel"
+        />
+        <div
+          aria-labelledby="react-tabs-4"
+          class="react-tabs__tab-panel"
+          id="react-tabs-5"
+          role="tabpanel"
+        />
+        <div
+          aria-labelledby="react-tabs-6"
+          class="react-tabs__tab-panel"
+          id="react-tabs-7"
+          role="tabpanel"
+        />
       </div>
-      <div
-        aria-labelledby="react-tabs-2"
-        className="react-tabs__tab-panel"
-        id="react-tabs-3"
-        role="tabpanel"
-      />
-      <div
-        aria-labelledby="react-tabs-4"
-        className="react-tabs__tab-panel"
-        id="react-tabs-5"
-        role="tabpanel"
-      />
-      <div
-        aria-labelledby="react-tabs-6"
-        className="react-tabs__tab-panel"
-        id="react-tabs-7"
-        role="tabpanel"
-      />
     </div>
+    <p
+      class="lts__text"
+    >
+      Major Node.js versions enter Current release status for six months, which gives library authors time to add support for them. After six months, odd-numbered releases (9, 11, etc.) become unsupported, and even-numbered releases (10, 12, etc.) move to Active LTS status and are ready for general use. LTS release status is "long-term support", which typically guarantees that critical bugs will be fixed for a total of 30 months. Production applications should only use Active LTS or Maintenance LTS releases.
+    </p>
+    <table
+      class="downloads-table"
+    >
+      <thead>
+        <tr>
+          <th>
+            Release
+          </th>
+          <th>
+            Status
+          </th>
+          <th>
+            Codename
+          </th>
+          <th>
+            Initial Release
+          </th>
+          <th>
+            Active LTS Start
+          </th>
+          <th>
+            Maintainance LTS Start
+          </th>
+          <th>
+            End of Life
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            v15
+          </td>
+          <td>
+            Pending
+          </td>
+          <td />
+          <td>
+            2020-10-20
+          </td>
+          <td />
+          <td>
+            2021-04-01
+          </td>
+          <td>
+            2021-06-01
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </div>
 `;

--- a/src/components/DownloadReleases/__tests__/__snapshots__/download-releases.test.tsx.snap
+++ b/src/components/DownloadReleases/__tests__/__snapshots__/download-releases.test.tsx.snap
@@ -133,7 +133,7 @@ exports[`DownloadReleases component renders correctly 1`] = `
               </p>
             </div>
             <div
-              class="upcoming-releases__item--endoflife"
+              class="upcoming-releases__item--endoflife upcoming-releases__item--already-released"
             >
               <img
                 alt="hexagon icon"
@@ -147,7 +147,7 @@ exports[`DownloadReleases component renders correctly 1`] = `
               <p
                 class="release-date"
               >
-                Released
+                To be released
                  
                 2022-04-30
               </p>

--- a/src/components/DownloadReleases/index.tsx
+++ b/src/components/DownloadReleases/index.tsx
@@ -1,115 +1,18 @@
 import React from 'react';
-import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
-
-import { NodeReleaseData } from '../../hooks/useReleaseHistory';
-import hexagonFilled from '../../images/icons/hexagon-filled.svg';
-import hexagonOutline from '../../images/icons/hexagon-outline.svg';
-
 import DownloadTable from './DownloadTable';
+import UpcomingReleases from '../UpcomingReleases';
+import { NodeReleaseData } from '../../hooks/useReleaseHistory';
 import './DownloadReleases.scss';
 
 interface Props {
   releases: NodeReleaseData[];
 }
 
-export default function DownloadToggle({ releases }: Props): JSX.Element {
+export default function DownloadReleases({ releases }: Props): JSX.Element {
   return (
     <div className="download-releases">
       <h2 className="download-releases__title">Upcoming Releases</h2>
-      <Tabs>
-        <TabList>
-          <Tab>Node.js 12</Tab>
-          <Tab>Node.js 13</Tab>
-          <Tab>Node.js 14</Tab>
-          <Tab>Node.js 15</Tab>
-        </TabList>
-        <TabPanel>
-          <div className="node">
-            <div className="current">
-              <img src={hexagonFilled} alt="" />
-              <p className="release-title">Current</p>
-              <p className="release-date">Released 2019-04-23</p>
-            </div>
-            <div className="lts">
-              <img src={hexagonFilled} alt="" />
-              <p className="release-title">Active LTS</p>
-              <p className="release-date">Released 2019-10-21</p>
-            </div>
-            <div className="maintenance">
-              <img src={hexagonFilled} alt="" />
-              <p className="release-title">Maintenance Release</p>
-              <p className="release-date">Released 2020-10-20 </p>
-            </div>
-            <div className="endoflife">
-              <img src={hexagonOutline} alt="" />
-              <p className="release-title">End-of-life Release</p>
-              <p className="release-date">Released 2022-04-30</p>
-            </div>
-          </div>
-        </TabPanel>
-        <TabPanel>
-          <div className="node">
-            <div className="current">
-              <img src={hexagonFilled} alt="" />
-              <p className="release-title">Current</p>
-              <p className="release-date">Released 2019-10-22</p>
-            </div>
-            <div className="maintenance">
-              <img src={hexagonFilled} alt="" />
-              <p className="release-title">Maintenance Release</p>
-              <p className="release-date">Released 2020-04-01 </p>
-            </div>
-            <div className="endoflife">
-              <img src={hexagonOutline} alt="" />
-              <p className="release-title">End-of-life Release</p>
-              <p className="release-date">Released 2020-06-01</p>
-            </div>
-          </div>
-        </TabPanel>
-        <TabPanel>
-          <div className="node">
-            <div className="current">
-              <img src={hexagonFilled} alt="" />
-              <p className="release-title">Current</p>
-              <p className="release-date">Released 2020-04-21</p>
-            </div>
-            <div className="lts">
-              <img src={hexagonFilled} alt="" />
-              <p className="release-title">Active LTS</p>
-              <p className="release-date">Released 2020-10-20</p>
-            </div>
-            <div className="maintenance">
-              <img src={hexagonOutline} alt="" />
-              <p className="release-title">Maintenance Release</p>
-              <p className="release-date">Release 2021-10-19</p>
-            </div>
-            <div className="endoflife">
-              <img src={hexagonOutline} alt="" />
-              <p className="release-title">End-of-life Release</p>
-              <p className="release-date">Release 2023-04-30</p>
-            </div>
-          </div>
-        </TabPanel>
-        <TabPanel>
-          <div className="node">
-            <div className="current">
-              <img src={hexagonFilled} alt="" />
-              <p className="release-title">Current</p>
-              <p className="release-date">Released 2020-10-21 </p>
-            </div>
-            <div className="maintenance">
-              <img src={hexagonOutline} alt="" />
-              <p className="release-title">Maintenance Release</p>
-              <p className="release-date">Release 2021-04-01</p>
-            </div>
-            <div className="endoflife">
-              <img src={hexagonOutline} alt="" />
-              <p className="release-title">End-of-life Release</p>
-              <p className="release-date">Release 2021-06-01</p>
-            </div>
-          </div>
-        </TabPanel>
-      </Tabs>
+      <UpcomingReleases />
       <p className="lts__text">
         Major Node.js versions enter Current release status for six months,
         which gives library authors time to add support for them. After six

--- a/src/components/InstallTabs/InstallTabs.scss
+++ b/src/components/InstallTabs/InstallTabs.scss
@@ -1,123 +1,122 @@
-.react-tabs {
-  -webkit-tap-highlight-color: transparent;
+.install {
+  .react-tabs {
+    -webkit-tap-highlight-color: transparent;
 
-  &__tab-list {
-    margin: 0;
-    padding: 0;
-    text-align: center;
-    display: flex;
-  }
-
-  &__tab {
-    display: inline-block;
-    border: 1px solid transparent;
-    border-bottom: none;
-    bottom: -1px;
-    color: var(--black4);
-    position: relative;
-    list-style: none;
-    padding: 10px 12px;
-    background: var(--black8);
-    cursor: pointer;
-    width: 100%;
-    text-align: center;
-
-    &--selected {
-      background: var(--black9);
-      color: #fff;
-      border-radius: 5px 5px 0 0;
+    &__tab-list {
+      margin: 0;
+      padding: 0;
+      text-align: center;
+      display: flex;
     }
 
-    &:focus {
-      box-shadow: 0 0 5px var(--pink5);
-      border-color: var(--pink5);
+    &__tab {
+      display: inline-block;
+      border: 1px solid transparent;
       border-bottom: none;
-      outline: none;
+      bottom: -1px;
+      color: var(--black4);
+      position: relative;
+      list-style: none;
+      padding: 10px 12px;
+      background: var(--black8);
+      cursor: pointer;
+      width: 100%;
+      text-align: center;
 
-      &:after {
-        content: '';
-        position: absolute;
-        height: 5px;
-        left: 0;
-        right: 0;
-        bottom: -5px;
+      &--selected {
         background: var(--black9);
-      }
-    }
-  }
-
-  &__tab-panel {
-    display: none;
-    padding: 20px;
-
-    &--selected {
-      display: block;
-    }
-  }
-
-  .install {
-    &__header {
-      height: 30px;
-      margin: 0 5px;
-      font-weight: var(--font-weight-semibold);
-      &-circles {
-        height: 100%;
-        float: left;
-      }
-      &-grey-circle {
-        display: inline-block;
-        background-color: var(--black8);
-        width: 10px;
-        height: 10px;
-        border-radius: 50%;
-        margin: 10px 5px;
-      }
-      &-text {
-        width: calc(100% - 60px);
-        text-align: center;
-        line-height: 30px;
-      }
-    }
-    &__text {
-      color: var(--pink5);
-      &__line {
-        margin: var(--space-12) 0;
-      }
-      &__no-select {
-        margin-right: var(--space-12);
-        -webkit-touch-callout: none; /* iOS Safari */
-        -webkit-user-select: none; /* Safari */
-        -khtml-user-select: none; /* Konqueror HTML */
-        -moz-user-select: none; /* Old versions of Firefox */
-        -ms-user-select: none; /* Internet Explorer/Edge */
-        user-select: none;
-      }
-    }
-    &__docs-button,
-    &__docs-button:hover {
-      border-radius: var(--space-04);
-      border: 1px solid var(--black3);
-      padding: var(--space-08) var(--space-16);
-      position: absolute;
-      bottom: 2rem;
-      right: 2rem;
-      text-decoration: none;
-      box-sizing: border-box;
-      height: 4rem;
-      color: var(--black3);
-      font-weight: var(--font-weight-semibold);
-    }
-  }
-  .shell-box {
-    code {
-      color: var(--pink5);
-      width: calc(100% - 20px);
-      line-height: 30px;
-      > span.install__text__command {
         color: #fff;
+        border-radius: 5px 5px 0 0;
+      }
+
+      &:focus {
+        box-shadow: 0 0 5px var(--pink5);
+        border-color: var(--pink5);
+        border-bottom: none;
+        outline: none;
+
+        &:after {
+          content: '';
+          position: absolute;
+          height: 5px;
+          left: 0;
+          right: 0;
+          bottom: -5px;
+          background: var(--black9);
+        }
       }
     }
-    background-color: var(--black9);
-    padding-bottom: 15px;
+
+    &__tab-panel {
+      display: none;
+      padding: 20px;
+
+      &--selected {
+        display: block;
+      }
+    }
   }
+  &__header {
+    height: 30px;
+    margin: 0 5px;
+    font-weight: var(--font-weight-semibold);
+    &-circles {
+      height: 100%;
+      float: left;
+    }
+    &-grey-circle {
+      display: inline-block;
+      background-color: var(--black8);
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      margin: 10px 5px;
+    }
+    &-text {
+      width: calc(100% - 60px);
+      text-align: center;
+      line-height: 30px;
+    }
+  }
+  &__text {
+    color: var(--pink5);
+    &__line {
+      margin: var(--space-12) 0;
+    }
+    &__no-select {
+      margin-right: var(--space-12);
+      -webkit-touch-callout: none; /* iOS Safari */
+      -webkit-user-select: none; /* Safari */
+      -khtml-user-select: none; /* Konqueror HTML */
+      -moz-user-select: none; /* Old versions of Firefox */
+      -ms-user-select: none; /* Internet Explorer/Edge */
+      user-select: none;
+    }
+  }
+  &__docs-button,
+  &__docs-button:hover {
+    border-radius: var(--space-04);
+    border: 1px solid var(--black3);
+    padding: var(--space-08) var(--space-16);
+    position: absolute;
+    bottom: 2rem;
+    right: 2rem;
+    text-decoration: none;
+    box-sizing: border-box;
+    height: 4rem;
+    color: var(--black3);
+    font-weight: var(--font-weight-semibold);
+  }
+}
+.shell-box {
+  code {
+    color: var(--pink5);
+    width: calc(100% - 20px);
+    line-height: 30px;
+    > span.install__text__command {
+      color: #fff;
+    }
+  }
+  background-color: var(--black9);
+  padding-bottom: 15px;
 }

--- a/src/components/InstallTabs/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/InstallTabs/__tests__/__snapshots__/index.tsx.snap
@@ -1,45 +1,49 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Tests for InstallTabs component renders correctly 1`] = `
-<div>
+<div
+  className="install"
+>
   <div
-    class="react-tabs"
-    data-tabs="true"
+    className="react-tabs"
+    data-tabs={true}
+    onClick={[Function]}
+    onKeyDown={[Function]}
   >
     <div
-      class="install__header"
+      className="install__header"
     >
       <div
-        class="install__header-circles"
+        className="install__header-circles"
       >
         <div
-          class="install__header-grey-circle"
+          className="install__header-grey-circle"
         />
         <div
-          class="install__header-grey-circle"
+          className="install__header-grey-circle"
         />
         <div
-          class="install__header-grey-circle"
+          className="install__header-grey-circle"
         />
       </div>
       <div
-        class="install__header-text"
+        className="install__header-text"
       >
         bash
       </div>
     </div>
     <ul
-      class="react-tabs__tab-list"
+      className="react-tabs__tab-list"
       role="tablist"
     >
       <li
         aria-controls="react-tabs-1"
         aria-disabled="false"
         aria-selected="true"
-        class="react-tabs__tab react-tabs__tab--selected"
+        className="react-tabs__tab react-tabs__tab--selected"
         id="react-tabs-0"
         role="tab"
-        tabindex="0"
+        tabIndex="0"
       >
         Windows (Chocolatey)
       </li>
@@ -47,9 +51,10 @@ exports[`Tests for InstallTabs component renders correctly 1`] = `
         aria-controls="react-tabs-3"
         aria-disabled="false"
         aria-selected="false"
-        class="react-tabs__tab"
+        className="react-tabs__tab"
         id="react-tabs-2"
         role="tab"
+        tabIndex={null}
       >
         macOS (nvm)
       </li>
@@ -57,30 +62,32 @@ exports[`Tests for InstallTabs component renders correctly 1`] = `
         aria-controls="react-tabs-5"
         aria-disabled="false"
         aria-selected="false"
-        class="react-tabs__tab"
+        className="react-tabs__tab"
         id="react-tabs-4"
         role="tab"
+        tabIndex={null}
       >
         Linux (nvm)
       </li>
     </ul>
     <div
       aria-labelledby="react-tabs-0"
-      class="react-tabs__tab-panel react-tabs__tab-panel--selected"
+      className="react-tabs__tab-panel react-tabs__tab-panel--selected"
       id="react-tabs-1"
       role="tabpanel"
     >
       <div>
         <pre
-          class="shell-box"
+          className="shell-box"
         >
           <div
-            class="shell-box-top"
+            className="shell-box-top"
           >
             <span>
               SHELL
             </span>
             <button
+              onClick={[Function]}
               type="button"
             >
               copy
@@ -88,12 +95,12 @@ exports[`Tests for InstallTabs component renders correctly 1`] = `
           </div>
           <code>
             <span
-              class="install__text__no-select"
+              className="install__text__no-select"
             >
               $
             </span>
             <span
-              class="install__text__command"
+              className="install__text__command"
             >
               choco 
             </span>
@@ -103,7 +110,7 @@ exports[`Tests for InstallTabs component renders correctly 1`] = `
         <br />
         <br />
         <a
-          class="install__docs-button"
+          className="install__docs-button"
           href="https://nodejs.org/en/download/package-manager/#windows"
           rel="noopener noreferrer"
           target="_blank"
@@ -114,13 +121,13 @@ exports[`Tests for InstallTabs component renders correctly 1`] = `
     </div>
     <div
       aria-labelledby="react-tabs-2"
-      class="react-tabs__tab-panel"
+      className="react-tabs__tab-panel"
       id="react-tabs-3"
       role="tabpanel"
     />
     <div
       aria-labelledby="react-tabs-4"
-      class="react-tabs__tab-panel"
+      className="react-tabs__tab-panel"
       id="react-tabs-5"
       role="tabpanel"
     />

--- a/src/components/InstallTabs/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/InstallTabs/__tests__/__snapshots__/index.tsx.snap
@@ -1,136 +1,133 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Tests for InstallTabs component renders correctly 1`] = `
-<div
-  className="install"
->
+<div>
   <div
-    className="react-tabs"
-    data-tabs={true}
-    onClick={[Function]}
-    onKeyDown={[Function]}
+    class="install"
   >
     <div
-      className="install__header"
+      class="react-tabs"
+      data-tabs="true"
     >
       <div
-        className="install__header-circles"
+        class="install__header"
       >
         <div
-          className="install__header-grey-circle"
-        />
-        <div
-          className="install__header-grey-circle"
-        />
-        <div
-          className="install__header-grey-circle"
-        />
-      </div>
-      <div
-        className="install__header-text"
-      >
-        bash
-      </div>
-    </div>
-    <ul
-      className="react-tabs__tab-list"
-      role="tablist"
-    >
-      <li
-        aria-controls="react-tabs-1"
-        aria-disabled="false"
-        aria-selected="true"
-        className="react-tabs__tab react-tabs__tab--selected"
-        id="react-tabs-0"
-        role="tab"
-        tabIndex="0"
-      >
-        Windows (Chocolatey)
-      </li>
-      <li
-        aria-controls="react-tabs-3"
-        aria-disabled="false"
-        aria-selected="false"
-        className="react-tabs__tab"
-        id="react-tabs-2"
-        role="tab"
-        tabIndex={null}
-      >
-        macOS (nvm)
-      </li>
-      <li
-        aria-controls="react-tabs-5"
-        aria-disabled="false"
-        aria-selected="false"
-        className="react-tabs__tab"
-        id="react-tabs-4"
-        role="tab"
-        tabIndex={null}
-      >
-        Linux (nvm)
-      </li>
-    </ul>
-    <div
-      aria-labelledby="react-tabs-0"
-      className="react-tabs__tab-panel react-tabs__tab-panel--selected"
-      id="react-tabs-1"
-      role="tabpanel"
-    >
-      <div>
-        <pre
-          className="shell-box"
+          class="install__header-circles"
         >
           <div
-            className="shell-box-top"
-          >
-            <span>
-              SHELL
-            </span>
-            <button
-              onClick={[Function]}
-              type="button"
-            >
-              copy
-            </button>
-          </div>
-          <code>
-            <span
-              className="install__text__no-select"
-            >
-              $
-            </span>
-            <span
-              className="install__text__command"
-            >
-              choco 
-            </span>
-            install nodejs-lts
-          </code>
-        </pre>
-        <br />
-        <br />
-        <a
-          className="install__docs-button"
-          href="https://nodejs.org/en/download/package-manager/#windows"
-          rel="noopener noreferrer"
-          target="_blank"
+            class="install__header-grey-circle"
+          />
+          <div
+            class="install__header-grey-circle"
+          />
+          <div
+            class="install__header-grey-circle"
+          />
+        </div>
+        <div
+          class="install__header-text"
         >
-          Read documentation
-        </a>
+          bash
+        </div>
       </div>
+      <ul
+        class="react-tabs__tab-list"
+        role="tablist"
+      >
+        <li
+          aria-controls="react-tabs-1"
+          aria-disabled="false"
+          aria-selected="true"
+          class="react-tabs__tab react-tabs__tab--selected"
+          id="react-tabs-0"
+          role="tab"
+          tabindex="0"
+        >
+          Windows (Chocolatey)
+        </li>
+        <li
+          aria-controls="react-tabs-3"
+          aria-disabled="false"
+          aria-selected="false"
+          class="react-tabs__tab"
+          id="react-tabs-2"
+          role="tab"
+        >
+          macOS (nvm)
+        </li>
+        <li
+          aria-controls="react-tabs-5"
+          aria-disabled="false"
+          aria-selected="false"
+          class="react-tabs__tab"
+          id="react-tabs-4"
+          role="tab"
+        >
+          Linux (nvm)
+        </li>
+      </ul>
+      <div
+        aria-labelledby="react-tabs-0"
+        class="react-tabs__tab-panel react-tabs__tab-panel--selected"
+        id="react-tabs-1"
+        role="tabpanel"
+      >
+        <div>
+          <pre
+            class="shell-box"
+          >
+            <div
+              class="shell-box-top"
+            >
+              <span>
+                SHELL
+              </span>
+              <button
+                type="button"
+              >
+                copy
+              </button>
+            </div>
+            <code>
+              <span
+                class="install__text__no-select"
+              >
+                $
+              </span>
+              <span
+                class="install__text__command"
+              >
+                choco 
+              </span>
+              install nodejs-lts
+            </code>
+          </pre>
+          <br />
+          <br />
+          <a
+            class="install__docs-button"
+            href="https://nodejs.org/en/download/package-manager/#windows"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Read documentation
+          </a>
+        </div>
+      </div>
+      <div
+        aria-labelledby="react-tabs-2"
+        class="react-tabs__tab-panel"
+        id="react-tabs-3"
+        role="tabpanel"
+      />
+      <div
+        aria-labelledby="react-tabs-4"
+        class="react-tabs__tab-panel"
+        id="react-tabs-5"
+        role="tabpanel"
+      />
     </div>
-    <div
-      aria-labelledby="react-tabs-2"
-      className="react-tabs__tab-panel"
-      id="react-tabs-3"
-      role="tabpanel"
-    />
-    <div
-      aria-labelledby="react-tabs-4"
-      className="react-tabs__tab-panel"
-      id="react-tabs-5"
-      role="tabpanel"
-    />
   </div>
 </div>
 `;

--- a/src/components/InstallTabs/index.tsx
+++ b/src/components/InstallTabs/index.tsx
@@ -25,20 +25,6 @@ const InstallTabs = (): JSX.Element => {
 
   function panelSwitch(): JSX.Element {
     switch (userOS) {
-      default:
-        return (
-          <>
-            <TabPanel>
-              <WindowsPanel />
-            </TabPanel>
-            <TabPanel>
-              <MacOSPanel />
-            </TabPanel>
-            <TabPanel>
-              <LinuxPanel />
-            </TabPanel>
-          </>
-        );
       case UserOS.MAC:
         return (
           <>
@@ -67,28 +53,44 @@ const InstallTabs = (): JSX.Element => {
             </TabPanel>
           </>
         );
+      default:
+        return (
+          <>
+            <TabPanel>
+              <WindowsPanel />
+            </TabPanel>
+            <TabPanel>
+              <MacOSPanel />
+            </TabPanel>
+            <TabPanel>
+              <LinuxPanel />
+            </TabPanel>
+          </>
+        );
     }
   }
 
   return installTabSystems[userOS] !== undefined ? (
-    <Tabs>
-      <div className="install__header">
-        <div className="install__header-circles">
-          <div className="install__header-grey-circle" />
-          <div className="install__header-grey-circle" />
-          <div className="install__header-grey-circle" />
+    <div className="install">
+      <Tabs>
+        <div className="install__header">
+          <div className="install__header-circles">
+            <div className="install__header-grey-circle" />
+            <div className="install__header-grey-circle" />
+            <div className="install__header-grey-circle" />
+          </div>
+          <div className="install__header-text">
+            {userOS === 'MAC' ? 'zsh' : 'bash'}
+          </div>
         </div>
-        <div className="install__header-text">
-          {userOS === 'MAC' ? 'zsh' : 'bash'}
-        </div>
-      </div>
-      <TabList>
-        {installTabSystems[userOS].map((system: string) => (
-          <Tab key={system.toString()}>{system}</Tab>
-        ))}
-      </TabList>
-      {panelSwitch()}
-    </Tabs>
+        <TabList>
+          {installTabSystems[userOS].map((system: string) => (
+            <Tab key={system.toString()}>{system}</Tab>
+          ))}
+        </TabList>
+        {panelSwitch()}
+      </Tabs>
+    </div>
   ) : (
     <></>
   );

--- a/src/components/UpcomingReleases/UpcomingReleases.scss
+++ b/src/components/UpcomingReleases/UpcomingReleases.scss
@@ -1,0 +1,43 @@
+.upcoming-releases {
+  width: 100%;
+  .react-tabs {
+    -webkit-tap-highlight-color: transparent;
+
+    &__tab-list {
+      margin: 0;
+      padding: 0;
+      text-align: center;
+      display: flex;
+      border-bottom: 1px solid #d7d8df;
+    }
+
+    &__tab {
+      display: inline-block;
+      list-style: none;
+      padding: 7px 20px;
+      cursor: pointer;
+
+      &--selected {
+        border-bottom: 4px solid var(--brand5);
+      }
+    }
+
+    &__tab-panel {
+      display: none;
+      padding: 70px 0;
+
+      &--selected {
+        display: block;
+      }
+    }
+  }
+
+  &__panel {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    grid-template-rows: 1fr;
+    grid-column-gap: 0px;
+    grid-row-gap: 0px;
+    text-align: center;
+  }
+}

--- a/src/components/UpcomingReleases/UpcomingReleasesItem/UpcomingReleasesItem.scss
+++ b/src/components/UpcomingReleases/UpcomingReleasesItem/UpcomingReleasesItem.scss
@@ -1,0 +1,30 @@
+.upcoming-releases {
+  &__item {
+    &--already-released {
+      opacity: 0.5;
+    }
+
+    &--current {
+      grid-area: 1 / 1 / 2 / 1;
+    }
+    &--lts {
+      grid-area: 1 / 2 / 2 / 2;
+    }
+    &--maintenance {
+      grid-area: 1 / 3 / 2 / 3;
+    }
+    &--endoflife {
+      grid-area: 1 / 4 / 2 / 4;
+    }
+  }
+}
+
+.release-title {
+  font-weight: 600;
+  margin: 0;
+  margin-top: 10px;
+}
+.release-date {
+  font-size: 12px;
+  margin: 0;
+}

--- a/src/components/UpcomingReleases/UpcomingReleasesItem/index.tsx
+++ b/src/components/UpcomingReleases/UpcomingReleasesItem/index.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import hexagonFilled from '../../../images/icons/hexagon-filled.svg';
+import hexagonOutline from '../../../images/icons/hexagon-outline.svg';
+import { UpcomingRelease, RELEASE_TYPES } from '../upcomingReleases';
+import './UpcomingReleasesItem.scss';
+
+type Props = UpcomingRelease;
+
+export default function UpcomingReleasesItem({
+  releaseType,
+  releaseDate,
+  alreadyReleased,
+}: Props): JSX.Element {
+  const image = alreadyReleased ? hexagonFilled : hexagonOutline;
+  const className = alreadyReleased
+    ? `upcoming-releases__item--${releaseType}`
+    : `upcoming-releases__item--${releaseType} upcoming-releases__item--already-released`;
+
+  return (
+    <div className={className}>
+      <img src={image} alt="hexagon icon" />
+      <p className="release-title">{RELEASE_TYPES[releaseType]}</p>
+      <p className="release-date">
+        {alreadyReleased ? 'Released' : 'To be released'} {releaseDate}
+      </p>
+    </div>
+  );
+}

--- a/src/components/UpcomingReleases/UpcomingReleasesPanel/index.tsx
+++ b/src/components/UpcomingReleases/UpcomingReleasesPanel/index.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import UpcomingReleasesItem from '../UpcomingReleasesItem';
+import { UpcomingRelease } from '../upcomingReleases';
+
+type Props = {
+  releases: UpcomingRelease[];
+};
+
+export default function UpcomingReleasesPanel({
+  releases,
+}: Props): JSX.Element {
+  return (
+    <div className="upcoming-releases__panel">
+      {releases.map(release => (
+        <UpcomingReleasesItem
+          key={release.releaseType}
+          releaseDate={release.releaseDate}
+          releaseType={release.releaseType}
+          alreadyReleased={release.alreadyReleased}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/UpcomingReleases/__tests__/__snapshots__/upcoming-releases.test.tsx.snap
+++ b/src/components/UpcomingReleases/__tests__/__snapshots__/upcoming-releases.test.tsx.snap
@@ -1,173 +1,170 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`UpcomingReleases component renders correctly 1`] = `
-<div
-  className="upcoming-releases"
->
+<div>
   <div
-    className="react-tabs"
-    data-tabs={true}
-    onClick={[Function]}
-    onKeyDown={[Function]}
+    class="upcoming-releases"
   >
-    <ul
-      className="react-tabs__tab-list"
-      role="tablist"
-    >
-      <li
-        aria-controls="react-tabs-1"
-        aria-disabled="false"
-        aria-selected="true"
-        className="react-tabs__tab react-tabs__tab--selected"
-        id="react-tabs-0"
-        role="tab"
-        tabIndex="0"
-      >
-        Node.js 12
-      </li>
-      <li
-        aria-controls="react-tabs-3"
-        aria-disabled="false"
-        aria-selected="false"
-        className="react-tabs__tab"
-        id="react-tabs-2"
-        role="tab"
-        tabIndex={null}
-      >
-        Node.js 13
-      </li>
-      <li
-        aria-controls="react-tabs-5"
-        aria-disabled="false"
-        aria-selected="false"
-        className="react-tabs__tab"
-        id="react-tabs-4"
-        role="tab"
-        tabIndex={null}
-      >
-        Node.js 14
-      </li>
-      <li
-        aria-controls="react-tabs-7"
-        aria-disabled="false"
-        aria-selected="false"
-        className="react-tabs__tab"
-        id="react-tabs-6"
-        role="tab"
-        tabIndex={null}
-      >
-        Node.js 15
-      </li>
-    </ul>
     <div
-      aria-labelledby="react-tabs-0"
-      className="react-tabs__tab-panel react-tabs__tab-panel--selected"
-      id="react-tabs-1"
-      role="tabpanel"
+      class="react-tabs"
+      data-tabs="true"
     >
+      <ul
+        class="react-tabs__tab-list"
+        role="tablist"
+      >
+        <li
+          aria-controls="react-tabs-1"
+          aria-disabled="false"
+          aria-selected="true"
+          class="react-tabs__tab react-tabs__tab--selected"
+          id="react-tabs-0"
+          role="tab"
+          tabindex="0"
+        >
+          Node.js 12
+        </li>
+        <li
+          aria-controls="react-tabs-3"
+          aria-disabled="false"
+          aria-selected="false"
+          class="react-tabs__tab"
+          id="react-tabs-2"
+          role="tab"
+        >
+          Node.js 13
+        </li>
+        <li
+          aria-controls="react-tabs-5"
+          aria-disabled="false"
+          aria-selected="false"
+          class="react-tabs__tab"
+          id="react-tabs-4"
+          role="tab"
+        >
+          Node.js 14
+        </li>
+        <li
+          aria-controls="react-tabs-7"
+          aria-disabled="false"
+          aria-selected="false"
+          class="react-tabs__tab"
+          id="react-tabs-6"
+          role="tab"
+        >
+          Node.js 15
+        </li>
+      </ul>
       <div
-        className="upcoming-releases__panel"
+        aria-labelledby="react-tabs-0"
+        class="react-tabs__tab-panel react-tabs__tab-panel--selected"
+        id="react-tabs-1"
+        role="tabpanel"
       >
         <div
-          className="upcoming-releases__item--current"
+          class="upcoming-releases__panel"
         >
-          <img
-            alt="hexagon icon"
-            src="test-file-stub"
-          />
-          <p
-            className="release-title"
+          <div
+            class="upcoming-releases__item--current"
           >
-            Current
-          </p>
-          <p
-            className="release-date"
+            <img
+              alt="hexagon icon"
+              src="test-file-stub"
+            />
+            <p
+              class="release-title"
+            >
+              Current
+            </p>
+            <p
+              class="release-date"
+            >
+              Released
+               
+              2019-04-23
+            </p>
+          </div>
+          <div
+            class="upcoming-releases__item--lts"
           >
-            Released
-             
-            2019-04-23
-          </p>
-        </div>
-        <div
-          className="upcoming-releases__item--lts"
-        >
-          <img
-            alt="hexagon icon"
-            src="test-file-stub"
-          />
-          <p
-            className="release-title"
+            <img
+              alt="hexagon icon"
+              src="test-file-stub"
+            />
+            <p
+              class="release-title"
+            >
+              LTS
+            </p>
+            <p
+              class="release-date"
+            >
+              Released
+               
+              2019-10-21
+            </p>
+          </div>
+          <div
+            class="upcoming-releases__item--maintenance"
           >
-            LTS
-          </p>
-          <p
-            className="release-date"
+            <img
+              alt="hexagon icon"
+              src="test-file-stub"
+            />
+            <p
+              class="release-title"
+            >
+              Maintenance Release
+            </p>
+            <p
+              class="release-date"
+            >
+              Released
+               
+              2020-10-20
+            </p>
+          </div>
+          <div
+            class="upcoming-releases__item--endoflife"
           >
-            Released
-             
-            2019-10-21
-          </p>
-        </div>
-        <div
-          className="upcoming-releases__item--maintenance"
-        >
-          <img
-            alt="hexagon icon"
-            src="test-file-stub"
-          />
-          <p
-            className="release-title"
-          >
-            Maintenance Release
-          </p>
-          <p
-            className="release-date"
-          >
-            Released
-             
-            2020-10-20
-          </p>
-        </div>
-        <div
-          className="upcoming-releases__item--endoflife"
-        >
-          <img
-            alt="hexagon icon"
-            src="test-file-stub"
-          />
-          <p
-            className="release-title"
-          >
-            End-of-life Release
-          </p>
-          <p
-            className="release-date"
-          >
-            Released
-             
-            2022-04-30
-          </p>
+            <img
+              alt="hexagon icon"
+              src="test-file-stub"
+            />
+            <p
+              class="release-title"
+            >
+              End-of-life Release
+            </p>
+            <p
+              class="release-date"
+            >
+              Released
+               
+              2022-04-30
+            </p>
+          </div>
         </div>
       </div>
+      <div
+        aria-labelledby="react-tabs-2"
+        class="react-tabs__tab-panel"
+        id="react-tabs-3"
+        role="tabpanel"
+      />
+      <div
+        aria-labelledby="react-tabs-4"
+        class="react-tabs__tab-panel"
+        id="react-tabs-5"
+        role="tabpanel"
+      />
+      <div
+        aria-labelledby="react-tabs-6"
+        class="react-tabs__tab-panel"
+        id="react-tabs-7"
+        role="tabpanel"
+      />
     </div>
-    <div
-      aria-labelledby="react-tabs-2"
-      className="react-tabs__tab-panel"
-      id="react-tabs-3"
-      role="tabpanel"
-    />
-    <div
-      aria-labelledby="react-tabs-4"
-      className="react-tabs__tab-panel"
-      id="react-tabs-5"
-      role="tabpanel"
-    />
-    <div
-      aria-labelledby="react-tabs-6"
-      className="react-tabs__tab-panel"
-      id="react-tabs-7"
-      role="tabpanel"
-    />
   </div>
 </div>
 `;

--- a/src/components/UpcomingReleases/__tests__/__snapshots__/upcoming-releases.test.tsx.snap
+++ b/src/components/UpcomingReleases/__tests__/__snapshots__/upcoming-releases.test.tsx.snap
@@ -125,7 +125,7 @@ exports[`UpcomingReleases component renders correctly 1`] = `
             </p>
           </div>
           <div
-            class="upcoming-releases__item--endoflife"
+            class="upcoming-releases__item--endoflife upcoming-releases__item--already-released"
           >
             <img
               alt="hexagon icon"
@@ -139,7 +139,7 @@ exports[`UpcomingReleases component renders correctly 1`] = `
             <p
               class="release-date"
             >
-              Released
+              To be released
                
               2022-04-30
             </p>

--- a/src/components/UpcomingReleases/__tests__/__snapshots__/upcoming-releases.test.tsx.snap
+++ b/src/components/UpcomingReleases/__tests__/__snapshots__/upcoming-releases.test.tsx.snap
@@ -1,0 +1,173 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UpcomingReleases component renders correctly 1`] = `
+<div
+  className="upcoming-releases"
+>
+  <div
+    className="react-tabs"
+    data-tabs={true}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+  >
+    <ul
+      className="react-tabs__tab-list"
+      role="tablist"
+    >
+      <li
+        aria-controls="react-tabs-1"
+        aria-disabled="false"
+        aria-selected="true"
+        className="react-tabs__tab react-tabs__tab--selected"
+        id="react-tabs-0"
+        role="tab"
+        tabIndex="0"
+      >
+        Node.js 12
+      </li>
+      <li
+        aria-controls="react-tabs-3"
+        aria-disabled="false"
+        aria-selected="false"
+        className="react-tabs__tab"
+        id="react-tabs-2"
+        role="tab"
+        tabIndex={null}
+      >
+        Node.js 13
+      </li>
+      <li
+        aria-controls="react-tabs-5"
+        aria-disabled="false"
+        aria-selected="false"
+        className="react-tabs__tab"
+        id="react-tabs-4"
+        role="tab"
+        tabIndex={null}
+      >
+        Node.js 14
+      </li>
+      <li
+        aria-controls="react-tabs-7"
+        aria-disabled="false"
+        aria-selected="false"
+        className="react-tabs__tab"
+        id="react-tabs-6"
+        role="tab"
+        tabIndex={null}
+      >
+        Node.js 15
+      </li>
+    </ul>
+    <div
+      aria-labelledby="react-tabs-0"
+      className="react-tabs__tab-panel react-tabs__tab-panel--selected"
+      id="react-tabs-1"
+      role="tabpanel"
+    >
+      <div
+        className="upcoming-releases__panel"
+      >
+        <div
+          className="upcoming-releases__item--current"
+        >
+          <img
+            alt="hexagon icon"
+            src="test-file-stub"
+          />
+          <p
+            className="release-title"
+          >
+            Current
+          </p>
+          <p
+            className="release-date"
+          >
+            Released
+             
+            2019-04-23
+          </p>
+        </div>
+        <div
+          className="upcoming-releases__item--lts"
+        >
+          <img
+            alt="hexagon icon"
+            src="test-file-stub"
+          />
+          <p
+            className="release-title"
+          >
+            LTS
+          </p>
+          <p
+            className="release-date"
+          >
+            Released
+             
+            2019-10-21
+          </p>
+        </div>
+        <div
+          className="upcoming-releases__item--maintenance"
+        >
+          <img
+            alt="hexagon icon"
+            src="test-file-stub"
+          />
+          <p
+            className="release-title"
+          >
+            Maintenance Release
+          </p>
+          <p
+            className="release-date"
+          >
+            Released
+             
+            2020-10-20
+          </p>
+        </div>
+        <div
+          className="upcoming-releases__item--endoflife"
+        >
+          <img
+            alt="hexagon icon"
+            src="test-file-stub"
+          />
+          <p
+            className="release-title"
+          >
+            End-of-life Release
+          </p>
+          <p
+            className="release-date"
+          >
+            Released
+             
+            2022-04-30
+          </p>
+        </div>
+      </div>
+    </div>
+    <div
+      aria-labelledby="react-tabs-2"
+      className="react-tabs__tab-panel"
+      id="react-tabs-3"
+      role="tabpanel"
+    />
+    <div
+      aria-labelledby="react-tabs-4"
+      className="react-tabs__tab-panel"
+      id="react-tabs-5"
+      role="tabpanel"
+    />
+    <div
+      aria-labelledby="react-tabs-6"
+      className="react-tabs__tab-panel"
+      id="react-tabs-7"
+      role="tabpanel"
+    />
+  </div>
+</div>
+`;

--- a/src/components/UpcomingReleases/__tests__/upcoming-releases.test.tsx
+++ b/src/components/UpcomingReleases/__tests__/upcoming-releases.test.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
+import { render } from '@testing-library/react';
 import UpcomingReleases from '..';
 
 describe('UpcomingReleases component', (): void => {
   it('renders correctly', (): void => {
-    const tree = renderer.create(<UpcomingReleases />).toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<UpcomingReleases />);
+    expect(container).toMatchSnapshot();
   });
 });

--- a/src/components/UpcomingReleases/__tests__/upcoming-releases.test.tsx
+++ b/src/components/UpcomingReleases/__tests__/upcoming-releases.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import UpcomingReleases from '..';
+
+describe('UpcomingReleases component', (): void => {
+  it('renders correctly', (): void => {
+    const tree = renderer.create(<UpcomingReleases />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/components/UpcomingReleases/index.tsx
+++ b/src/components/UpcomingReleases/index.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
+import UpcomingReleasesPanel from './UpcomingReleasesPanel';
+import {
+  NODE_12_RELEASES,
+  NODE_13_RELEASES,
+  NODE_14_RELEASES,
+  NODE_15_RELEASES,
+} from './upcomingReleases';
+import './UpcomingReleases.scss';
+
+export default function UpcomingReleases(): JSX.Element {
+  return (
+    <div className="upcoming-releases">
+      <Tabs>
+        <TabList>
+          <Tab>Node.js 12</Tab>
+          <Tab>Node.js 13</Tab>
+          <Tab>Node.js 14</Tab>
+          <Tab>Node.js 15</Tab>
+        </TabList>
+        <TabPanel>
+          <UpcomingReleasesPanel releases={NODE_12_RELEASES} />
+        </TabPanel>
+        <TabPanel>
+          <UpcomingReleasesPanel releases={NODE_13_RELEASES} />
+        </TabPanel>
+        <TabPanel>
+          <UpcomingReleasesPanel releases={NODE_14_RELEASES} />
+        </TabPanel>
+        <TabPanel>
+          <UpcomingReleasesPanel releases={NODE_15_RELEASES} />
+        </TabPanel>
+      </Tabs>
+    </div>
+  );
+}

--- a/src/components/UpcomingReleases/upcomingReleases.ts
+++ b/src/components/UpcomingReleases/upcomingReleases.ts
@@ -30,7 +30,7 @@ export const NODE_12_RELEASES: UpcomingRelease[] = [
     releaseType: 'maintenance',
   },
   {
-    alreadyReleased: true,
+    alreadyReleased: false,
     releaseDate: '2022-04-30',
     releaseType: 'endoflife',
   },

--- a/src/components/UpcomingReleases/upcomingReleases.ts
+++ b/src/components/UpcomingReleases/upcomingReleases.ts
@@ -1,0 +1,96 @@
+export type ReleaseTypes = 'current' | 'lts' | 'maintenance' | 'endoflife';
+
+export type UpcomingRelease = {
+  releaseDate: string;
+  releaseType: ReleaseTypes;
+  alreadyReleased: boolean;
+};
+
+export const RELEASE_TYPES: { [key in ReleaseTypes]: string } = {
+  current: 'Current',
+  lts: 'LTS',
+  maintenance: 'Maintenance Release',
+  endoflife: 'End-of-life Release',
+};
+
+export const NODE_12_RELEASES: UpcomingRelease[] = [
+  {
+    alreadyReleased: true,
+    releaseDate: '2019-04-23',
+    releaseType: 'current',
+  },
+  {
+    alreadyReleased: true,
+    releaseDate: '2019-10-21',
+    releaseType: 'lts',
+  },
+  {
+    alreadyReleased: true,
+    releaseDate: '2020-10-20',
+    releaseType: 'maintenance',
+  },
+  {
+    alreadyReleased: true,
+    releaseDate: '2022-04-30',
+    releaseType: 'endoflife',
+  },
+];
+
+export const NODE_13_RELEASES: UpcomingRelease[] = [
+  {
+    alreadyReleased: true,
+    releaseDate: '2019-10-22',
+    releaseType: 'current',
+  },
+  {
+    alreadyReleased: true,
+    releaseDate: '2020-04-01',
+    releaseType: 'maintenance',
+  },
+  {
+    alreadyReleased: true,
+    releaseDate: '2020-06-01',
+    releaseType: 'endoflife',
+  },
+];
+
+export const NODE_14_RELEASES: UpcomingRelease[] = [
+  {
+    alreadyReleased: true,
+    releaseDate: '2020-04-21',
+    releaseType: 'current',
+  },
+  {
+    alreadyReleased: true,
+    releaseDate: '2020-10-20',
+    releaseType: 'lts',
+  },
+  {
+    alreadyReleased: false,
+    releaseDate: '2021-10-19',
+    releaseType: 'maintenance',
+  },
+  {
+    alreadyReleased: false,
+    releaseDate: '2023-04-30',
+    releaseType: 'endoflife',
+  },
+];
+
+export const NODE_15_RELEASES: UpcomingRelease[] = [
+  {
+    alreadyReleased: true,
+    releaseDate: '2020-10-21',
+    releaseType: 'current',
+  },
+  {
+    alreadyReleased: false,
+    releaseDate: '2021-04-01',
+    releaseType: 'maintenance',
+  },
+  {
+    alreadyReleased: false,
+    releaseDate: '2021-06-01',
+    releaseType: 'endoflife',
+  },
+];


### PR DESCRIPTION
## Description

This pr change the look and feel of tabs on "upcoming releases" section according to #987.

Notes:
- I add a parent div(with classname) to the `installTabs` component. So, it isolate the css properties / rules of "react-tab".  Without this prefix, the `installTabs` css rules affected the entire app.

- I moved the upcoming releases data to a separate file. So now the data does not depend on the UI/React code. Furthermore, it helps to reuse code so I created` UpcomingReleasesItem` component.

## Related Issues
Related to #987 
