### PR TITLE
Fix: Formatting and remark lint errors

### DIFF
--- a/.remarkignore
+++ b/.remarkignore
@@ -1,0 +1,1 @@
+src/documentation/0056-node-with-typescript

--- a/content/community/index.md
+++ b/content/community/index.md
@@ -47,7 +47,7 @@ Node.js has a dedicated [repository on GitHub](https://github.com/nodejs/help) t
 ### Real-time Chat
 For real-time chat about Node.js development use the [OpenJS Foundation Slack](https://slack-invite.openjsf.org/) or IRC
 For Slack, join the OpenJSF workspace and then join the [#nodejs](https://openjs-foundation.slack.com/archives/CK9Q4MB53) channel or [Node.js Slackers](https://www.nodeslackers.com/)
-For IRC, go to irc.freenode.net in the #node.js channel with an [IRC client](https://en.wikipedia.org/wiki/Comparison_of_Internet_Relay_Chat_clients) or connect in your web browser to the channel using [freenode's WebChat](https://webchat.freenode.net/#node.js).
+For IRC, go to irc.freenode.net in the #Node.js channel with an [IRC client](https://en.wikipedia.org/wiki/Comparison_of_Internet_Relay_Chat_clients) or connect in your web browser to the channel using [freenode's WebChat](https://webchat.freenode.net/#node.js).
 
 ### Stack Overflow
 

--- a/src/util/konami.ts
+++ b/src/util/konami.ts
@@ -16,20 +16,23 @@ if (typeof window !== `undefined`) {
     let buffer = '';
     let lastDate = Date.now();
 
-    document.addEventListener('keyup', function triggerKonami({
-      keyCode,
-    }): void {
-      if (!VALID_KEYS.has(keyCode)) {
-        return;
+    document.addEventListener(
+      'keyup',
+      function triggerKonami({ keyCode }): void {
+        if (!VALID_KEYS.has(keyCode)) {
+          return;
+        }
+        buffer = `${
+          Date.now() - lastDate >= MAX_DELAY ? '' : buffer
+        }${keyCode}`;
+        lastDate = Date.now();
+        if (!contains(buffer, CODE_SEQUENCE)) {
+          return;
+        }
+        document.dispatchEvent(KONAMI_EVENT);
+        buffer = '';
       }
-      buffer = `${Date.now() - lastDate >= MAX_DELAY ? '' : buffer}${keyCode}`;
-      lastDate = Date.now();
-      if (!contains(buffer, CODE_SEQUENCE)) {
-        return;
-      }
-      document.dispatchEvent(KONAMI_EVENT);
-      buffer = '';
-    });
+    );
   })();
 
   let discoMode: NodeJS.Timeout | null = null;


### PR DESCRIPTION
## Description
Ran prettier for `/src/utils/konami.ts`, and added a `.remarkignore` file for `src/documentation/0056-node-with-typescript/index.md` since it uses `ts` code blocks, which are not getting recognised by the linter.

## Related Issues
Fixes #1181 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

<!--
  If you want to generate a preview of this PR on our staging server please
  make a comment on the Pull-Request with the text `/preview`
 -->