### PR TITLE
tools: Restrict workflow permissions

### DIFF
--- a/.github/workflows/cleanup-staging.yml
+++ b/.github/workflows/cleanup-staging.yml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     types: [closed]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/generate-preview.yml
+++ b/.github/workflows/generate-preview.yml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: [labeled]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR restricts permissions on the `pull_request_target` workflows to the minimum required.

I've tested the changes in a private repo, but had to stub out the GCloud and Build steps. As far as I can tell those don't need any extra permissions.