### PR TITLE
fix: override the BASE_PATH in storybook config

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -11,6 +11,7 @@ global.___loader = {
 
 // __PATH_PREFIX__ is used inside gatsby-link an other various places. For storybook not to crash, you need to set it as well.
 global.__PATH_PREFIX__ = '';
+global.__BASE_PATH__ = '';
 
 // Navigating through a gatsby app using gatsby-link or any other gatsby component will use the `___navigate` method.
 // In Storybook it makes more sense to log an action than doing an actual navigate. Checkout the actions addon docs for more info: https://github.com/storybookjs/storybook/tree/master/addons/actions.


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR overrides the `__BASE_PATH__` property on `global` to make it readily available to storybook in production build.

## Related Issues

Fixes #1092 

## How to test on local?

1. Checkout branch  - `git checkout fix-storybook-build-error`
2. Run command `npm run build-storybook`. This will generate a static storybook in prod env.
3. Navigate to `public/storybook` and open up `index.html` in a browser. All stories should be running fine.

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

<!--
  If you want to generate a preview of this PR on our staging server please
  make a comment on the Pull-Request with the text `/preview`
 -->