### PR TITLE
docs: Change 'that' to 'this' in 'Node.js with Typescript'

### DIFF
--- a/src/documentation/0056-node-with-typescript/index.md
+++ b/src/documentation/0056-node-with-typescript/index.md
@@ -49,7 +49,7 @@ npm install typescript
 
 Now we can compile it to JavaScript using `tsc` command in the terminal. Let's do it!
 
-Assuming that our file is named `example.ts` the command would like like that:
+Assuming that our file is named `example.ts` the command would like like this:
 
 ```bash
 tsc example.ts


### PR DESCRIPTION
## Description

Change 'that' to 'this' in the 'Node.js with Typescript' documentation