### PR TITLE
docs: fix typo in WebAssembly doc

### DIFF
--- a/src/documentation/0057-node-with-web-assembly/index.md
+++ b/src/documentation/0057-node-with-web-assembly/index.md
@@ -15,7 +15,7 @@ The WebAssembly specification details two file formats, a binary format called a
 * Module - A compiled WebAssembly binary, ie a `.wasm` file.
 * Memory - A resizable ArrayBuffer.
 * Table - A resizable typed array of references not stored in Memory.
-* Instance - An instantiation of a Module with its' Memory, Table, and variables.
+* Instance - An instantiation of a Module with its Memory, Table, and variables.
 
 In order to use WebAssembly, you need a `.wasm` binary file and a set of APIs to communicate with WebAssembly. Node.js provides the necessary APIs via the global `WebAssembly` object.
 


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This merely fixes the spelling of `its`, which is already the possessive form.