### PR TITLE
Nvm link updater

### DIFF
--- a/src/components/InstallTabs/LinuxPanel/index.tsx
+++ b/src/components/InstallTabs/LinuxPanel/index.tsx
@@ -1,9 +1,22 @@
 import { Link } from 'gatsby';
 import React from 'react';
 import ShellBox from '../../ShellBox';
+import useNvmVersion from '../../../hooks/useNvmVersion';
 import '../InstallTabs.scss';
 
 const LinuxPanel = (): JSX.Element => {
+  const asyncState = useNvmVersion();
+
+  if (asyncState.state === 'loading') {
+    return <em>Loading...</em>;
+  }
+
+  if (asyncState.state === 'error') {
+    return <em>Error loading. Try refreshing the page.</em>;
+  }
+
+  const { nvmVersion } = asyncState;
+
   return (
     <div>
       <ShellBox
@@ -16,10 +29,12 @@ g++ libgcc linux-headers grep util-linux binutils findutils"
         ca-certificates openssl ncurses coreutils python2 make gcc g++ libgcc
         linux-headers grep util-linux binutils findutils
       </ShellBox>
-      <ShellBox textToCopy="curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash">
+      <ShellBox
+        textToCopy={`curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/${nvmVersion}/install.sh | bash`}
+      >
         <span className="install__text__no-select">$</span>
         <span className="install__text__command"> curl -o- </span>
-        https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh{' '}
+        {`https://raw.githubusercontent.com/nvm-sh/nvm/${nvmVersion}/install.sh`}
         <span className="install__text__command">| bash</span>
       </ShellBox>
       <ShellBox textToCopy="nvm install --lts">

--- a/src/components/InstallTabs/MacOSPanel/index.tsx
+++ b/src/components/InstallTabs/MacOSPanel/index.tsx
@@ -1,15 +1,30 @@
 import { Link } from 'gatsby';
 import React from 'react';
 import ShellBox from '../../ShellBox';
+import useNvmVersion from '../../../hooks/useNvmVersion';
 import '../InstallTabs.scss';
 
 const MacOSPanel = (): JSX.Element => {
+  const asyncState = useNvmVersion();
+
+  if (asyncState.state === 'loading') {
+    return <em>Loading...</em>;
+  }
+
+  if (asyncState.state === 'error') {
+    return <em>Error loading. Try refreshing the page.</em>;
+  }
+
+  const { nvmVersion } = asyncState;
+
   return (
     <div>
-      <ShellBox textToCopy="curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash">
+      <ShellBox
+        textToCopy={`curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/${nvmVersion}/install.sh | bash`}
+      >
         <span className="install__text__no-select">$</span>
         <span className="install__text__command">curl -o- </span>
-        https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh
+        {`https://raw.githubusercontent.com/nvm-sh/nvm/${nvmVersion}/install.sh`}
         <span className="install__text__command"> | bash </span>
       </ShellBox>
       <ShellBox textToCopy="nvm install --lts">

--- a/src/components/InstallTabs/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/InstallTabs/__tests__/__snapshots__/index.tsx.snap
@@ -323,8 +323,7 @@ exports[`Tests for InstallTabs component renders correctly for Linux 1`] = `
               >
                  curl -o- 
               </span>
-              https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh
-               
+              https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh
               <span
                 class="install__text__command"
               >
@@ -520,8 +519,7 @@ exports[`Tests for InstallTabs component renders correctly for Unix 1`] = `
               >
                  curl -o- 
               </span>
-              https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh
-               
+              https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh
               <span
                 class="install__text__command"
               >
@@ -688,7 +686,7 @@ exports[`Tests for InstallTabs component renders correctly for macOS 1`] = `
               >
                 curl -o- 
               </span>
-              https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh
+              https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh
               <span
                 class="install__text__command"
               >

--- a/src/components/InstallTabs/__tests__/__snapshots__/linux-panel.test.tsx.snap
+++ b/src/components/InstallTabs/__tests__/__snapshots__/linux-panel.test.tsx.snap
@@ -58,8 +58,7 @@ exports[`Tests for LinuxPanel component renders correctly 1`] = `
         >
            curl -o- 
         </span>
-        https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh
-         
+        https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh
         <span
           class="install__text__command"
         >

--- a/src/components/InstallTabs/__tests__/__snapshots__/macos-panel.test.tsx.snap
+++ b/src/components/InstallTabs/__tests__/__snapshots__/macos-panel.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`Tests for MacOSPanel component renders correctly 1`] = `
         >
           curl -o- 
         </span>
-        https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh
+        https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh
         <span
           class="install__text__command"
         >

--- a/src/components/InstallTabs/__tests__/index.tsx
+++ b/src/components/InstallTabs/__tests__/index.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import {
+  render,
+  screen,
+  waitForElementToBeRemoved,
+} from '@testing-library/react';
 import InstallTabs from '../index';
 import * as detectOSModule from '../../../util/detectOS';
 import { UserOS } from '../../../util/detectOS';
@@ -12,19 +16,22 @@ describe('Tests for InstallTabs component', () => {
     const { container } = render(<InstallTabs />);
     expect(container).toMatchSnapshot();
   });
-  it('renders correctly for macOS', () => {
+  it('renders correctly for macOS', async () => {
     jest.spyOn(detectOSModule, 'detectOS').mockReturnValue(UserOS.MAC);
     const { container } = render(<InstallTabs />);
+    await waitForElementToBeRemoved(screen.getByText('Loading...'));
     expect(container).toMatchSnapshot();
   });
-  it('renders correctly for Linux', () => {
+  it('renders correctly for Linux', async () => {
     jest.spyOn(detectOSModule, 'detectOS').mockReturnValue(UserOS.LINUX);
     const { container } = render(<InstallTabs />);
+    await waitForElementToBeRemoved(screen.getByText('Loading...'));
     expect(container).toMatchSnapshot();
   });
-  it('renders correctly for Unix', () => {
+  it('renders correctly for Unix', async () => {
     jest.spyOn(detectOSModule, 'detectOS').mockReturnValue(UserOS.UNIX);
     const { container } = render(<InstallTabs />);
+    await waitForElementToBeRemoved(screen.getByText('Loading...'));
     expect(container).toMatchSnapshot();
   });
   it('renders correctly for other', () => {

--- a/src/components/InstallTabs/__tests__/linux-panel.test.tsx
+++ b/src/components/InstallTabs/__tests__/linux-panel.test.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import {
+  render,
+  screen,
+  waitForElementToBeRemoved,
+} from '@testing-library/react';
 import LinuxPanel from '../LinuxPanel';
 
 describe('Tests for LinuxPanel component', () => {
-  it('renders correctly', () => {
+  it('renders correctly', async () => {
     const { container } = render(<LinuxPanel />);
+    await waitForElementToBeRemoved(screen.getByText('Loading...'));
     expect(container).toMatchSnapshot();
   });
 });

--- a/src/components/InstallTabs/__tests__/macos-panel.test.tsx
+++ b/src/components/InstallTabs/__tests__/macos-panel.test.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import {
+  render,
+  screen,
+  waitForElementToBeRemoved,
+} from '@testing-library/react';
 import MacOSPanel from '../MacOSPanel';
 
 describe('Tests for MacOSPanel component', () => {
-  it('renders correctly', () => {
+  it('renders correctly', async () => {
     const { container } = render(<MacOSPanel />);
+    await waitForElementToBeRemoved(screen.getByText('Loading...'));
     expect(container).toMatchSnapshot();
   });
 });

--- a/src/hooks/useNvmVersion.tsx
+++ b/src/hooks/useNvmVersion.tsx
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+import { getLatestNvmVersion } from '../../util-node/getNvmData';
+
+type AsyncState =
+  | {
+      state: 'loading';
+    }
+  | { state: 'error' }
+  | { state: 'loaded'; nvmVersion: string };
+
+export default function useNvmVersion(): AsyncState {
+  const [state, setState] = useState<AsyncState>({ state: 'loading' });
+  useEffect(() => {
+    getLatestNvmVersion()
+      .then(nvmVersion => setState({ state: 'loaded', nvmVersion }))
+      .catch(() => setState({ state: 'error' }));
+  }, []);
+  return state;
+}

--- a/test/util/getNvmData.test.ts
+++ b/test/util/getNvmData.test.ts
@@ -1,0 +1,42 @@
+import fetch from 'node-fetch';
+
+import { getLatestNvmVersion } from '../../util-node/getNvmData';
+
+jest.mock('node-fetch');
+
+const mockFetch = fetch as jest.MockedFunction<typeof fetch>;
+
+const prepareMockFetch = ({
+  response = [{ name: 'mockVersionString' }] as any,
+} = {}) => {
+  mockFetch.mockResolvedValue({
+    json: () => Promise.resolve(response),
+  } as any);
+};
+
+describe('getLatestNvmVersion', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the latest NVM version', async () => {
+    prepareMockFetch();
+
+    const result = await getLatestNvmVersion();
+
+    expect(result).toEqual('mockVersionString');
+  });
+
+  it.each`
+    response          | reason
+    ${'foo'}          | ${'is not a string'}
+    ${[]}             | ${'is empty'}
+    ${[false]}        | ${'is not an array of objects'}
+    ${[{}]}           | ${'contains objects without a name'}
+    ${[{ name: 12 }]} | ${'contains objects with a non-string name'}
+  `('rejects response which $reason', ({ response }) => {
+    prepareMockFetch({ response });
+
+    expect(getLatestNvmVersion()).rejects.toThrow('Unable to parse response');
+  });
+});

--- a/util-node/getNvmData.ts
+++ b/util-node/getNvmData.ts
@@ -1,0 +1,23 @@
+import fetch from 'node-fetch';
+
+type NvmTagsResponse = Array<{ name: string }>;
+
+const isNvmTagsResponse = (json: unknown): json is NvmTagsResponse => {
+  if (!Array.isArray(json)) return false;
+  return json.every(entry => {
+    if (!entry) return false;
+    if (typeof entry !== 'object') return false;
+    return typeof entry.name === 'string';
+  });
+};
+
+export const getLatestNvmVersion = async () => {
+  const json = await fetch('https://api.github.com/repos/nvm-sh/nvm/tags').then(
+    res => res.json()
+  );
+
+  if (!isNvmTagsResponse(json)) throw new Error('Unable to parse response');
+  if (json.length === 0) throw new Error('Unable to parse response');
+
+  return json[0].name;
+};


### PR DESCRIPTION
## Description

- Adds utility method for fetching the latest NVM version string
- Provides a hook for exposing this to components
- Invokes hook in Linux and Mac install tabs in order to display latest NVM version

## Warning

Since fetching the NVM version data is asynchronous, this change has introduced some asynchronicity in what was otherwise a synchronous section of UI. I have handled loading and error states, but the UI in those cases is very basic (literally just render a string). But that means there is potential future scope for rendering something more graceful in case of a slow or error-prone network (loading spinner?). 

## Related Issues

Fixes #2031 
