### PR TITLE
Docs: Change chalk version in a code example, as v5 is now Pure ESM

### DIFF
--- a/src/documentation/0013-node-output-to-cli/index.md
+++ b/src/documentation/0013-node-output-to-cli/index.md
@@ -182,7 +182,7 @@ You can try that in the Node.js REPL, and it will print `hi!` in yellow.
 
 However, this is the low-level way to do this. The simplest way to go about coloring the console output is by using a library. [Chalk](https://github.com/chalk/chalk) is such a library, and in addition to coloring it also helps with other styling facilities, like making text bold, italic or underlined.
 
-You install it with `npm install chalk`, then you can use it:
+You install it with `npm install chalk@4`, then you can use it:
 
 ```js
 const chalk = require('chalk')


### PR DESCRIPTION
To use `const chalk = require("chalk");` you have to install version 4 of the `chalk` package. Their newest version is pure ESM and will give an error: `(node:61082) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.`. You could update the documentation to explain how to use ESM, but I don't think this is the right place for that, so I think this is the right change.

<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
