### PR TITLE
docs: Update links of nvm and correct its case of name

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ A quick look at some of the top-level files and directories found in this projec
 
 7. **`.gitignore`**: This file tells git which files it should not track/not maintain a version history.
 
-8. **`.nvmrc`**: NVM configuration so packages work as they should
+8. **`.nvmrc`**: nvm configuration so packages work as they should
 
 9. **`.prettierrc`**: This is a configuration file for a tool called [Prettier](https://prettier.io/), which is a tool to help keep the formatting of your code consistent.
 

--- a/src/documentation/0003-node-installation/index.md
+++ b/src/documentation/0003-node-installation/index.md
@@ -23,7 +23,7 @@ Other package managers for Linux and Windows are listed in <https://nodejs.org/e
 
 It is also very useful to test your code with old Node.js versions.
 
-See <https://github.com/creationix/nvm> for more information about this option.
+See <https://github.com/nvm-sh/nvm> for more information about this option.
 
 My suggestion is to use the official installer if you are just starting out and you don't use Homebrew already, otherwise, Homebrew is my favorite solution.
 

--- a/src/pages/docs.tsx
+++ b/src/pages/docs.tsx
@@ -400,7 +400,7 @@ function renderDefaultArticle(
       </p>
       <p className="t-body1">
         On Unix / OS X systems Node.js built from source can be installed
-        using&nbsp;<a href="https://github.com/creationix/nvm">nvm</a>&nbsp;by
+        using&nbsp;<a href="https://github.com/nvm-sh/nvm">nvm</a>&nbsp;by
         installing into the location that nvm expects:
       </p>
       <ShellBox


### PR DESCRIPTION
## Description

They moved the repository to the organization in [v0.35.0](https://github.com/nvm-sh/nvm/releases/tag/v0.35.0).