### PR TITLE
fix: Add svgo config to fix svgs scaling issue

### DIFF
--- a/svgo.config.js
+++ b/svgo.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  plugins: [
+    {
+      name: 'preset-default',
+      params: {
+        overrides: {
+          removeViewBox: false,
+        },
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## Description
**Add a svgo config (svgo.config.js) that disables the removal of the `viewBox` attributes on SVGs. The absence of the `viewBox` attribute prevents the SVGs from scaling correctly.**
In the download page, this caused the Mac Installer icon to be "cropped" and prevented the selected download option icon to grow in size (48px to 56px).
Svgo is used by svgr (@svgr/webpack & gatsby-plugin-svgr).

### Before
![Screenshot from 2021-12-30 17-40-38](https://user-images.githubusercontent.com/33841027/147771248-e4b1d079-9e06-4633-87e7-e23a5c475c9b.png)
### After
![Screenshot from 2021-12-30 17-10-57](https://user-images.githubusercontent.com/33841027/147771270-93d5d748-7320-4faf-94bc-6bb2dd5a851f.png)

## Related Issues
Fixes #2143 

## Test
The contribution guide says that "Pull Requests for a new feature or bug fix must include tests" but I don't know how to test it. It's mocked (svgMock.tsx) for the tests.