### PR TITLE
style: remove box shadow from side nav titles

### DIFF
--- a/src/styles/learn.scss
+++ b/src/styles/learn.scss
@@ -22,7 +22,6 @@
   &__title {
     align-items: center;
     background-color: var(--color-fill-side-nav);
-    box-shadow: 0 25px 20px var(--color-fill-side-nav);
     color: var(--color-text-primary);
     display: flex;
     font-weight: 600;


### PR DESCRIPTION
Improves visibility of first list items that come right under side nav titles

<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

The existing box shadow under side navigation titles make the first list items less visible/readable. This PR removes the box shadow altogether to fix the issue.
