### PR TITLE
style: Centering footer on desktop

### DIFF
--- a/src/components/Footer/footer.scss
+++ b/src/components/Footer/footer.scss
@@ -1,6 +1,6 @@
 .footer {
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
   flex-wrap: wrap;
   margin: 0;
   margin-top: auto;


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Center footer on desktop view. It looks better centered on desktop imo. See below for change. I accidentally mislabeled my branch and commit, my bad.

<img width="791" alt="Screen Shot 2021-05-16 at 6 52 35 AM" src="https://user-images.githubusercontent.com/40124399/118396061-4dc01580-b613-11eb-93e8-008dc99f5d93.png">

changes to this

<img width="776" alt="Screen Shot 2021-05-16 at 6 52 55 AM" src="https://user-images.githubusercontent.com/40124399/118396074-59134100-b613-11eb-853d-1544841934ff.png">
