### PR TITLE
Propose Ammendment for getting Inquirer.js to work

### DIFF
--- a/src/documentation/0014-node-input-from-cli/index.md
+++ b/src/documentation/0014-node-input-from-cli/index.md
@@ -38,6 +38,9 @@ A more complete and abstract solution is provided by the [Inquirer.js package](h
 You can install it using `npm install inquirer`, and then you can replicate the above code like this:
 
 ```js
+import { createRequire } from "module";
+const require = createRequire(import.meta.url)
+
 const inquirer = require('inquirer')
 
 var questions = [


### PR DESCRIPTION
Hello, I had came across a replication problem, with Node providing me with a 'ReferenceError: require is not defined' after some searching I found that since I am using ESM to import everything, this work around allows me to import inquirer.js which is from what i can tell in a CJS format. This ammendment is suggested to work in both cases. 
Kindest Regards

<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

<!--
  If you want to generate a preview of this PR on our staging server please
  make a comment on the Pull-Request with the text `/preview`
 -->