### PR TITLE
style: 💄 updated sidenav color to match the rest of the page

### DIFF
--- a/src/styles/tokens.scss
+++ b/src/styles/tokens.scss
@@ -162,7 +162,7 @@ body {
   --color-fill-app: #090c15;
   --color-fill-body: #090c15;
   --color-fill-canvas: #090c15;
-  --color-fill-side-nav: #0d111d;
+  --color-fill-side-nav: #090c15;
   --color-fill-top-nav: #090c15;
   --color-fill-action: var(--brand4);
   --color-fill-button: var(--pink5);


### PR DESCRIPTION

## Description
This PR makes the about sidebar match the rest of the page in dark mode.
