### PR TITLE
fix: Color contrast a11y issues on homepage

### DIFF
--- a/src/components/InstallTabs/InstallTabs.scss
+++ b/src/components/InstallTabs/InstallTabs.scss
@@ -18,13 +18,13 @@
       position: relative;
       list-style: none;
       padding: 10px 12px;
-      background: #515c62;
+      background: var(--black11);
       cursor: pointer;
       width: 100%;
       text-align: center;
 
       &--selected {
-        background: #1f272a;
+        background: var(--black10);
         color: #fff;
         border-radius: 5px 5px 0 0;
       }
@@ -42,7 +42,7 @@
           left: 0;
           right: 0;
           bottom: -5px;
-          background: #1f272a;
+          background: var(--black10);
         }
       }
     }

--- a/src/components/InstallTabs/InstallTabs.scss
+++ b/src/components/InstallTabs/InstallTabs.scss
@@ -18,13 +18,13 @@
       position: relative;
       list-style: none;
       padding: 10px 12px;
-      background: var(--black8);
+      background: #515c62;
       cursor: pointer;
       width: 100%;
       text-align: center;
 
       &--selected {
-        background: var(--black9);
+        background: #1f272a;
         color: #fff;
         border-radius: 5px 5px 0 0;
       }
@@ -42,7 +42,7 @@
           left: 0;
           right: 0;
           bottom: -5px;
-          background: var(--black9);
+          background: #1f272a;
         }
       }
     }

--- a/src/components/ShellBox/ShellBox.scss
+++ b/src/components/ShellBox/ShellBox.scss
@@ -2,7 +2,7 @@
   font-family: var(--mono);
   display: flex;
   flex-direction: column;
-  background-color: var(--black9);
+  background-color: #1f272a;
   border-radius: 0.4rem;
   box-sizing: border-box;
   padding: 0 0 var(--space-24) var(--space-16);

--- a/src/components/ShellBox/ShellBox.scss
+++ b/src/components/ShellBox/ShellBox.scss
@@ -2,7 +2,7 @@
   font-family: var(--mono);
   display: flex;
   flex-direction: column;
-  background-color: #1f272a;
+  background-color: var(--black10);
   border-radius: 0.4rem;
   box-sizing: border-box;
   padding: 0 0 var(--space-24) var(--space-16);

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -32,7 +32,7 @@
   margin: 0 auto;
   margin-bottom: 240px;
   height: 450px;
-  background: var(--black9);
+  background: #1f272a;
   border-radius: var(--space-04);
   box-shadow: 5px 10px 50px rgba(0, 0, 0, 0.25);
   color: var(--black0);

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -32,7 +32,7 @@
   margin: 0 auto;
   margin-bottom: 240px;
   height: 450px;
-  background: #1f272a;
+  background: var(--black10);
   border-radius: var(--space-04);
   box-shadow: 5px 10px 50px rgba(0, 0, 0, 0.25);
   color: var(--black0);

--- a/src/styles/install-tabs.scss
+++ b/src/styles/install-tabs.scss
@@ -22,7 +22,7 @@
     text-align: center;
 
     &--selected {
-      background: #1f272a;
+      background: var(--black10);
       color: #fff;
       border-radius: 5px 5px 0 0;
     }

--- a/src/styles/install-tabs.scss
+++ b/src/styles/install-tabs.scss
@@ -22,7 +22,7 @@
     text-align: center;
 
     &--selected {
-      background: var(--black9);
+      background: #1f272a;
       color: #fff;
       border-radius: 5px 5px 0 0;
     }

--- a/src/styles/tokens.scss
+++ b/src/styles/tokens.scss
@@ -32,6 +32,8 @@ body {
   --black7: #6e7b83;
   --black8: #556066;
   --black9: #2c3437;
+  --black10: #1f272a;
+  --black11: #515c62;
   --body0: #f2f2f2;
   --warning1: #fdf3e7;
   --warning2: #fad9b0;


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description
Changed background colors of the terminal window on homepage to the `Pa11y` recommended colors to increase contrast on: 
- selected tab 
- tabs that are not selected 

Note: text colors are unchanged

## Related Issues
Fixes https://github.com/nodejs/nodejs.dev/issues/1108
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

<!--
  If you want to generate a preview of this PR on our staging server please
  make a comment on the Pull-Request with the text `/preview`
 -->