### PR TITLE
fix(download): fixed border-radius and padding based on figmas

### DIFF
--- a/src/components/DownloadAdditional/DownloadAdditional.scss
+++ b/src/components/DownloadAdditional/DownloadAdditional.scss
@@ -33,8 +33,19 @@ $downloadable-item-height: 40px;
     padding: 16px 0 0 16px;
     transition: height 30ms ease-in;
 
+    &:first-of-type {
+      border-top-left-radius: 2px;
+      border-top-right-radius: 2px;
+    }
+
+    &:last-of-type {
+      border-bottom-left-radius: 2px;
+      border-bottom-right-radius: 2px;
+    }
+
     &__expanded {
       height: auto;
+      padding-bottom: 5px;
     }
 
     &__header {


### PR DESCRIPTION
## Description

This PR fixes the `padding` and `border-radius` for the Additional Downloads section. It tries to follow the Figma's without breaking other aspects.

### Screenshot

<img width="890" alt="image" src="https://user-images.githubusercontent.com/12037269/174827107-dd197a41-9a93-478f-982f-0c5d53278a4f.png">
