### PR TITLE
change let to const

### DIFF
--- a/src/documentation/0051-node-buffers/index.md
+++ b/src/documentation/0051-node-buffers/index.md
@@ -128,7 +128,7 @@ Copying a buffer is possible using the `set()` method:
 
 ```js
 const buf = Buffer.from('Hey!')
-let bufcopy = Buffer.alloc(4) //allocate 4 bytes
+const bufcopy = Buffer.alloc(4) //allocate 4 bytes
 bufcopy.set(buf)
 ```
 


### PR DESCRIPTION
## Description

In the changed line, we can change `let` to `const` since we are not going to explicitly assign anything to the `bufcopy` variable.
