### PR TITLE
chore: use Node 16 for Cloud Build

### DIFF
--- a/cloudbuild-deploy.yaml
+++ b/cloudbuild-deploy.yaml
@@ -13,13 +13,13 @@
 # to grant publishing access to Cloud Build.)
 
 steps:
-  - name: 'node:12'
+  - name: 'node:16'
     entrypoint: npm
     args: ['ci']
-  - name: 'node:12'
+  - name: 'node:16'
     entrypoint: npm
     args: ['run', 'build']
-  - name: 'node:12'
+  - name: 'node:16'
     entrypoint: npm
     args: ['run', 'build-storybook']
   - name: 'gcr.io/$PROJECT_ID/firebase'


### PR DESCRIPTION
16 is now LTS, and 12 is using an older NPM that doesn't support packagelock v2

<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
