### PR TITLE
Added missing category field

### DIFF
--- a/src/documentation/0056-node-with-typescript/index.md
+++ b/src/documentation/0056-node-with-typescript/index.md
@@ -3,6 +3,7 @@ title: 'Node.js with TypeScript'
 description: 'Find out why TypeScript is an awesome tool and learn to use it by yourself.'
 authors: sbielenica
 section: Getting Started
+category: learn
 ---
 
 ## What is TypeScript


### PR DESCRIPTION
## Description

The `category` field in the front matter was missed in one of the documentation files in #1282. This PR fixes that.