### PR TITLE
no need to assign what fs.writeFileSync returns to a variable

### DIFF
--- a/src/documentation/0044-node-writing-files/index.md
+++ b/src/documentation/0044-node-writing-files/index.md
@@ -32,7 +32,7 @@ const fs = require('fs')
 const content = 'Some content!'
 
 try {
-  const data = fs.writeFileSync('/Users/joe/test.txt', content)
+  fs.writeFileSync('/Users/joe/test.txt', content)
   //file written successfully
 } catch (err) {
   console.error(err)


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

According to [the Node.js docs](https://nodejs.org/api/fs.html#fswritefilesyncfile-data-options), `fs.writeFileSync` returns undefined. So, I think there's no point to assign the return value to the `data` variable in the example and this could possibly mislead readers.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

<!--
  If you want to generate a preview of this PR on our staging server please
  make a comment on the Pull-Request with the text `/preview`
 -->
