### PR TITLE
fix: side nav full width in mobile view.

### DIFF
--- a/src/components/AboutPageSideNavBar/index.tsx
+++ b/src/components/AboutPageSideNavBar/index.tsx
@@ -55,6 +55,12 @@ const aboutPageSideNavBarItem: AboutPageSideNavBarItem[] = [
   },
 ];
 
+// eslint-disable-next-line no-shadow
+export enum OverflowTypes {
+  unset = 'unset',
+  hidden = 'hidden',
+}
+
 export default function AboutPageSideNavBar({
   pageKey,
 }: {
@@ -66,6 +72,13 @@ export default function AboutPageSideNavBar({
   const className = navOpen
     ? 'side-nav-about side-nav--open'
     : 'side-nav-about';
+
+  if (typeof document !== 'undefined') {
+    document.body.style.overflow = navOpen
+      ? OverflowTypes.hidden
+      : OverflowTypes.unset;
+  }
+
   const navElement = useRef<HTMLElement | null>(null);
   return (
     <nav className={className} ref={navElement}>

--- a/src/styles/about.scss
+++ b/src/styles/about.scss
@@ -5,4 +5,12 @@
   overflow: hidden;
   position: inherit;
   width: auto;
+
+  &.side-nav--open {
+    @extend .side-nav--open;
+    width: 100%;
+    height: 100vh;
+    top: calc(var(--nav-height) * 2);
+    touch-action: none;
+  }
 }

--- a/src/styles/about.scss
+++ b/src/styles/about.scss
@@ -2,6 +2,7 @@
 
 .side-nav-about {
   @extend .side-nav;
+  top: 1.8rem;
   overflow: hidden;
   position: inherit;
   width: auto;
@@ -12,5 +13,8 @@
     height: 100vh;
     top: calc(var(--nav-height) * 2);
     touch-action: none;
+    .side-nav__open {
+      top: 1.8rem;
+    }
   }
 }

--- a/src/styles/learn.scss
+++ b/src/styles/learn.scss
@@ -2,6 +2,7 @@
   /* Needed since overflow: none will disable position: sticky on children */
   clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
   background-color: var(--color-fill-side-nav);
+  height: calc(100vh - var(--nav-height));
   overflow: auto;
   overflow-x: hidden;
   padding: 0 var(--space-20);
@@ -153,7 +154,7 @@
 }
 
 .side-nav.side-nav--open .side-nav__open {
-  top: calc(var(--nav-height) + 2.4rem);
+  top: calc(var(--nav-height) + 1.6rem);
   margin-bottom: -35px;
   margin-top: 16px;
   color: transparent;
@@ -180,7 +181,7 @@
       overflow: visible;
       overflow-y: scroll;
       position: fixed;
-      top: calc(var(--nav-height) * 2);
+      top: var(--nav-height);
     }
 
     > :last-child {

--- a/test/components/aboutPageSideNavBar.test.tsx
+++ b/test/components/aboutPageSideNavBar.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { screen, render, fireEvent } from '@testing-library/react';
 import AboutPageSideNavBar, {
   AboutPageKeys,
+  OverflowTypes,
 } from '../../src/components/AboutPageSideNavBar';
 
 describe('AboutPageSideNavBar', () => {
@@ -27,5 +28,26 @@ describe('AboutPageSideNavBar', () => {
     const innrerHtml = container.innerHTML;
     const activeLinks = innrerHtml.match('side-nav__item-community--active');
     expect(activeLinks.length).toBe(1);
+  });
+  it('should set the body oveflow hidden on menu click', () => {
+    render(<AboutPageSideNavBar pageKey={AboutPageKeys.releases} />);
+    const downloadItem: Element = screen.getAllByRole('button')[0] as Element;
+    expect(document.body.style.overflow).toBe(OverflowTypes.unset);
+    fireEvent.click(downloadItem);
+    expect(document.body.style.overflow).toBe(OverflowTypes.hidden);
+  });
+
+  fit('should set the body overflow hidden/unset on toggling', () => {
+    render(<AboutPageSideNavBar pageKey={AboutPageKeys.releases} />);
+    const downloadItem: Element = screen.getAllByRole('button')[0] as Element;
+    expect(document.body.style.overflow).toBe(OverflowTypes.unset);
+    fireEvent.click(downloadItem);
+    expect(document.body.style.overflow).toBe(OverflowTypes.hidden);
+    fireEvent.click(downloadItem);
+    expect(document.body.style.overflow).toBe(OverflowTypes.unset);
+    fireEvent.click(downloadItem);
+    expect(document.body.style.overflow).toBe(OverflowTypes.hidden);
+    fireEvent.click(downloadItem);
+    expect(document.body.style.overflow).toBe(OverflowTypes.unset);
   });
 });


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description
This MR handles width issues caused in mobile devices. Previously the SideBar in mobile view was half in size. this MR will correct it.

| Dark Mode  | Light Mode|
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/26359740/122636934-78692680-d109-11eb-8ce5-69421e7d67d7.png) |  ![image](https://user-images.githubusercontent.com/26359740/122636920-6d15fb00-d109-11eb-8c71-bcf8b3314416.png)

![SideNavMob](https://user-images.githubusercontent.com/26359740/123139180-8dc8b280-d473-11eb-85b0-ca01964dd9a3.gif)



<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues
#1446

https://staging.nodejs.dev/1448/privacy
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

<!--
  If you want to generate a preview of this PR on our staging server please
  make a comment on the Pull-Request with the text `/preview`
 -->
