### PR TITLE
docs: add link to Prisma ORM

### DIFF
--- a/src/documentation/0056-node-with-typescript/index.md
+++ b/src/documentation/0056-node-with-typescript/index.md
@@ -120,6 +120,7 @@ Some of the notable examples of open-source projects using TypeScript are:
 
 * [NestJS](https://nestjs.com/) - robust and fully-featured framework that makes creating scalable and well-architected systems easy and pleasant
 * [TypeORM](https://typeorm.io/#/) - great ORM influenced by other well-known tools from other languages like Hibernate, Doctrine or Entity Framework
+* [Prisma](https://prisma.io/) - next-generation ORM featuring a declarative data model, generated migrations and fully type-safe database queries
 * [RxJS](https://rxjs.dev/) - widely used library for reactive programming
 
 And many, many more great projects... Maybe even your next one!


### PR DESCRIPTION
## Description

When pointing out helpful resources for building applications with TypeScript, I think it would be nice to also point people to [Prisma](https://www.prisma.io/) as an ORM. Prisma provides full type-safety for all DB queries (as opposed to TypeORM where [lots of type guarantees are missing](https://www.prisma.io/docs/concepts/more/comparisons/prisma-and-typeorm#type-safety)).
