### PR TITLE
fix: Render installTabs properly for firefox on linux

### DIFF
--- a/src/components/InstallTabs/index.tsx
+++ b/src/components/InstallTabs/index.tsx
@@ -20,6 +20,7 @@ const InstallTabs = (): JSX.Element => {
     WIN: [os.win, os.mac, os.linux],
     MAC: [os.mac, os.win, os.linux],
     LINUX: [os.linux, os.mac, os.win],
+    UNIX: [os.linux, os.mac, os.win],
     UNKNOWN: [os.win, os.mac, os.linux],
   };
 
@@ -40,6 +41,7 @@ const InstallTabs = (): JSX.Element => {
           </>
         );
       case UserOS.LINUX:
+      case UserOS.UNIX:
         return (
           <>
             <TabPanel>


### PR DESCRIPTION
Firefox is detected as `UserOS.UNIX` by the detectOS module. (The `navigator.appVersion` output is `5.0 (X11)` ). Given that most users calssified under `UserOS.UNIX` will be using Firefox for Linux and the Linux commands generally run on other UNIX like systems (per https://techahboy.com/2020/08/02/how-to-install-nodejs-via-nvm-under-freebsd-12/), allow users whose OS is classified as UNIX to see the Linux commands.

Bug: #1007