### PR TITLE
docs: Remove unused import from the read directory content example

### DIFF
--- a/src/documentation/0045-node-folders/index.md
+++ b/src/documentation/0045-node-folders/index.md
@@ -37,7 +37,6 @@ This piece of code reads the content of a folder, both files and subfolders, and
 
 ```js
 const fs = require('fs')
-const path = require('path')
 
 const folderPath = '/Users/joe'
 


### PR DESCRIPTION
## Description

The "Read the content of a directory" section contains an example with an import that's not being used (the `path` constant). This PR removes the unused `require()` call.