### PR TITLE
build: extend timeout to 15 minutes

### DIFF
--- a/cloudbuild-deploy.yaml
+++ b/cloudbuild-deploy.yaml
@@ -24,3 +24,4 @@ steps:
     args: ['run', 'build-storybook']
   - name: 'gcr.io/$PROJECT_ID/firebase'
     args: ['deploy', '--project', '$PROJECT_ID', '--only', 'hosting']
+timout: 900s


### PR DESCRIPTION
Default timeout is 10 minutes and our build now is longer than that.

Fixes https://github.com/nodejs/nodejs.dev/issues/2145