### PR TITLE
docs: Rephrase "final solution" as "ultimate solution"

### DIFF
--- a/src/documentation/0035-javascript-async-await/index.md
+++ b/src/documentation/0035-javascript-async-await/index.md
@@ -16,7 +16,7 @@ Async functions are a combination of promises and generators, and basically, the
 
 They reduce the boilerplate around promises, and the "don't break the chain" limitation of chaining promises.
 
-When Promises were introduced in ES2015, they were meant to solve a problem with asynchronous code, and they did, but over the 2 years that separated ES2015 and ES2017, it was clear that _promises could not be the final solution_.
+When Promises were introduced in ES2015, they were meant to solve a problem with asynchronous code, and they did, but over the 2 years that separated ES2015 and ES2017, it was clear that _promises could not be the ultimate solution_.
 
 Promises were introduced to solve the famous _callback hell_ problem, but they introduced complexity on their own, and syntax complexity.
 


### PR DESCRIPTION
Fix a problematic term used in the documentation page `modern-asynchronous-javascript-with-async-and-await`.


## Description

The Holocaust was a long time ago, but reading that term still makes people twitch.
Rephrase it as "the ultimate solution" to avoid that issue; it's arguably a more apt phrasing anyway.
