### PR TITLE
Removed default value line.

### DIFF
--- a/src/documentation/0009-node-environment-variables/index.md
+++ b/src/documentation/0009-node-environment-variables/index.md
@@ -7,7 +7,7 @@ section: Getting Started
 
 The `process` core module of Node.js provides the `env` property which hosts all the environment variables that were set at the moment the process was started.
 
-Here is an example that accesses the NODE_ENV environment variable, which is set to `development` by default.
+Here is an example that accesses the NODE_ENV environment variable, it will return `undefined` untill the variable is set. After every change in `process.env`, you need to restart the server. 
 
 > Note: `process` does not require a "require", it's automatically available.
 


### PR DESCRIPTION
process.env.NODE_ENV doesn't have a default value as development. I just changed that to undefined. It is required to restart the server to after changing env variables, was also been added.

Thanks

<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

<!--
  If you want to generate a preview of this PR on our staging server please
  make a comment on the Pull-Request with the text `/preview`
 -->