### PR TITLE
style: Hide download button from header in mobile view

### DIFF
--- a/src/components/Header/__tests__/__snapshots__/header.test.tsx.snap
+++ b/src/components/Header/__tests__/__snapshots__/header.test.tsx.snap
@@ -321,16 +321,6 @@ exports[`Tests for Header component renders shorter menu items for mobile 1`] = 
           >
             <a
               class="activeStyleTab"
-              href="/download"
-            >
-              Download
-            </a>
-          </li>
-          <li
-            class="nav__tabs"
-          >
-            <a
-              class="activeStyleTab"
               href="https://nodejs.org/en/get-involved/"
               rel="noopener noreferrer"
               target="_blank"

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -6,7 +6,7 @@ import logoDark from '../../images/logos/nodejs-logo-dark-mode.svg';
 import { useMediaQuery } from '../../hooks/useMediaQuery';
 
 const Header = (): JSX.Element => {
-  const isMobile = useMediaQuery('(max-width: 870px)');
+  const isMobile = useMediaQuery('(max-width: 768px)');
 
   const handleThemeOnClick = (
     e: MouseEvent<HTMLButtonElement, Event> | KeyboardEvent<HTMLButtonElement>,
@@ -62,16 +62,18 @@ const Header = (): JSX.Element => {
                 {isMobile ? 'Docs' : 'Documentation'}
               </a>
             </li>
-            <li className="nav__tabs">
-              <Link
-                to="/download"
-                className="activeStyleTab"
-                activeClassName="active"
-                partiallyActive
-              >
-                Download
-              </Link>
-            </li>
+            {!isMobile && (
+              <li className="nav__tabs">
+                <Link
+                  to="/download"
+                  className="activeStyleTab"
+                  activeClassName="active"
+                  partiallyActive
+                >
+                  Download
+                </Link>
+              </li>
+            )}
             <li className="nav__tabs">
               <a
                 href="https://nodejs.org/en/get-involved/"


### PR DESCRIPTION
## Description

* Hide the download header button on mobile view.
* Change width considered mobile from `870` -> `768` to better align with industry standard 

## Related Issues

Closes #1322 

Mobile view:

<img width="401" alt="Screen Shot 2021-05-18 at 5 46 52 AM" src="https://user-images.githubusercontent.com/40124399/118638430-74f61e80-b79c-11eb-8eff-f407d8bd1c56.png">


