### PR TITLE
style(ShellBox): Remove duplicate ShellBox styles

### DIFF
--- a/src/components/InstallTabs/InstallTabs.scss
+++ b/src/components/InstallTabs/InstallTabs.scss
@@ -108,15 +108,3 @@
     font-weight: var(--font-weight-semibold);
   }
 }
-.shell-box {
-  code {
-    color: var(--pink5);
-    width: calc(100% - 20px);
-    line-height: 30px;
-    > span.install__text__command {
-      color: #fff;
-    }
-  }
-  background-color: var(--black9);
-  padding-bottom: 15px;
-}

--- a/src/components/ShellBox/ShellBox.scss
+++ b/src/components/ShellBox/ShellBox.scss
@@ -2,7 +2,7 @@
   font-family: var(--mono);
   display: flex;
   flex-direction: column;
-  background-color: var(--black1);
+  background-color: var(--black9);
   border-radius: 0.4rem;
   box-sizing: border-box;
   padding: 0 0 var(--space-24) var(--space-16);
@@ -10,7 +10,13 @@
   code {
     overflow-x: auto;
     font-family: inherit;
-    color: var(--brand6);
+    color: var(--pink5);
+    width: calc(100% - 20px);
+    line-height: 30px;
+
+    > span.install__text__command {
+      color: #fff;
+    }
 
     > span.function {
       color: var(--warning5);

--- a/src/components/ShellBox/ShellBox.scss
+++ b/src/components/ShellBox/ShellBox.scss
@@ -15,7 +15,7 @@
     line-height: 30px;
 
     > span.install__text__command {
-      color: #fff;
+      color: var(--black0);
     }
 
     > span.function {


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Moves all the styling for the shell box to `Shellbox.scss` in an attempt to fix overriding styles. As discussed in https://github.com/nodejs/nodejs.dev/issues/1034 I was unable to test this locally so please do before merging.

## Related Issues

Resolves https://github.com/nodejs/nodejs.dev/issues/1034