### PR TITLE
Added missing llink for 'closure'

### DIFF
--- a/src/documentation/0004-node-javascript-language/index.md
+++ b/src/documentation/0004-node-javascript-language/index.md
@@ -36,5 +36,5 @@ The following concepts are also key to understand asynchronous programming, whic
 * [Timers](https://nodejs.dev/learn/discover-javascript-timers)
 * [Promises](https://nodejs.dev/learn/understanding-javascript-promises)
 * [Async and Await](https://nodejs.dev/learn/modern-asynchronous-javascript-with-async-and-await)
-* Closures
+* [Closures](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Closures)
 * [The Event Loop](https://nodejs.dev/learn/the-nodejs-event-loop)


### PR DESCRIPTION
The 'closure' wasn't hyperlinked to any resource, hence hyperlinked it to the mdn docs

<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
