### PR TITLE
Removed sentence for default value of process variables.

### DIFF
--- a/src/documentation/0009-node-environment-variables/index.md
+++ b/src/documentation/0009-node-environment-variables/index.md
@@ -7,7 +7,7 @@ section: Getting Started
 
 The `process` core module of Node.js provides the `env` property which hosts all the environment variables that were set at the moment the process was started.
 
-Here is an example that accesses the NODE_ENV environment variable, which is set to `development` by default.
+Here is an example that accesses the NODE_ENV environment variable, which will return `undefined` untill variable is set. After every change in `process.env` variables, you need to restart the server.
 
 > Note: `process` does not require a "require", it's automatically available.
 


### PR DESCRIPTION
process.env.NODE_ENV doesn't have a default value as development. I just changed that to undefined. It is required to restart the server to after changing env variables, was also been added.

## Description
It was earlier written as process.env.NODE_ENV has default values as development, but it is totally
wrong.

## Related Issues
The user will be always setting the value before using that.
