### PR TITLE
fix: Adding toc for working-groups page

### DIFF
--- a/content/about/working-groups.md
+++ b/content/about/working-groups.md
@@ -4,25 +4,11 @@ description: "Working Groups| Node.js"
 authors: williamkapke,Trott,fhemberger,rxmarbles,mhdawson,XhmikosR,ryanmurakami,outsideris,MaledongGit,vsemozhetbyt,wonderdogone,sotayamashita,richardlau,pierreneter,nschonni,marocchino,stevemao,lpinca,phillipj,jasnell,sejaljain123
 category: working-groups
 ---
-<!-- Information here should mostly mirror: https://github.com/nodejs/node/blob/master/WORKING_GROUPS.md -->
 
 Core Working Groups are created by the
 [Technical Steering Committee (TSC)](https://github.com/nodejs/TSC/blob/master/TSC-Charter.md).
 
-## Current Working Groups
-
-* [Addon API](#addon-api)
-* [Build](#build)
-* [Diagnostics](#diagnostics)
-* [Docker](#docker)
-* [Evangelism](#evangelism)
-* [i18n](#i18n)
-* [Package Maintenance](#package-maintenance)
-* [Release](#release)
-* [Security](#security)
-* [Streams](#streams)
-
-### [Addon API](https://github.com/nodejs/nan)
+## [Addon API](https://github.com/nodejs/nan)
 
 The Addon API Working Group is responsible for maintaining the NAN project and
 corresponding _nan_ package in npm. The NAN project makes available an
@@ -47,7 +33,7 @@ Responsibilities include:
 The current members can be found in their
 [README](https://github.com/nodejs/nan#collaborators).
 
-### [Build](https://github.com/nodejs/build)
+## [Build](https://github.com/nodejs/build)
 
 The Build Working Group's purpose is to create and maintain a distributed
 automation infrastructure.
@@ -59,7 +45,7 @@ Responsibilities include:
 * Running performance testing and comparisons.
 * Creating and managing build-containers.
 
-### [Diagnostics](https://github.com/nodejs/diagnostics)
+## [Diagnostics](https://github.com/nodejs/diagnostics)
 
 The Diagnostics Working Group's purpose is to surface a set of comprehensive,
 documented, and extensible diagnostic interfaces for use by Node.js tools and
@@ -80,7 +66,7 @@ Responsibilities include:
 * Defining and adding common structures to the dumps generated in order to
   support tools that want to introspect those dumps.
 
-### [Docker](https://github.com/nodejs/docker-node)
+## [Docker](https://github.com/nodejs/docker-node)
 
 The Docker Working Group's purpose is to build, maintain, and improve official
 Docker images for the Node.js project.
@@ -91,7 +77,7 @@ Responsibilities include:
 * Decide and implement image improvements and/or fixes.
 * Maintain and improve the images' documentation.
 
-### [Evangelism](https://github.com/nodejs/evangelism)
+## [Evangelism](https://github.com/nodejs/evangelism)
 
 The Evangelism Working Group promotes the accomplishments
 of Node.js and lets the community know how they can get involved.
@@ -105,7 +91,7 @@ Responsibilities include:
 * Publishing regular update summaries and other promotional
   content.
 
-### [i18n](https://github.com/nodejs/i18n)
+## [i18n](https://github.com/nodejs/i18n)
 
 The i18n Working Groups handle more than just translations. They
 are endpoints for community members to collaborate with each
@@ -160,7 +146,7 @@ Each language community maintains its own membership.
 * [nodejs-uk - Ukrainian (Українська)](https://github.com/nodejs/nodejs-uk)
 * [nodejs-vi - Vietnamese (Tiếng Việt)](https://github.com/nodejs/nodejs-vi)
 
-### [Package Maintenance](https://github.com/nodejs/package-maintenance)
+## [Package Maintenance](https://github.com/nodejs/package-maintenance)
 
 Responsibilities include:
 
@@ -181,7 +167,7 @@ Responsibilities include:
   `* nodejs/ci-config-github-actions`
   `* nodejs/package-maintenance repository.`
 
-### [Release](https://github.com/nodejs/Release)
+## [Release](https://github.com/nodejs/Release)
 
 The Release Working Group manages the release process for Node.js.
 
@@ -195,7 +181,7 @@ Responsibilities include:
   backporting changes to these branches.
 * Define the policy for what gets backported to release streams
 
-### [Security](https://github.com/nodejs/security-wg)
+## [Security](https://github.com/nodejs/security-wg)
 
 The Security Working Group manages all aspects and processes linked to Node.js security.
 
@@ -224,7 +210,7 @@ Responsibilities include:
 * Facilitate and promote the expansion of a healthy security service and product
   provider ecosystem.
 
-### [Streams](https://github.com/nodejs/readable-stream)
+## [Streams](https://github.com/nodejs/readable-stream)
 
 The Streams Working Group is dedicated to the support and improvement of the
 Streams API as used in Node.js and the npm ecosystem. We seek to create a

--- a/src/pages/working-groups.tsx
+++ b/src/pages/working-groups.tsx
@@ -9,7 +9,7 @@ import SideNavBar, { SideNavBarKeys } from '../components/SideNavBar';
 
 export default function WorkingGroupsPage({ data }: Page): JSX.Element {
   const { title, description } = data.page.frontmatter;
-  const { html } = data.page;
+  const { html, tableOfContents } = data.page;
   const { authors } = data.page.fields;
   return (
     <>
@@ -19,6 +19,7 @@ export default function WorkingGroupsPage({ data }: Page): JSX.Element {
           <Article
             title={title}
             html={html}
+            tableOfContents={tableOfContents}
             authors={authors}
             editPath="content/about/working-groups.md"
           />
@@ -33,7 +34,7 @@ export const query = graphql`
   query {
     page: markdownRemark(fields: { slug: { eq: "working-groups" } }) {
       html
-      tableOfContents(absolute: true, pathToSlugField: "frontmatter.path")
+      tableOfContents(absolute: false, pathToSlugField: "frontmatter.path")
       frontmatter {
         title
         description

--- a/test/pages/__snapshots__/working-groups.test.tsx.snap
+++ b/test/pages/__snapshots__/working-groups.test.tsx.snap
@@ -234,6 +234,18 @@ exports[`Working Groups page renders correctly 1`] = `
         >
           Mock Title
         </h1>
+        <details
+          class="toc"
+        >
+          <summary>
+            <h6>
+              TABLE OF CONTENTS
+            </h6>
+          </summary>
+          <div>
+            Table of Content
+          </div>
+        </details>
         <div>
           <div>
             Sample


### PR DESCRIPTION
## Description

I noticed the `working-groups` page wasnt using a TOC and instead had a bulleted list below the title. This PR implements the TOC and removed the bulleted list.

## Related Issues

#1663 

## BEFORE

<img width="746" alt="Screen Shot 2021-07-28 at 5 56 25 AM" src="https://user-images.githubusercontent.com/40124399/127311305-27f8d268-7c6f-419c-8f81-3843e7cec193.png">

## AFTER

<img width="711" alt="Screen Shot 2021-07-28 at 5 58 23 AM" src="https://user-images.githubusercontent.com/40124399/127311450-7508f994-66f5-437e-9e18-4426625148af.png">
