### PR TITLE
docs: update reference to npm install

### DIFF
--- a/src/documentation/0020-package-lock-json/index.md
+++ b/src/documentation/0020-package-lock-json/index.md
@@ -26,7 +26,7 @@ It could be you, or another person trying to initialize the project on the other
 
 So your original project and the newly initialized project are actually different. Even if a patch or minor release should not introduce breaking changes, we all know bugs can (and so, they will) slide in.
 
-The `package-lock.json` sets your currently installed version of each package **in stone**, and `npm` will use those exact versions when running `npm install`.
+The `package-lock.json` sets your currently installed version of each package **in stone**, and `npm` will use those exact versions when running `npm ci`.
 
 This concept is not new, and other programming languages package managers (like Composer in PHP) use a similar system for years.
 


### PR DESCRIPTION
clarification to docs

<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

clarification to docs, as 'npm install' doesn't use 'exactly' the packages defined in package-lock.json, it will update package-lock.json based on semver of packages.json as I understand.  'npm ci' will do what the text describes

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

<!--
  If you want to generate a preview of this PR on our staging server please
  make a comment on the Pull-Request with the text `/preview`
 -->
