### PR TITLE
update docs: changes body-parser to express.json() middleware

### DIFF
--- a/src/documentation/0039a-node-request-data/index.md
+++ b/src/documentation/0039a-node-request-data/index.md
@@ -8,7 +8,7 @@ category: learn
 
 Here is how you can extract the data that was sent as JSON in the request body.
 
-If you are using Express, that's quite simple: use the `body-parser` Node.js module.
+If you are using Express, that's quite simple: use the `express.json()` middleware which is available in Express v4.16.0 onwards.
 
 For example, to get the body of this request:
 


### PR DESCRIPTION
Change `body-parser` reference to `express.json()` 

<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

This middleware is available in Express v4.16.0 onwards,  and also is the one you are using in the example.
