### PR TITLE
fix: 🐛 internal links shouldn't open a new window

### DIFF
--- a/src/components/InstallTabs/LinuxPanel/index.tsx
+++ b/src/components/InstallTabs/LinuxPanel/index.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'gatsby';
 import React from 'react';
 import ShellBox from '../../ShellBox';
 import '../InstallTabs.scss';
@@ -27,15 +28,12 @@ g++ libgcc linux-headers grep util-linux binutils findutils"
       </ShellBox>
       <br />
       <br />
-      {/* TODO when the new docs page is ready link to that page.  */}
-      <a
+      <Link
         className="install__docs-button"
-        href="https://nodejs.dev/download/package-manager/#nvm"
-        target="_blank"
-        rel="noopener noreferrer"
+        to="/download/package-manager/#nvm"
       >
         Read documentation
-      </a>
+      </Link>
     </div>
   );
 };

--- a/src/components/InstallTabs/MacOSPanel/index.tsx
+++ b/src/components/InstallTabs/MacOSPanel/index.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'gatsby';
 import React from 'react';
 import ShellBox from '../../ShellBox';
 import '../InstallTabs.scss';
@@ -17,14 +18,12 @@ const MacOSPanel = (): JSX.Element => {
       </ShellBox>
       <br />
       <br />
-      <a
+      <Link
         className="install__docs-button"
-        href="https://nodejs.dev/download/package-manager/#nvm"
-        target="_blank"
-        rel="noopener noreferrer"
+        to="/download/package-manager/#nvm"
       >
         Read documentation
-      </a>
+      </Link>
     </div>
   );
 };

--- a/src/components/InstallTabs/WindowsPanel/index.tsx
+++ b/src/components/InstallTabs/WindowsPanel/index.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'gatsby';
 import React from 'react';
 import ShellBox from '../../ShellBox';
 import '../InstallTabs.scss';
@@ -19,14 +20,12 @@ const WindowsPanel = (): JSX.Element => {
       </ShellBox>
       <br />
       <br />
-      <a
+      <Link
         className="install__docs-button"
-        href="https://nodejs.dev/download/package-manager/#nvs"
-        target="_blank"
-        rel="noopener noreferrer"
+        to="/download/package-manager/#nvs"
       >
         Read documentation
-      </a>
+      </Link>
     </div>
   );
 };

--- a/src/components/InstallTabs/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/InstallTabs/__tests__/__snapshots__/index.tsx.snap
@@ -165,9 +165,7 @@ exports[`Tests for InstallTabs component renders correctly 1`] = `
           <br />
           <a
             class="install__docs-button"
-            href="https://nodejs.dev/download/package-manager/#nvs"
-            rel="noopener noreferrer"
-            target="_blank"
+            href="/download/package-manager/#nvs"
           >
             Read documentation
           </a>
@@ -361,9 +359,7 @@ exports[`Tests for InstallTabs component renders correctly for Linux 1`] = `
           <br />
           <a
             class="install__docs-button"
-            href="https://nodejs.dev/download/package-manager/#nvm"
-            rel="noopener noreferrer"
-            target="_blank"
+            href="/download/package-manager/#nvm"
           >
             Read documentation
           </a>
@@ -557,9 +553,7 @@ exports[`Tests for InstallTabs component renders correctly for Unix 1`] = `
           <br />
           <a
             class="install__docs-button"
-            href="https://nodejs.dev/download/package-manager/#nvm"
-            rel="noopener noreferrer"
-            target="_blank"
+            href="/download/package-manager/#nvm"
           >
             Read documentation
           </a>
@@ -723,9 +717,7 @@ exports[`Tests for InstallTabs component renders correctly for macOS 1`] = `
           <br />
           <a
             class="install__docs-button"
-            href="https://nodejs.dev/download/package-manager/#nvm"
-            rel="noopener noreferrer"
-            target="_blank"
+            href="/download/package-manager/#nvm"
           >
             Read documentation
           </a>
@@ -915,9 +907,7 @@ exports[`Tests for InstallTabs component renders correctly for other 1`] = `
           <br />
           <a
             class="install__docs-button"
-            href="https://nodejs.dev/download/package-manager/#nvs"
-            rel="noopener noreferrer"
-            target="_blank"
+            href="/download/package-manager/#nvs"
           >
             Read documentation
           </a>

--- a/src/components/InstallTabs/__tests__/__snapshots__/linux-panel.test.tsx.snap
+++ b/src/components/InstallTabs/__tests__/__snapshots__/linux-panel.test.tsx.snap
@@ -100,9 +100,7 @@ exports[`Tests for LinuxPanel component renders correctly 1`] = `
     <br />
     <a
       class="install__docs-button"
-      href="https://nodejs.dev/download/package-manager/#nvm"
-      rel="noopener noreferrer"
-      target="_blank"
+      href="/download/package-manager/#nvm"
     >
       Read documentation
     </a>

--- a/src/components/InstallTabs/__tests__/__snapshots__/macos-panel.test.tsx.snap
+++ b/src/components/InstallTabs/__tests__/__snapshots__/macos-panel.test.tsx.snap
@@ -70,9 +70,7 @@ exports[`Tests for MacOSPanel component renders correctly 1`] = `
     <br />
     <a
       class="install__docs-button"
-      href="https://nodejs.dev/download/package-manager/#nvm"
-      rel="noopener noreferrer"
-      target="_blank"
+      href="/download/package-manager/#nvm"
     >
       Read documentation
     </a>

--- a/test/pages/__snapshots__/home.test.tsx.snap
+++ b/test/pages/__snapshots__/home.test.tsx.snap
@@ -353,9 +353,7 @@ exports[`Home page renders correctly 1`] = `
                   <br />
                   <a
                     class="install__docs-button"
-                    href="https://nodejs.dev/download/package-manager/#nvs"
-                    rel="noopener noreferrer"
-                    target="_blank"
+                    href="/download/package-manager/#nvs"
                   >
                     Read documentation
                   </a>


### PR DESCRIPTION

## Description

`/download/package-manager` was opening in a new window but shouldn't because it's part of the same domain now
