### PR TITLE
Confuse about es6 job queue

### DIFF
--- a/src/documentation/0029-node-event-loop/index.md
+++ b/src/documentation/0029-node-event-loop/index.md
@@ -152,7 +152,7 @@ We don't have to wait for functions like `setTimeout`, fetch or other things to 
 
 ## ES6 Job Queue
 
-ECMAScript 2015 introduced the concept of the Job Queue, which is used by Promises (also introduced in ES6/ES2015). It's a way to execute the result of an async function as soon as possible, rather than being put at the end of the call stack.
+ECMAScript 2015 introduced the concept of the Job Queue, which is used by Promises (also introduced in ES6/ES2015). It's a way to execute the result of an async function as soon as possible, rather than being put at the end of the message queue.
 
 Promises that resolve before the current function ends will be executed right after the current function.
 


### PR DESCRIPTION
I am on nodejs event loop article and section is es6 job queue, I am facing difficulty to understand this section please help me understanding these lines ECMAScript 2015 introduced the concept of the Job Queue, which is used by Promises (also introduced in ES6/ES2015). It's a way to execute the result of an async function as soon as possible, rather than being put at the end of the call stack. I don't understand these lines particularly the last line rather than being put at the end of the call stack, I am confused why they used word call stack instead of message queue.

<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

<!--
  If you want to generate a preview of this PR on our staging server please
  make a comment on the Pull-Request with the text `/preview`
 -->
