### PR TITLE
docs: change bash to app.js at getting started tutorial

### DIFF
--- a/src/documentation/0007-node-run-cli/index.md
+++ b/src/documentation/0007-node-run-cli/index.md
@@ -16,13 +16,13 @@ node app.js
 
 Above, you are explicitly telling the shell to run your script with `node`. You can also embed this information into your JavaScript file with a "shebang" line. The "shebang" is the first line in the file, and tells the OS which interpreter to use for running the script. Below is the first line of JavaScript:
 
-```app.js
+```JS
 #!/usr/bin/node
 ```
 
 Above, we are explicitly giving the absolute path of interpreter. Not all operating systems have `node` in the bin folder, but all should have `env`. You can tell the OS to run `env` with node as parameter:
 
-```app.js
+```JS
 #!/usr/bin/env node
 
 // your code

--- a/src/documentation/0007-node-run-cli/index.md
+++ b/src/documentation/0007-node-run-cli/index.md
@@ -16,13 +16,13 @@ node app.js
 
 Above, you are explicitly telling the shell to run your script with `node`. You can also embed this information into your JavaScript file with a "shebang" line. The "shebang" is the first line in the file, and tells the OS which interpreter to use for running the script. Below is the first line of JavaScript:
 
-```bash
+```app.js
 #!/usr/bin/node
 ```
 
 Above, we are explicitly giving the absolute path of interpreter. Not all operating systems have `node` in the bin folder, but all should have `env`. You can tell the OS to run `env` with node as parameter:
 
-```bash
+```app.js
 #!/usr/bin/env node
 
 // your code

--- a/src/documentation/0007-node-run-cli/index.md
+++ b/src/documentation/0007-node-run-cli/index.md
@@ -16,13 +16,13 @@ node app.js
 
 Above, you are explicitly telling the shell to run your script with `node`. You can also embed this information into your JavaScript file with a "shebang" line. The "shebang" is the first line in the file, and tells the OS which interpreter to use for running the script. Below is the first line of JavaScript:
 
-```JS
+```js
 #!/usr/bin/node
 ```
 
 Above, we are explicitly giving the absolute path of interpreter. Not all operating systems have `node` in the bin folder, but all should have `env`. You can tell the OS to run `env` with node as parameter:
 
-```JS
+```js
 #!/usr/bin/env node
 
 // your code


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description
Changes the "bash" code header for "app.js" at the getting started lesson [run node from the command line](https://nodejs.dev/learn/run-nodejs-scripts-from-the-command-line).

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
