### PR TITLE
Fix typo in documentation

### DIFF
--- a/src/documentation/0013-node-output-to-cli/index.md
+++ b/src/documentation/0013-node-output-to-cli/index.md
@@ -31,7 +31,7 @@ We can also format pretty phrases by passing variables and a format specifier.
 For example:
 
 ```js
-console.log('My %s has %d years', 'cat', 2)
+console.log('My %s has %d ears', 'cat', 2)
 ```
 
 * `%s` format a variable as a string


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description
Fixes a typo in the page 'Output to the command line using Node.js'
URL => https://nodejs.dev/learn/output-to-the-command-line-using-nodejs

This PR replaces 'years' with 'ears' shown in the image below
![image](https://user-images.githubusercontent.com/30928792/152361673-1e6c57a8-5fd4-4b2a-8186-db463bb0bd81.png)

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues
#2258 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
