### PR TITLE
Fix: pnpm domain change in Introduction to the npm package manager

### DIFF
--- a/src/documentation/0016-npm/index.md
+++ b/src/documentation/0016-npm/index.md
@@ -16,7 +16,7 @@ It started as a way to download and manage dependencies of Node.js packages, but
 
 There are many things that `npm` does.
 
-> [**Yarn**](https://yarnpkg.com/en/) and [**pnpm**](https://pnpm.js.org/) are alternatives to npm cli. You can check them out as well.
+> [**Yarn**](https://yarnpkg.com/en/) and [**pnpm**](https://pnpm.io) are alternatives to npm cli. You can check them out as well.
 
 ## Downloads
 


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
pnpm had changed the domain from **pnpm.js.org** to **pnpm.io**. pnpm is mentioned in the lesson [An introduction to the npm package manager](https://nodejs.dev/learn/an-introduction-to-the-npm-package-manager#introduction-to-npm) while saying the alternative npm cli. 
pnpm domain change **[commit](https://github.com/pnpm/pnpm.github.io/commit/aa63e77d46badc6e95f7afa68e6e44a572aa10d4)**.

 
![pnpm_domain](https://user-images.githubusercontent.com/63643748/158198538-718ea56e-d68a-407f-a52f-cffce8fc0984.png)


## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
