### PR TITLE
Fix semantic mistake in npm list article

### DIFF
--- a/src/documentation/0021-npm-know-version-installed/index.md
+++ b/src/documentation/0021-npm-know-version-installed/index.md
@@ -5,7 +5,7 @@ authors: flaviocopes, MylesBorins, LaRuaNa, ahmadawais
 section: Getting Started
 ---
 
-To see the latest version of all installed npm packages, including their dependencies:
+To see the version of all installed npm packages, including their dependencies:
 
 ```bash
 npm list


### PR DESCRIPTION
Correct [`npm list`](https://docs.npmjs.com/cli/v6/commands/npm-ls) definition.