### PR TITLE
Remove invalid gatsby-source-filesystem "include" option

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -27,7 +27,6 @@ module.exports = {
       options: {
         name: 'learn',
         path: `${__dirname}/src/documentation/`,
-        include: ['**/*.md'], // ignore files starting with a dot
       },
     },
     {
@@ -42,7 +41,6 @@ module.exports = {
       options: {
         name: 'homepage',
         path: `${__dirname}/content/homepage`,
-        include: ['**/*.md'], // ignore files starting with a dot
       },
     },
     {


### PR DESCRIPTION
## Description

This option does not exist anywhere in the `gatsby-source-filesystem` codebase and does not do anything. Submitting this PR now to ensure your website won't break once we introduce plugin option validation! :pray:

## Related Issues

N/A
