### PR TITLE
Allow the Download page's table to scroll horizontally on small width viewports

### DIFF
--- a/src/components/DownloadReleases/DownloadReleases.scss
+++ b/src/components/DownloadReleases/DownloadReleases.scss
@@ -1,3 +1,7 @@
+.download-releases {
+  width: 100%;
+}
+
 .download-releases__title {
   margin: 126px 0 50px;
   font-weight: var(--font-weight-semibold);

--- a/src/components/DownloadReleases/DownloadTable.scss
+++ b/src/components/DownloadReleases/DownloadTable.scss
@@ -1,42 +1,46 @@
-.downloads-table {
-  color: var(--color-text-primary);
-  font-size: var(--font-size-body3);
+.downloads-table-container {
+  overflow-x: auto;
 
-  thead {
-    th {
-      background: var(--color-fill-body);
-      color: var(--color-text-primary);
-      text-align: left;
-      padding: var(--space-08) var(--space-16);
-      font-weight: normal;
+  .downloads-table {
+    color: var(--color-text-primary);
+    font-size: var(--font-size-body3);
+
+    thead {
+      th {
+        background: var(--color-fill-body);
+        color: var(--color-text-primary);
+        text-align: left;
+        padding: var(--space-08) var(--space-16);
+        font-weight: normal;
+      }
+      th:first-child {
+        border-radius: 3px 0px 0px 0px;
+      }
+      th:last-child {
+        border-radius: 0px 3px 0px 0px;
+      }
     }
-    th:first-child {
-      border-radius: 3px 0px 0px 0px;
-    }
-    th:last-child {
-      border-radius: 0px 3px 0px 0px;
-    }
-  }
 
-  tbody {
-    tr {
-      background: var(--color-fill-app);
+    tbody {
+      tr {
+        background: var(--color-fill-app);
 
-      td {
-        padding: var(--space-16) var(--space-16);
-        border-bottom: 1px solid #e2e3e7;
+        td {
+          padding: var(--space-16) var(--space-16);
+          border-bottom: 1px solid #e2e3e7;
 
-        .dark-mode & {
-          border-bottom: 1px solid var(--color-border-primary);
+          .dark-mode & {
+            border-bottom: 1px solid var(--color-border-primary);
+          }
         }
-      }
 
-      &:hover {
-        background: var(--brand10);
-      }
+        &:hover {
+          background: var(--brand10);
+        }
 
-      .dark-mode &:hover {
-        background: var(--brand9);
+        .dark-mode &:hover {
+          background: var(--brand9);
+        }
       }
     }
   }

--- a/src/components/DownloadReleases/DownloadTable.tsx
+++ b/src/components/DownloadReleases/DownloadTable.tsx
@@ -8,59 +8,63 @@ interface Props {
 }
 
 const DownloadTable = ({ releases }: Props): JSX.Element => (
-  <table className="downloads-table">
-    <thead>
-      <tr>
-        <th>Release</th>
-        <th>Status</th>
-        <th>Codename</th>
-        <th>Initial Release</th>
-        <th>Active LTS Start</th>
-        <th>Maintainance LTS Start</th>
-        <th>End of Life</th>
-      </tr>
-    </thead>
-    <tbody>
-      {releases.map(
-        ({
-          release,
-          status,
-          codename,
-          initialRelease,
-          activeLTSStart,
-          maintenanceLTSStart,
-          endOfLife,
-        }: NodeReleaseData): JSX.Element => {
-          // Check if release is pending or not
-          const isPending = status === 'Pending';
-          // Download hyperlink for release
-          const releaseDownloadLink = `https://nodejs.org/download/release/latest-${release}.x/`;
-          // Download hyperlink for codename
-          const codenameReleaseLink = `https://nodejs.org/download/release/latest-${codename.toLowerCase()}/`;
+  <div className="downloads-table-container">
+    <table className="downloads-table">
+      <thead>
+        <tr>
+          <th>Release</th>
+          <th>Status</th>
+          <th>Codename</th>
+          <th>Initial Release</th>
+          <th>Active LTS Start</th>
+          <th>Maintainance LTS Start</th>
+          <th>End of Life</th>
+        </tr>
+      </thead>
+      <tbody>
+        {releases.map(
+          ({
+            release,
+            status,
+            codename,
+            initialRelease,
+            activeLTSStart,
+            maintenanceLTSStart,
+            endOfLife,
+          }: NodeReleaseData): JSX.Element => {
+            // Check if release is pending or not
+            const isPending = status === 'Pending';
+            // Download hyperlink for release
+            const releaseDownloadLink = `https://nodejs.org/download/release/latest-${release}.x/`;
+            // Download hyperlink for codename
+            const codenameReleaseLink = `https://nodejs.org/download/release/latest-${codename.toLowerCase()}/`;
 
-          return (
-            <tr key={release}>
-              <td>
-                {isPending ? (
-                  release
-                ) : (
-                  <a href={releaseDownloadLink}>{release}</a>
-                )}
-              </td>
-              <td>{status || ''}</td>
-              <td>
-                {codename ? <a href={codenameReleaseLink}>{codename}</a> : null}
-              </td>
-              <td>{initialRelease}</td>
-              <td>{activeLTSStart}</td>
-              <td>{maintenanceLTSStart}</td>
-              <td>{endOfLife}</td>
-            </tr>
-          );
-        }
-      )}
-    </tbody>
-  </table>
+            return (
+              <tr key={release}>
+                <td>
+                  {isPending ? (
+                    release
+                  ) : (
+                    <a href={releaseDownloadLink}>{release}</a>
+                  )}
+                </td>
+                <td>{status || ''}</td>
+                <td>
+                  {codename ? (
+                    <a href={codenameReleaseLink}>{codename}</a>
+                  ) : null}
+                </td>
+                <td>{initialRelease}</td>
+                <td>{activeLTSStart}</td>
+                <td>{maintenanceLTSStart}</td>
+                <td>{endOfLife}</td>
+              </tr>
+            );
+          }
+        )}
+      </tbody>
+    </table>
+  </div>
 );
 
 export default DownloadTable;

--- a/src/components/DownloadReleases/__tests__/__snapshots__/download-releases.test.tsx.snap
+++ b/src/components/DownloadReleases/__tests__/__snapshots__/download-releases.test.tsx.snap
@@ -179,56 +179,60 @@ exports[`DownloadReleases component renders correctly 1`] = `
     >
       Major Node.js versions enter Current release status for six months, which gives library authors time to add support for them. After six months, odd-numbered releases (9, 11, etc.) become unsupported, and even-numbered releases (10, 12, etc.) move to Active LTS status and are ready for general use. LTS release status is "long-term support", which typically guarantees that critical bugs will be fixed for a total of 30 months. Production applications should only use Active LTS or Maintenance LTS releases.
     </p>
-    <table
-      class="downloads-table"
+    <div
+      class="downloads-table-container"
     >
-      <thead>
-        <tr>
-          <th>
-            Release
-          </th>
-          <th>
-            Status
-          </th>
-          <th>
-            Codename
-          </th>
-          <th>
-            Initial Release
-          </th>
-          <th>
-            Active LTS Start
-          </th>
-          <th>
-            Maintainance LTS Start
-          </th>
-          <th>
-            End of Life
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>
-            v15
-          </td>
-          <td>
-            Pending
-          </td>
-          <td />
-          <td>
-            2020-10-20
-          </td>
-          <td />
-          <td>
-            2021-04-01
-          </td>
-          <td>
-            2021-06-01
-          </td>
-        </tr>
-      </tbody>
-    </table>
+      <table
+        class="downloads-table"
+      >
+        <thead>
+          <tr>
+            <th>
+              Release
+            </th>
+            <th>
+              Status
+            </th>
+            <th>
+              Codename
+            </th>
+            <th>
+              Initial Release
+            </th>
+            <th>
+              Active LTS Start
+            </th>
+            <th>
+              Maintainance LTS Start
+            </th>
+            <th>
+              End of Life
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              v15
+            </td>
+            <td>
+              Pending
+            </td>
+            <td />
+            <td>
+              2020-10-20
+            </td>
+            <td />
+            <td>
+              2021-04-01
+            </td>
+            <td>
+              2021-06-01
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </div>
 </div>
 `;

--- a/src/components/DownloadReleases/__tests__/__snapshots__/download-table.test.tsx.snap
+++ b/src/components/DownloadReleases/__tests__/__snapshots__/download-table.test.tsx.snap
@@ -2,55 +2,59 @@
 
 exports[`DownloadTable component renders correctly 1`] = `
 <div>
-  <table
-    class="downloads-table"
+  <div
+    class="downloads-table-container"
   >
-    <thead>
-      <tr>
-        <th>
-          Release
-        </th>
-        <th>
-          Status
-        </th>
-        <th>
-          Codename
-        </th>
-        <th>
-          Initial Release
-        </th>
-        <th>
-          Active LTS Start
-        </th>
-        <th>
-          Maintainance LTS Start
-        </th>
-        <th>
-          End of Life
-        </th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>
-          v15
-        </td>
-        <td>
-          Pending
-        </td>
-        <td />
-        <td>
-          2020-10-20
-        </td>
-        <td />
-        <td>
-          2021-04-01
-        </td>
-        <td>
-          2021-06-01
-        </td>
-      </tr>
-    </tbody>
-  </table>
+    <table
+      class="downloads-table"
+    >
+      <thead>
+        <tr>
+          <th>
+            Release
+          </th>
+          <th>
+            Status
+          </th>
+          <th>
+            Codename
+          </th>
+          <th>
+            Initial Release
+          </th>
+          <th>
+            Active LTS Start
+          </th>
+          <th>
+            Maintainance LTS Start
+          </th>
+          <th>
+            End of Life
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            v15
+          </td>
+          <td>
+            Pending
+          </td>
+          <td />
+          <td>
+            2020-10-20
+          </td>
+          <td />
+          <td>
+            2021-04-01
+          </td>
+          <td>
+            2021-06-01
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
 </div>
 `;


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Allows the table to scroll when the viewport's width is smaller than the table's width.

Before:

![Animation showing the before behavior](https://user-images.githubusercontent.com/16027268/97383610-46aa0380-188b-11eb-805b-a1a0c2f864c8.gif)

After:

![Animation showing the after behavior](https://user-images.githubusercontent.com/16027268/97383615-49a4f400-188b-11eb-963e-da68225b28a6.gif)



## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
Fixes #1029

<!--
  If you want to generate a preview of this PR on our staging server please
  make a comment on the Pull-Request with the text `/preview`
 -->