### PR TITLE
docs: adjust ext argument in format example for 0047-node-module-path

### DIFF
--- a/src/documentation/0047-node-module-path/index.md
+++ b/src/documentation/0047-node-module-path/index.md
@@ -63,7 +63,7 @@ Returns a path string from an object, This is the opposite of `path.parse`<br/>
 // POSIX
 require('path').format({ dir: '/Users/joe', base: 'test.txt' }) //  '/Users/joe/test.txt'
 
-require('path').format({ root: '/Users/joe', name: 'test', ext: 'txt' }) //  '/Users/joe/test.txt'
+require('path').format({ root: '/Users/joe', name: 'test', ext: '.txt' }) //  '/Users/joe/test.txt'
 
 // WINDOWS
 require('path').format({ dir: 'C:\\Users\\joe', base: 'test.txt' }) //  'C:\\Users\\joe\\test.txt'


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Resolves `path.format` to print `'/Users/joe/test.txt'` instead of `'/Users/joe/testtxt'` by using `.txt` as ext in function.
## Related Issues
N/A
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

<!--
  If you want to generate a preview of this PR on our staging server please
  make a comment on the Pull-Request with the text `/preview`
 -->
