### PR TITLE
docs: Change 'like like that' to 'look like' in 'Node.js with Typescript' and add a comma

### DIFF
--- a/src/documentation/0056-node-with-typescript/index.md
+++ b/src/documentation/0056-node-with-typescript/index.md
@@ -49,7 +49,7 @@ npm install typescript
 
 Now we can compile it to JavaScript using `tsc` command in the terminal. Let's do it!
 
-Assuming that our file is named `example.ts` the command would like like that:
+Assuming that our file is named `example.ts`, the command would look like:
 
 ```bash
 tsc example.ts


### PR DESCRIPTION
## Description

docs: Change 'like like that' to 'look like' in 'Node.js with Typescript' documentation. Add a comma after the, "Assuming that our file is named `example.ts`"