### PR TITLE
Fix: incorrect link in Introduction to Node.js

### DIFF
--- a/src/documentation/0001-node-introduction/index.md
+++ b/src/documentation/0001-node-introduction/index.md
@@ -97,7 +97,7 @@ Node.js is a low-level platform. In order to make things easy and exciting for d
 Many of those established over time as popular options. Here is a non-comprehensive list of the ones worth learning:
 
 * [**AdonisJS**](https://adonisjs.com/): A TypeScript-based fully featured framework highly focused on developer ergonomics, stability, and confidence. Adonis is one of the fastest Node.js web frameworks.
-* [**Egg.js**](https://eggjs.org/en/): A framework to build better enterprise frameworks and apps with Node.js & Koa.
+* [**Egg.js**](https://eggjs.org): A framework to build better enterprise frameworks and apps with Node.js & Koa.
 * [**Express**](https://expressjs.com/): It provides one of the most simple yet powerful ways to create a web server. Its minimalist approach, unopinionated, focused on the core features of a server, is key to its success.
 * [**Fastify**](https://fastify.io/): A web framework highly focused on providing the best developer experience with the least overhead and a powerful plugin architecture. Fastify is one of the fastest Node.js web frameworks.
 * [**FeatherJS**](https://feathersjs.com/): Feathers is a lightweight web-framework for creating real-time applications and REST APIs using JavaScript or TypeScript. Build prototypes in minutes and production-ready apps in days.


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

In the [Introduction to Node.js](https://nodejs.dev/learn#nodejs-frameworks-and-tools) under the Node.js Frameworks and Tools section, clicking on the Egg.js which is the second one redirects to the link https://eggjs.org/en/ from which we cannot come back using the history stack and it gives the warning Sorry that page is missing which then redirects to https://eggjs.org/.

## Related Issues 
Fixes #2320

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
