### PR TITLE
Fix npm tutorial scripts to use valid JSON example

### DIFF
--- a/src/documentation/0016-npm/index.md
+++ b/src/documentation/0016-npm/index.md
@@ -89,7 +89,7 @@ For example:
   "scripts": {
     "start-dev": "node lib/server-development",
     "start": "node lib/server-production"
-  },
+  }
 }
 ```
 
@@ -101,7 +101,7 @@ It's very common to use this feature to run Webpack:
     "watch": "webpack --watch --progress --colors --config webpack.conf.js",
     "dev": "webpack --progress --colors --config webpack.conf.js",
     "prod": "NODE_ENV=production webpack -p --config webpack.conf.js",
-  },
+  }
 }
 ```
 


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description
The package.json example of npm tutorial contains a ',' character in a place that we don't expect it. This breaks `npm run` as it complains that `package.json` is not in an actual json format.


```
$ npm --version
7.6.0
```

```
npm run start
npm ERR! code EJSONPARSE
npm ERR! path /Path/package.json
npm ERR! JSON.parse Unexpected token "}" (0x7D) in JSON at position 81 while parsing near "... \"node app.js\"\n  },\n}\n\n"
npm ERR! JSON.parse Failed to parse JSON data.
npm ERR! JSON.parse Note: package.json must be actual JSON, not just JavaScript.
```

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

<!--
  If you want to generate a preview of this PR on our staging server please
  make a comment on the Pull-Request with the text `/preview`
 -->