### PR TITLE
docs: update the semver example to respect the caret ranges

### DIFF
--- a/src/documentation/0020-package-lock-json/index.md
+++ b/src/documentation/0020-package-lock-json/index.md
@@ -13,13 +13,13 @@ The goal of `package-lock.json` file is to keep track of the exact version of ev
 
 This solves a very specific problem that `package.json` left unsolved. In package.json you can set which versions you want to upgrade to (patch or minor), using the **semver** notation, for example:
 
-* if you write `~0.13.0`, you want to only update patch releases: `0.13.1` is ok, but `0.14.0` is not.
-* if you write `^0.13.0`, you want to update patch and minor releases: `0.13.1`, `0.14.0` and so on.
-* if you write `0.13.0`, that is the exact version that will be used, always
+* if you write `~1.13.0`, you want to only update patch releases: `1.13.1` is ok, but `1.14.0` is not.
+* if you write `^1.13.0`, you want to update patch and minor releases: `1.14.0`, `1.15.0` and so on.
+* if you write `1.13.0`, that is the exact version that will be used, always
 
 You don't commit to Git your node_modules folder, which is generally huge, and when you try to replicate the project on another machine by using the `npm install` command, if you specified the `~` syntax and a patch release of a package has been released, that one is going to be installed. Same for `^` and minor releases.
 
-> If you specify exact versions, like `0.13.0` in the example, you are not affected by this problem.
+> If you specify exact versions, like `1.13.0` in the example, you are not affected by this problem.
 
 It could be you, or another person trying to initialize the project on the other side of the world by running `npm install`.
 


### PR DESCRIPTION
I've updated the example for semver in the package-lock documentation because the previous example didn't respect the caret rules.
The rule is "allows changes that do not modify the left-most non-zero digit in the [major, minor, patch] tuple"

Then ^0.13.0 = >=0.13.0 <0.14.0 but in the previous example, it's specified : " 0.13.1, 0.14.0 and so on"

more information : https://docs.npmjs.com/cli/v7/using-npm/semver#caret-ranges-123-025-004

