### PR TITLE
docs: update nodejs installation on windows to `nvs`

### DIFF
--- a/src/components/InstallTabs/WindowsPanel/index.tsx
+++ b/src/components/InstallTabs/WindowsPanel/index.tsx
@@ -5,15 +5,23 @@ import '../InstallTabs.scss';
 const WindowsPanel = (): JSX.Element => {
   return (
     <div>
-      <ShellBox textToCopy="choco install nodejs-lts">
+      <ShellBox textToCopy="choco install nvs">
         <span className="install__text__no-select">$</span>
-        <span className="install__text__command">choco </span>install nodejs-lts
+        <span className="install__text__command">choco </span>install nvs
+      </ShellBox>
+      <ShellBox textToCopy="nvs add lts">
+        <span className="install__text__no-select">$</span>
+        <span className="install__text__command">nvs </span>add lts
+      </ShellBox>
+      <ShellBox textToCopy="nvs use lts">
+        <span className="install__text__no-select">$</span>
+        <span className="install__text__command">nvs </span>use lts
       </ShellBox>
       <br />
       <br />
       <a
         className="install__docs-button"
-        href="https://nodejs.org/en/download/package-manager/#windows"
+        href="https://nodejs.org/en/download/package-manager/#nvs"
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/src/components/InstallTabs/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/InstallTabs/__tests__/__snapshots__/index.tsx.snap
@@ -100,14 +100,72 @@ exports[`Tests for InstallTabs component renders correctly 1`] = `
               >
                 choco 
               </span>
-              install nodejs-lts
+              install nvs
+            </code>
+          </pre>
+          <pre
+            class="shell-box"
+          >
+            <div
+              class="shell-box-top"
+            >
+              <span>
+                SHELL
+              </span>
+              <button
+                type="button"
+              >
+                copy
+              </button>
+            </div>
+            <code>
+              <span
+                class="install__text__no-select"
+              >
+                $
+              </span>
+              <span
+                class="install__text__command"
+              >
+                nvs 
+              </span>
+              add lts
+            </code>
+          </pre>
+          <pre
+            class="shell-box"
+          >
+            <div
+              class="shell-box-top"
+            >
+              <span>
+                SHELL
+              </span>
+              <button
+                type="button"
+              >
+                copy
+              </button>
+            </div>
+            <code>
+              <span
+                class="install__text__no-select"
+              >
+                $
+              </span>
+              <span
+                class="install__text__command"
+              >
+                nvs 
+              </span>
+              use lts
             </code>
           </pre>
           <br />
           <br />
           <a
             class="install__docs-button"
-            href="https://nodejs.org/en/download/package-manager/#windows"
+            href="https://nodejs.org/en/download/package-manager/#nvs"
             rel="noopener noreferrer"
             target="_blank"
           >
@@ -792,14 +850,72 @@ exports[`Tests for InstallTabs component renders correctly for other 1`] = `
               >
                 choco 
               </span>
-              install nodejs-lts
+              install nvs
+            </code>
+          </pre>
+          <pre
+            class="shell-box"
+          >
+            <div
+              class="shell-box-top"
+            >
+              <span>
+                SHELL
+              </span>
+              <button
+                type="button"
+              >
+                copy
+              </button>
+            </div>
+            <code>
+              <span
+                class="install__text__no-select"
+              >
+                $
+              </span>
+              <span
+                class="install__text__command"
+              >
+                nvs 
+              </span>
+              add lts
+            </code>
+          </pre>
+          <pre
+            class="shell-box"
+          >
+            <div
+              class="shell-box-top"
+            >
+              <span>
+                SHELL
+              </span>
+              <button
+                type="button"
+              >
+                copy
+              </button>
+            </div>
+            <code>
+              <span
+                class="install__text__no-select"
+              >
+                $
+              </span>
+              <span
+                class="install__text__command"
+              >
+                nvs 
+              </span>
+              use lts
             </code>
           </pre>
           <br />
           <br />
           <a
             class="install__docs-button"
-            href="https://nodejs.org/en/download/package-manager/#windows"
+            href="https://nodejs.org/en/download/package-manager/#nvs"
             rel="noopener noreferrer"
             target="_blank"
           >

--- a/test/pages/__snapshots__/home.test.tsx.snap
+++ b/test/pages/__snapshots__/home.test.tsx.snap
@@ -290,14 +290,72 @@ exports[`Home page renders correctly 1`] = `
                       >
                         choco 
                       </span>
-                      install nodejs-lts
+                      install nvs
+                    </code>
+                  </pre>
+                  <pre
+                    class="shell-box"
+                  >
+                    <div
+                      class="shell-box-top"
+                    >
+                      <span>
+                        SHELL
+                      </span>
+                      <button
+                        type="button"
+                      >
+                        copy
+                      </button>
+                    </div>
+                    <code>
+                      <span
+                        class="install__text__no-select"
+                      >
+                        $
+                      </span>
+                      <span
+                        class="install__text__command"
+                      >
+                        nvs 
+                      </span>
+                      add lts
+                    </code>
+                  </pre>
+                  <pre
+                    class="shell-box"
+                  >
+                    <div
+                      class="shell-box-top"
+                    >
+                      <span>
+                        SHELL
+                      </span>
+                      <button
+                        type="button"
+                      >
+                        copy
+                      </button>
+                    </div>
+                    <code>
+                      <span
+                        class="install__text__no-select"
+                      >
+                        $
+                      </span>
+                      <span
+                        class="install__text__command"
+                      >
+                        nvs 
+                      </span>
+                      use lts
                     </code>
                   </pre>
                   <br />
                   <br />
                   <a
                     class="install__docs-button"
-                    href="https://nodejs.org/en/download/package-manager/#windows"
+                    href="https://nodejs.org/en/download/package-manager/#nvs"
                     rel="noopener noreferrer"
                     target="_blank"
                   >


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description
Updated windows install tab with `nvs` guideline.
<!-- Write a brief description of the changes introduced by this PR -->
In NodeJs docs, we have updated the `nvs` installation steps. `nvs` could be used to install NodeJs in Windows, macOS, and Unix-Like systems. https://github.com/nodejs/nodejs.org/pull/3874

Since we are recommending package manager for macOS and Unix-like systems, updating the Windows installation Tab with `nvs`

Evidence:
![image](https://user-images.githubusercontent.com/26359740/118705688-272df480-b836-11eb-85f3-2a9b36012c12.png)


## Related Issues
https://github.com/nodejs/nodejs.org/issues/3873
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

<!--
  If you want to generate a preview of this PR on our staging server please
  make a comment on the Pull-Request with the text `/preview`
 -->