### PR TITLE
style: setting side nav to float

### DIFF
--- a/src/styles/about.scss
+++ b/src/styles/about.scss
@@ -2,9 +2,6 @@
 
 .side-nav-about {
   @extend .side-nav;
-  top: 1.8rem;
-  overflow: hidden;
-  position: inherit;
   width: auto;
 
   &.side-nav--open {

--- a/src/styles/learn.scss
+++ b/src/styles/learn.scss
@@ -7,7 +7,7 @@
   overflow-x: hidden;
   padding: 0 var(--space-20);
   position: sticky;
-  top: var(--nav-height);
+  top: calc(var(--nav-height) + var(--space-12) + 2px);
   width: 100%;
   max-width: 36rem;
   box-sizing: border-box;


### PR DESCRIPTION
## Description

The side bar on the about page wasnt floating before. The scss file set `position: inherit;`, but I guess you cant inherit the sticky property. Also removed the `top` because when you scrolled to the bottom of the page it would cut off part of the navbar.

## Related Issues

https://github.com/nodejs/nodejs.dev/issues/1474
