### PR TITLE
docs: Fix typo counterReset to countReset

### DIFF
--- a/src/documentation/0013-node-output-to-cli/index.md
+++ b/src/documentation/0013-node-output-to-cli/index.md
@@ -115,7 +115,7 @@ oranges.forEach(fruit => {
 })
 ```
 
-Notice how the call to `console.counterReset('orange')` resets the value counter to zero.
+Notice how the call to `console.countReset('orange')` resets the value counter to zero.
 
 ## Print the stack trace
 


### PR DESCRIPTION
Signed-off-by: Rommy Gustiawan <rgcppp@gmail.com>

<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Fixing syntax error (possibly typo) in documentation file, from `counterReset()` to `countReset()`.

`counterReset()` is not a valid method in JavaScript.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

<!--
  If you want to generate a preview of this PR on our staging server please
  make a comment on the Pull-Request with the text `/preview`
 -->
