### PR TITLE
fix broken link

### DIFF
--- a/src/documentation/0006-v8/index.md
+++ b/src/documentation/0006-v8/index.md
@@ -18,7 +18,7 @@ The Node.js ecosystem is huge and thanks to V8 which also powers desktop apps, w
 
 Other browsers have their own JavaScript engine:
 
-* Firefox has [**SpiderMonkey**](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey)
+* Firefox has [**SpiderMonkey**](https://spidermonkey.dev)
 * Safari has [**JavaScriptCore**](https://developer.apple.com/documentation/javascriptcore) (also called Nitro)
 * Edge was originally based on [**Chakra**](https://github.com/Microsoft/ChakraCore) but has more recently been [rebuilt using Chromium](https://support.microsoft.com/en-us/help/4501095/download-the-new-microsoft-edge-based-on-chromium) and the V8 engine.
 


### PR DESCRIPTION
Fix broken link in the index page of 'getting started' section

## Description

This page has the JavaScript that each browser use: https://nodejs.dev/learn/the-v8-javascript-engine. However, the link to the Firefox JS engine (SpiderMonkey) is broken.

This PR fixes the broken link.