### PR TITLE
fix: increase button contrast

### DIFF
--- a/src/components/ShellBox/ShellBox.scss
+++ b/src/components/ShellBox/ShellBox.scss
@@ -68,7 +68,7 @@
     }
 
     button {
-      background-color: var(--brand2);
+      background-color: var(--brand);
       border-radius: 0 0.3rem 0.3rem 0.3rem;
       border-width: 0;
       i {


### PR DESCRIPTION
## Description

This PR changes the background colour of the shell box buttons from `--brand2` to `--brand7`. This increases the contrast to 6.51, which meets the WCAG AA standards for text contrast.

## Screenshots
### Current
![image](https://user-images.githubusercontent.com/42586271/148561342-79da198a-2e98-4ac8-ae52-d509e7fa2ad5.png)

### New
![image](https://user-images.githubusercontent.com/42586271/148561189-2e91e2de-84c1-40b9-878e-a36ac4c9330e.png)


## Related Issues

As far as I know, there are no issues related to this.
