### PR TITLE
Docs example of order between promise nextTick immediate.

### DIFF
--- a/src/documentation/0031-node-setimmediate/index.md
+++ b/src/documentation/0031-node-setimmediate/index.md
@@ -36,4 +36,4 @@ Here is an example to show the order between `setImmediate()`, `process.nextTick
   style="height: 500px; width: 100%; border: 0;">
 </iframe>
 
-This code will first call `start()`, then call `foo()` in `process.nextTick queue`. After that, it will handle `promises microtask queue`, which prints `bar` and adds `zoo()` in `process.nextTick queue` at the same time. Then it will called `zoo()` which just be added. In the end, the `baz()` is called.
+This code will first call `start()`, then call `foo()` in `process.nextTick queue`. After that, it will handle `promises microtask queue`, which prints `bar` and adds `zoo()` in `process.nextTick queue` at the same time. Then it will call `zoo()` which just be added. In the end, the `baz()` is called.

--- a/src/documentation/0031-node-setimmediate/index.md
+++ b/src/documentation/0031-node-setimmediate/index.md
@@ -1,7 +1,7 @@
 ---
 title: 'Understanding setImmediate()'
 description: 'The Node.js setImmediate function interacts with the event loop in a special way'
-authors: flaviocopes, MylesBorins, LaRuaNa, ahmadawais
+authors: flaviocopes, MylesBorins, LaRuaNa, ahmadawais, clean99
 section: Getting Started
 category: learn
 ---

--- a/src/documentation/0031-node-setimmediate/index.md
+++ b/src/documentation/0031-node-setimmediate/index.md
@@ -16,8 +16,24 @@ setImmediate(() => {
 
 Any function passed as the setImmediate() argument is a callback that's executed in the next iteration of the event loop.
 
-How is `setImmediate()` different from `setTimeout(() => {}, 0)` (passing a 0ms timeout), and from `process.nextTick()`?
+How is `setImmediate()` different from `setTimeout(() => {}, 0)` (passing a 0ms timeout), and from `process.nextTick()` and `Promise.then()`?
 
 A function passed to `process.nextTick()` is going to be executed on the current iteration of the event loop, after the current operation ends. This means it will always execute before `setTimeout` and `setImmediate`.
 
 A `setTimeout()` callback with a 0ms delay is very similar to `setImmediate()`. The execution order will depend on various factors, but they will be both run in the next iteration of the event loop.
+
+A `process.nextTick` callback is added to `process.nextTick queue`. A `Promise.then()` callback is added to `promises microtask queue`.
+
+Event loop executes tasks in `process.nextTick queue` first, and then executes `promises microtask queue`.
+
+Here is an example to show the order between `setImmediate()`, `process.nextTick()` and `Promise.then()`:
+
+<iframe
+  title="A simple example for showing difference between setImmediate nextTick Promise"
+  src="https://stackblitz.com/edit/nodejs-dev-setimmediate?file=index.js
+  &zenmode=1&view=editor"
+  alt="nodejs-dev-setimmediate-example on StackBlitz"
+  style="height: 500px; width: 100%; border: 0;">
+</iframe>
+
+This code will first call `start()`, then call `foo()` in `process.nextTick queue`. After that, it will handle `promises microtask queue`, which prints `bar` and adds `zoo()` in `process.nextTick queue` at the same time. Then it will called `zoo()` which just be added. In the end, the `baz()` is called.

--- a/src/documentation/0031-node-setimmediate/index.md
+++ b/src/documentation/0031-node-setimmediate/index.md
@@ -36,4 +36,4 @@ Here is an example to show the order between `setImmediate()`, `process.nextTick
   style="height: 500px; width: 100%; border: 0;">
 </iframe>
 
-This code will first call `start()`, then call `foo()` in `process.nextTick queue`. After that, it will handle `promises microtask queue`, which prints `bar` and adds `zoo()` in `process.nextTick queue` at the same time. Then it will call `zoo()` which just be added. In the end, the `baz()` in `macrotask queue` is called.
+This code will first call `start()`, then call `foo()` in `process.nextTick queue`. After that, it will handle `promises microtask queue`, which prints `bar` and adds `zoo()` in `process.nextTick queue` at the same time. Then it will call `zoo()` which has just been added. In the end, the `baz()` in `macrotask queue` is called.

--- a/src/documentation/0031-node-setimmediate/index.md
+++ b/src/documentation/0031-node-setimmediate/index.md
@@ -23,6 +23,7 @@ A function passed to `process.nextTick()` is going to be executed on the current
 A `setTimeout()` callback with a 0ms delay is very similar to `setImmediate()`. The execution order will depend on various factors, but they will be both run in the next iteration of the event loop.
 
 A `process.nextTick` callback is added to `process.nextTick queue`. A `Promise.then()` callback is added to `promises microtask queue`. A `setTimeout`, `setImmediate` callback is added to `macrotask queue`.
+
 Event loop executes tasks in `process.nextTick queue` first, and then executes `promises microtask queue`, and then executes `macrotask queue`.
 
 Here is an example to show the order between `setImmediate()`, `process.nextTick()` and `Promise.then()`:

--- a/src/documentation/0031-node-setimmediate/index.md
+++ b/src/documentation/0031-node-setimmediate/index.md
@@ -22,9 +22,8 @@ A function passed to `process.nextTick()` is going to be executed on the current
 
 A `setTimeout()` callback with a 0ms delay is very similar to `setImmediate()`. The execution order will depend on various factors, but they will be both run in the next iteration of the event loop.
 
-A `process.nextTick` callback is added to `process.nextTick queue`. A `Promise.then()` callback is added to `promises microtask queue`.
-
-Event loop executes tasks in `process.nextTick queue` first, and then executes `promises microtask queue`.
+A `process.nextTick` callback is added to `process.nextTick queue`. A `Promise.then()` callback is added to `promises microtask queue`. A `setTimeout`, `setImmediate` callback is added to `macrotask queue`.
+Event loop executes tasks in `process.nextTick queue` first, and then executes `promises microtask queue`, and then executes `macrotask queue`.
 
 Here is an example to show the order between `setImmediate()`, `process.nextTick()` and `Promise.then()`:
 
@@ -36,4 +35,4 @@ Here is an example to show the order between `setImmediate()`, `process.nextTick
   style="height: 500px; width: 100%; border: 0;">
 </iframe>
 
-This code will first call `start()`, then call `foo()` in `process.nextTick queue`. After that, it will handle `promises microtask queue`, which prints `bar` and adds `zoo()` in `process.nextTick queue` at the same time. Then it will call `zoo()` which just be added. In the end, the `baz()` is called.
+This code will first call `start()`, then call `foo()` in `process.nextTick queue`. After that, it will handle `promises microtask queue`, which prints `bar` and adds `zoo()` in `process.nextTick queue` at the same time. Then it will call `zoo()` which just be added. In the end, the `baz()` in `macrotask queue` is called.


### PR DESCRIPTION
## Description

The docs shows how to use `promise` `nextTick` `immediate` to add callbacks in the queue, but the execution order of them is always confusing for beginners. So I add an example and explanation to show the execution order of them.

## Related Issues
[About Promise & process.nextTick](https://github.com/nodejs/help/issues/1789)

#2071 