### PR TITLE
docs: adjust typo for 0047-node-module-path

### DIFF
--- a/src/documentation/0047-node-module-path/index.md
+++ b/src/documentation/0047-node-module-path/index.md
@@ -49,7 +49,7 @@ require('path').extname('/test/something/file.txt') // '.txt'
 ### `path.format()`
 
 Returns a path string from an object, This is the opposite of `path.parse`<br/>
-`path.format` accepts an object as argument with the follwing keys:
+`path.format` accepts an object as argument with the following keys:
 * `root`: the root
 * `dir`: the folder path starting from the root
 * `base`: the file name + extension


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Resolves typo for `path.format()` of 0047-node-module-path
## Related Issues
N/A
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

<!--
  If you want to generate a preview of this PR on our staging server please
  make a comment on the Pull-Request with the text `/preview`
 -->
