### PR TITLE
Add SideBar for `About` Pages

### DIFF
--- a/src/components/AboutPageSideNavBar/index.tsx
+++ b/src/components/AboutPageSideNavBar/index.tsx
@@ -1,0 +1,92 @@
+import React, { useRef, useState } from 'react';
+import { AboutPageSideNavBarItem } from '../../types';
+import NavigationItem from '../NavigationItem';
+import '../../styles/about.scss';
+
+// eslint-disable-next-line no-shadow
+export enum AboutPageKeys {
+  about = '',
+  governance = 'governance',
+  community = 'community',
+  workingGroups = 'working-groups',
+  releases = 'releases',
+  resources = 'resources',
+  trademark = 'trademark',
+  privacy = 'privacy',
+}
+
+const aboutPageSideNavBarItem: AboutPageSideNavBarItem[] = [
+  {
+    title: 'About',
+    slug: AboutPageKeys.about,
+  },
+  {
+    title: 'Project Governance',
+    slug: AboutPageKeys.governance,
+  },
+  {
+    title: 'Community',
+    slug: AboutPageKeys.community,
+  },
+  {
+    title: 'Working Groups',
+    slug: AboutPageKeys.workingGroups,
+  },
+  {
+    title: 'Releases',
+    slug: AboutPageKeys.releases,
+  },
+  {
+    title: 'Resources',
+    slug: AboutPageKeys.resources,
+  },
+  {
+    title: 'Trademark Policy',
+    slug: AboutPageKeys.trademark,
+  },
+  {
+    title: 'Privacy Policy',
+    slug: AboutPageKeys.privacy,
+  },
+];
+
+export default function AboutPageSideNavBar({
+  pageKey,
+}: {
+  pageKey: string;
+}): JSX.Element {
+  const [navOpen, setNavOpen] = useState<boolean>(false);
+  const toggle = (): void => setNavOpen(!navOpen);
+
+  const className = navOpen
+    ? 'side-nav-about side-nav--open'
+    : 'side-nav-about';
+  const navElement = useRef<HTMLElement | null>(null);
+  return (
+    <>
+      {' '}
+      <nav className={className} ref={navElement}>
+        <button type="button" className="side-nav__open" onClick={toggle}>
+          Menu
+        </button>
+        <ul className="community-nav__list">
+          {aboutPageSideNavBarItem.map(({ title: commTitle, slug }) => {
+            return (
+              <>
+                <NavigationItem
+                  key={slug}
+                  title={commTitle}
+                  isLearn={false}
+                  isRead={false}
+                  isActive={slug === pageKey}
+                  slug={slug}
+                  baseUrl="/"
+                />
+              </>
+            );
+          })}
+        </ul>
+      </nav>
+    </>
+  );
+}

--- a/src/components/NavigationItem/index.tsx
+++ b/src/components/NavigationItem/index.tsx
@@ -9,6 +9,7 @@ interface Props {
   isActive: boolean;
   slug: string;
   title: string;
+  baseUrl?: string;
   onClick?: () => void;
 }
 
@@ -18,6 +19,7 @@ const NavigationItem = ({
   isActive,
   slug,
   title,
+  baseUrl,
   onClick,
 }: Props): JSX.Element => {
   const className = isLearn
@@ -31,7 +33,7 @@ const NavigationItem = ({
 
   return (
     <Link
-      to={`/learn/${slug}`}
+      to={`${baseUrl || '/learn/'}${slug}`}
       id={`link-${slug}`}
       onClick={onClick}
       className={className}

--- a/src/pages/trademark.tsx
+++ b/src/pages/trademark.tsx
@@ -5,15 +5,20 @@ import Layout from '../components/Layout';
 import Article from '../components/Article';
 import Footer from '../components/Footer';
 import '../styles/article-reader.scss';
+import AboutPageSideNavBar, {
+  AboutPageKeys,
+} from '../components/AboutPageSideNavBar';
 
 export default function TrademarkPage({ data }: Page): JSX.Element {
   const { title, description } = data.page.frontmatter;
   const { html, tableOfContents } = data.page;
   const { authors } = data.page.fields;
+
   return (
     <>
       <Layout title={title} description={description} showFooter={false}>
-        <main className="centered-container">
+        <main className="streched-container">
+          <AboutPageSideNavBar pageKey={AboutPageKeys.trademark} />
           <Article
             title={title}
             html={html}

--- a/src/styles/about.scss
+++ b/src/styles/about.scss
@@ -1,0 +1,7 @@
+@import 'learn.scss';
+
+.side-nav-about {
+  @extend .side-nav;
+  overflow: hidden;
+  position: inherit;
+}

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -562,3 +562,9 @@ details {
 .bg-node-gray {
   background-color: #333;
 }
+
+.streched-container {
+  display: flex;
+  justify-content: stretch;
+  width: fit-content;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -136,3 +136,8 @@ export interface BlogPageContext {
   previous: PaginationInfo;
   navigationData: NavigationSectionData;
 }
+
+export interface AboutPageSideNavBarItem {
+  title: string;
+  slug: string;
+}

--- a/stories/NavigationItem.stories.tsx
+++ b/stories/NavigationItem.stories.tsx
@@ -21,5 +21,6 @@ export const root = (): JSX.Element => (
     slug="versioning"
     onClick={noop}
     title="Navigation Item"
+    baseUrl="/"
   />
 );

--- a/test/components/__snapshots__/aboutPageSideNavBar.test.tsx.snap
+++ b/test/components/__snapshots__/aboutPageSideNavBar.test.tsx.snap
@@ -1,0 +1,153 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AboutPageSideNavBar renders correctly 1`] = `
+<div>
+   
+  <nav
+    class="side-nav-about"
+  >
+    <button
+      class="side-nav__open"
+      type="button"
+    >
+      Menu
+    </button>
+    <ul
+      class="community-nav__list"
+    >
+      <a
+        class="t-body2 side-nav__item-community"
+        href="/"
+        id="link-"
+      >
+        About
+      </a>
+      <a
+        class="t-body2 side-nav__item-community"
+        href="/governance"
+        id="link-governance"
+      >
+        Project Governance
+      </a>
+      <a
+        class="t-body2 side-nav__item-community"
+        href="/community"
+        id="link-community"
+      >
+        Community
+      </a>
+      <a
+        class="t-body2 side-nav__item-community"
+        href="/working-groups"
+        id="link-working-groups"
+      >
+        Working Groups
+      </a>
+      <a
+        class="t-body2 side-nav__item-community"
+        href="/releases"
+        id="link-releases"
+      >
+        Releases
+      </a>
+      <a
+        class="t-body2 side-nav__item-community"
+        href="/resources"
+        id="link-resources"
+      >
+        Resources
+      </a>
+      <a
+        class="t-body2 side-nav__item-community side-nav__item-community--active"
+        href="/trademark"
+        id="link-trademark"
+      >
+        Trademark Policy
+      </a>
+      <a
+        class="t-body2 side-nav__item-community"
+        href="/privacy"
+        id="link-privacy"
+      >
+        Privacy Policy
+      </a>
+    </ul>
+  </nav>
+</div>
+`;
+
+exports[`AboutPageSideNavBar should about Releases page exist and contain a href to \`~/release\` 1`] = `
+<div>
+   
+  <nav
+    class="side-nav-about"
+  >
+    <button
+      class="side-nav__open"
+      type="button"
+    >
+      Menu
+    </button>
+    <ul
+      class="community-nav__list"
+    >
+      <a
+        class="t-body2 side-nav__item-community"
+        href="/"
+        id="link-"
+      >
+        About
+      </a>
+      <a
+        class="t-body2 side-nav__item-community"
+        href="/governance"
+        id="link-governance"
+      >
+        Project Governance
+      </a>
+      <a
+        class="t-body2 side-nav__item-community"
+        href="/community"
+        id="link-community"
+      >
+        Community
+      </a>
+      <a
+        class="t-body2 side-nav__item-community"
+        href="/working-groups"
+        id="link-working-groups"
+      >
+        Working Groups
+      </a>
+      <a
+        class="t-body2 side-nav__item-community side-nav__item-community--active"
+        href="/releases"
+        id="link-releases"
+      >
+        Releases
+      </a>
+      <a
+        class="t-body2 side-nav__item-community"
+        href="/resources"
+        id="link-resources"
+      >
+        Resources
+      </a>
+      <a
+        class="t-body2 side-nav__item-community"
+        href="/trademark"
+        id="link-trademark"
+      >
+        Trademark Policy
+      </a>
+      <a
+        class="t-body2 side-nav__item-community"
+        href="/privacy"
+        id="link-privacy"
+      >
+        Privacy Policy
+      </a>
+    </ul>
+  </nav>
+</div>
+`;

--- a/test/components/aboutPageSideNavBar.test.tsx
+++ b/test/components/aboutPageSideNavBar.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import AboutPageSideNavBar, {
+  AboutPageKeys,
+} from '../../src/components/AboutPageSideNavBar';
+
+describe('AboutPageSideNavBar', () => {
+  it('renders correctly', () => {
+    const { container } = render(
+      <AboutPageSideNavBar pageKey={AboutPageKeys.trademark} />
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should about Releases page exist and contain a href to `~/release`', () => {
+    const { container } = render(
+      <AboutPageSideNavBar pageKey={AboutPageKeys.releases} />
+    );
+    expect(container).toMatchSnapshot();
+    expect(container.innerHTML).toContain('href="/releases');
+  });
+
+  it('should set the a single page as active', () => {
+    const { container } = render(
+      <AboutPageSideNavBar pageKey={AboutPageKeys.releases} />
+    );
+    const innrerHtml = container.innerHTML;
+    const activeLinks = innrerHtml.match('side-nav__item-community--active');
+    expect(activeLinks.length).toBe(1);
+  });
+});

--- a/test/pages/__snapshots__/trademark.test.tsx.snap
+++ b/test/pages/__snapshots__/trademark.test.tsx.snap
@@ -142,8 +142,79 @@ exports[`Trademark page renders correctly 1`] = `
       </div>
     </nav>
     <main
-      class="centered-container"
+      class="streched-container"
     >
+       
+      <nav
+        class="side-nav-about"
+      >
+        <button
+          class="side-nav__open"
+          type="button"
+        >
+          Menu
+        </button>
+        <ul
+          class="community-nav__list"
+        >
+          <a
+            class="t-body2 side-nav__item-community"
+            href="/"
+            id="link-"
+          >
+            About
+          </a>
+          <a
+            class="t-body2 side-nav__item-community"
+            href="/governance"
+            id="link-governance"
+          >
+            Project Governance
+          </a>
+          <a
+            class="t-body2 side-nav__item-community"
+            href="/community"
+            id="link-community"
+          >
+            Community
+          </a>
+          <a
+            class="t-body2 side-nav__item-community"
+            href="/working-groups"
+            id="link-working-groups"
+          >
+            Working Groups
+          </a>
+          <a
+            class="t-body2 side-nav__item-community"
+            href="/releases"
+            id="link-releases"
+          >
+            Releases
+          </a>
+          <a
+            class="t-body2 side-nav__item-community"
+            href="/resources"
+            id="link-resources"
+          >
+            Resources
+          </a>
+          <a
+            class="t-body2 side-nav__item-community side-nav__item-community--active"
+            href="/trademark"
+            id="link-trademark"
+          >
+            Trademark Policy
+          </a>
+          <a
+            class="t-body2 side-nav__item-community"
+            href="/privacy"
+            id="link-privacy"
+          >
+            Privacy Policy
+          </a>
+        </ul>
+      </nav>
       <article
         class="article-reader"
       >


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Description
Added a SideBar for About page
https://staging.nodejs.dev/1399/trademark/
<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues
#1354 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
The below image is replaced with the latest screenshot after making the changes of wr.
![image](https://user-images.githubusercontent.com/26359740/121786121-8f74b980-cbdb-11eb-8ee3-e1e0ac375bf8.png)
<!--
  If you want to generate a preview of this PR on our staging server please
  make a comment on the Pull-Request with the text `/preview`
 -->