### PR TITLE
fix(DownloadButton): Align DownloadButton styles with design

### DIFF
--- a/src/components/DownloadAdditional/DownloadAdditional.scss
+++ b/src/components/DownloadAdditional/DownloadAdditional.scss
@@ -34,7 +34,7 @@ $downloadable-item-height: 40px;
     transition: height 30ms ease-in;
 
     &__expanded {
-      height: calc(#{$downloadable-item-height} * 2);
+      height: auto;
     }
 
     &__header {
@@ -62,15 +62,18 @@ $downloadable-item-height: 40px;
     }
     &__body {
       display: flex;
+      flex-wrap: wrap;
       &__link {
         display: flex;
+        align-items: center;
         background: var(--brand2);
         color: var(--brand6);
         text-decoration: none;
         font-size: 14px;
+        line-height: 36px;
         border-radius: 40px;
-        margin: 13px 0 18px 18px;
-        padding: 6px 16px 4px 12px;
+        margin: 5px;
+        padding: 0 15px 0 0;
       }
     }
   }


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR updates styles for DownloadButton component in order to fix `/download` page Additional Download block

Before:
<img width="477" alt="Screenshot 2020-12-21 at 11 13 47" src="https://user-images.githubusercontent.com/5843270/102763848-ee6f1980-4382-11eb-85f0-66ab9887fd87.png">

After:
<img width="415" alt="Screenshot 2020-12-21 at 11 50 18" src="https://user-images.githubusercontent.com/5843270/102763834-e911cf00-4382-11eb-879e-2c72eca8d4a2.png">


## Related Issues
Fixes #1089 
