### PR TITLE
Fix preview link generation workflows

### DIFF
--- a/.github/workflows/generate-preview.yml
+++ b/.github/workflows/generate-preview.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            github.issues.removeLabel({
+            github.rest.issues.removeLabel({
               issue_number: ${{ github.event.pull_request.number }},
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/upload-to-staging.yml
+++ b/.github/workflows/upload-to-staging.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            github.issues.createComment({
+            github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

`actions/github-script@v5` recently got a breaking change where `github.issues...` in script section had to be replaced by `github.rest.issues...`, and that's causing the preview generation to fail.

https://github.com/actions/github-script#breaking-changes-in-v5