### PR TITLE
chore: remove footer component and consume it from layout

### DIFF
--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -3,7 +3,6 @@ import { graphql } from 'gatsby';
 import { Page } from '../types';
 import Layout from '../components/Layout';
 import Article from '../components/Article';
-import Footer from '../components/Footer';
 import '../styles/article-reader.scss';
 import SideNavBar, { SideNavBarKeys } from '../components/SideNavBar';
 

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -12,20 +12,17 @@ const AboutPage = ({ data }: Page): JSX.Element => {
   const { body } = data.page;
   const { authors } = data.page.fields;
   return (
-    <>
-      <Layout title={title} description={description} showFooter={false}>
-        <main className="grid-container">
-          <SideNavBar pageKey={SideNavBarKeys.about} />
-          <Article
-            title={title}
-            body={body}
-            authors={authors}
-            editPath="content/about/about.md"
-          />
-        </main>
-      </Layout>
-      <Footer />
-    </>
+    <Layout title={title} description={description}>
+      <main className="grid-container">
+        <SideNavBar pageKey={SideNavBarKeys.about} />
+        <Article
+          title={title}
+          body={body}
+          authors={authors}
+          editPath="content/about/about.md"
+        />
+      </main>
+    </Layout>
   );
 };
 

--- a/src/pages/community.tsx
+++ b/src/pages/community.tsx
@@ -3,8 +3,6 @@ import { graphql } from 'gatsby';
 import { Page } from '../types';
 import Layout from '../components/Layout';
 import Article from '../components/Article';
-import Footer from '../components/Footer';
-
 import '../styles/article-reader.scss';
 import '../styles/community.scss';
 import SideNavBar, { SideNavBarKeys } from '../components/SideNavBar';

--- a/src/pages/community.tsx
+++ b/src/pages/community.tsx
@@ -15,21 +15,18 @@ const CommunityPage = ({ data }: Page): JSX.Element => {
   const { authors } = data.page.fields;
 
   return (
-    <>
-      <Layout title={title} description={description} showFooter={false}>
-        <main className="grid-container">
-          <SideNavBar pageKey={SideNavBarKeys.community} />
-          <Article
-            title={title}
-            body={body}
-            tableOfContents={tableOfContents}
-            authors={authors}
-            editPath="content/community/index.md"
-          />
-        </main>
-      </Layout>
-      <Footer />
-    </>
+    <Layout title={title} description={description}>
+      <main className="grid-container">
+        <SideNavBar pageKey={SideNavBarKeys.community} />
+        <Article
+          title={title}
+          body={body}
+          tableOfContents={tableOfContents}
+          authors={authors}
+          editPath="content/community/index.md"
+        />
+      </main>
+    </Layout>
   );
 };
 

--- a/src/pages/docs.tsx
+++ b/src/pages/docs.tsx
@@ -10,7 +10,6 @@ import { ApiDocsObj, APIResponse } from '../hooks/useApiDocs';
 import downloadUrlByOs from '../util/downloadUrlByOS';
 import { detectOS, UserOS } from '../util/detectOS';
 
-import Footer from '../components/Footer';
 import Layout from '../components/Layout';
 import ShellBox from '../components/ShellBox';
 

--- a/src/pages/docs.tsx
+++ b/src/pages/docs.tsx
@@ -704,53 +704,42 @@ const APIDocsPage = ({
   }, [apiData]);
 
   return (
-    <>
-      <Layout
-        title={title}
-        description={description}
-        location={location}
-        showFooter={false}
-      >
-        <main className="grid-container">
-          <nav aria-label="Secondary" className="api-nav">
-            <ul className="api-nav__list">
-              <li className="api-nav__list-item">
-                {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-                <label
-                  className="sr-only"
-                  htmlFor="api-nav__version__select-id"
-                >
-                  Select API version
-                </label>
-                <select
-                  id="api-nav__version__select-id"
-                  className="api-nav__version"
-                  onChange={(e): void => {
-                    setPage(null);
-                    setVersion(e.target.value);
-                  }}
-                >
-                  {releases.map(
-                    (release): JSX.Element => (
-                      <option value={release.version} key={release.version}>
-                        {release.version}
-                      </option>
-                    )
-                  )}
-                </select>
-              </li>
-              {sideBarSection('Globals', 'globals', apiData)}
-              {sideBarSection('Methods', 'methods', apiData)}
-              {sideBarSection('Misc', 'miscs', apiData)}
-              {sideBarSection('Modules', 'modules', apiData)}
-              {sideBarSection('Classes', 'classes', apiData)}
-            </ul>
-          </nav>
-          {renderArticle(page, userOS, currentVersionSelected || '')}
-        </main>
-      </Layout>
-      <Footer />
-    </>
+    <Layout title={title} description={description} location={location}>
+      <main className="grid-container">
+        <nav aria-label="Secondary" className="api-nav">
+          <ul className="api-nav__list">
+            <li className="api-nav__list-item">
+              {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+              <label className="sr-only" htmlFor="api-nav__version__select-id">
+                Select API version
+              </label>
+              <select
+                id="api-nav__version__select-id"
+                className="api-nav__version"
+                onChange={(e): void => {
+                  setPage(null);
+                  setVersion(e.target.value);
+                }}
+              >
+                {releases.map(
+                  (release): JSX.Element => (
+                    <option value={release.version} key={release.version}>
+                      {release.version}
+                    </option>
+                  )
+                )}
+              </select>
+            </li>
+            {sideBarSection('Globals', 'globals', apiData)}
+            {sideBarSection('Methods', 'methods', apiData)}
+            {sideBarSection('Misc', 'miscs', apiData)}
+            {sideBarSection('Modules', 'modules', apiData)}
+            {sideBarSection('Classes', 'classes', apiData)}
+          </ul>
+        </nav>
+        {renderArticle(page, userOS, currentVersionSelected || '')}
+      </main>
+    </Layout>
   );
 };
 

--- a/src/pages/download/package-manager.tsx
+++ b/src/pages/download/package-manager.tsx
@@ -12,21 +12,18 @@ const PackageManagerPage = ({ data }: Page): JSX.Element => {
   const { body, tableOfContents } = data.page;
   const { authors } = data.page.fields;
   return (
-    <>
-      <Layout title={title} description={description} showFooter={false}>
-        <main className="grid-container">
-          <SideNavBar pageKey={SideNavBarKeys.packageManager} />
-          <Article
-            title={title}
-            body={body}
-            tableOfContents={tableOfContents}
-            authors={authors}
-            editPath="content/download/package-manager.md"
-          />
-        </main>
-      </Layout>
-      <Footer />
-    </>
+    <Layout title={title} description={description}>
+      <main className="grid-container">
+        <SideNavBar pageKey={SideNavBarKeys.packageManager} />
+        <Article
+          title={title}
+          body={body}
+          tableOfContents={tableOfContents}
+          authors={authors}
+          editPath="content/download/package-manager.md"
+        />
+      </main>
+    </Layout>
   );
 };
 

--- a/src/pages/download/package-manager.tsx
+++ b/src/pages/download/package-manager.tsx
@@ -3,7 +3,6 @@ import { graphql } from 'gatsby';
 import { Page } from '../../types';
 import Layout from '../../components/Layout';
 import Article from '../../components/Article';
-import Footer from '../../components/Footer';
 import '../../styles/article-reader.scss';
 import SideNavBar, { SideNavBarKeys } from '../../components/SideNavBar';
 

--- a/src/pages/governance.tsx
+++ b/src/pages/governance.tsx
@@ -3,7 +3,6 @@ import { graphql } from 'gatsby';
 import { Page } from '../types';
 import Layout from '../components/Layout';
 import Article from '../components/Article';
-import Footer from '../components/Footer';
 import '../styles/article-reader.scss';
 import SideNavBar, { SideNavBarKeys } from '../components/SideNavBar';
 

--- a/src/pages/governance.tsx
+++ b/src/pages/governance.tsx
@@ -13,21 +13,18 @@ const GovernancePage = ({ data }: Page): JSX.Element => {
   const { authors } = data.page.fields;
 
   return (
-    <>
-      <Layout title={title} description={description} showFooter={false}>
-        <main className="grid-container">
-          <SideNavBar pageKey={SideNavBarKeys.governance} />
-          <Article
-            title={title}
-            body={body}
-            tableOfContents={tableOfContents}
-            authors={authors}
-            editPath="content/about/governance.md"
-          />
-        </main>
-      </Layout>
-      <Footer />
-    </>
+    <Layout title={title} description={description}>
+      <main className="grid-container">
+        <SideNavBar pageKey={SideNavBarKeys.governance} />
+        <Article
+          title={title}
+          body={body}
+          tableOfContents={tableOfContents}
+          authors={authors}
+          editPath="content/about/governance.md"
+        />
+      </main>
+    </Layout>
   );
 };
 

--- a/src/pages/privacy.tsx
+++ b/src/pages/privacy.tsx
@@ -3,7 +3,6 @@ import { graphql } from 'gatsby';
 import { Page } from '../types';
 import Layout from '../components/Layout';
 import Article from '../components/Article';
-import Footer from '../components/Footer';
 import '../styles/article-reader.scss';
 import SideNavBar, { SideNavBarKeys } from '../components/SideNavBar';
 

--- a/src/pages/privacy.tsx
+++ b/src/pages/privacy.tsx
@@ -13,21 +13,18 @@ const PrivacyPage = ({ data }: Page): JSX.Element => {
   const { authors } = data.page.fields;
 
   return (
-    <>
-      <Layout title={title} description={description} showFooter={false}>
-        <main className="grid-container">
-          <SideNavBar pageKey={SideNavBarKeys.privacy} />
-          <Article
-            title={title}
-            body={body}
-            tableOfContents={tableOfContents}
-            authors={authors}
-            editPath="content/about/privacy.md"
-          />
-        </main>
-      </Layout>
-      <Footer />
-    </>
+    <Layout title={title} description={description}>
+      <main className="grid-container">
+        <SideNavBar pageKey={SideNavBarKeys.privacy} />
+        <Article
+          title={title}
+          body={body}
+          tableOfContents={tableOfContents}
+          authors={authors}
+          editPath="content/about/privacy.md"
+        />
+      </main>
+    </Layout>
   );
 };
 

--- a/src/pages/releases.tsx
+++ b/src/pages/releases.tsx
@@ -3,7 +3,6 @@ import { graphql } from 'gatsby';
 import { Page, NodeReleaseData, DataPage } from '../types';
 import Layout from '../components/Layout';
 import Article from '../components/Article';
-import Footer from '../components/Footer';
 import '../styles/article-reader.scss';
 import DownloadTable from '../components/DownloadReleases/DownloadTable';
 import SideNavBar, { SideNavBarKeys } from '../components/SideNavBar';

--- a/src/pages/releases.tsx
+++ b/src/pages/releases.tsx
@@ -27,23 +27,20 @@ const ReleasesPage = ({
   const { nodeReleasesData } = nodeReleases;
 
   return (
-    <>
-      <Layout title={title} description={description} showFooter={false}>
-        <main className="grid-container">
-          <SideNavBar pageKey={SideNavBarKeys.releases} />
-          <Article
-            title={title}
-            body={body}
-            tableOfContents={tableOfContents}
-            authors={authors}
-            editPath="content/about/releases.md"
-          >
-            <DownloadTable nodeReleasesData={nodeReleasesData} />
-          </Article>
-        </main>
-      </Layout>
-      <Footer />
-    </>
+    <Layout title={title} description={description}>
+      <main className="grid-container">
+        <SideNavBar pageKey={SideNavBarKeys.releases} />
+        <Article
+          title={title}
+          body={body}
+          tableOfContents={tableOfContents}
+          authors={authors}
+          editPath="content/about/releases.md"
+        >
+          <DownloadTable nodeReleasesData={nodeReleasesData} />
+        </Article>
+      </main>
+    </Layout>
   );
 };
 

--- a/src/pages/resources.tsx
+++ b/src/pages/resources.tsx
@@ -3,7 +3,6 @@ import { graphql } from 'gatsby';
 import { Page } from '../types';
 import Layout from '../components/Layout';
 import Article from '../components/Article';
-import Footer from '../components/Footer';
 import '../styles/article-reader.scss';
 import SideNavBar, { SideNavBarKeys } from '../components/SideNavBar';
 

--- a/src/pages/resources.tsx
+++ b/src/pages/resources.tsx
@@ -12,20 +12,17 @@ const ResourcesPage = ({ data }: Page): JSX.Element => {
   const { body } = data.page;
   const { authors } = data.page.fields;
   return (
-    <>
-      <Layout title={title} description={description} showFooter={false}>
-        <main className="grid-container">
-          <SideNavBar pageKey={SideNavBarKeys.resources} />
-          <Article
-            title={title}
-            body={body}
-            authors={authors}
-            editPath="content/resources/resources.md"
-          />
-        </main>
-      </Layout>
-      <Footer />
-    </>
+    <Layout title={title} description={description}>
+      <main className="grid-container">
+        <SideNavBar pageKey={SideNavBarKeys.resources} />
+        <Article
+          title={title}
+          body={body}
+          authors={authors}
+          editPath="content/resources/resources.md"
+        />
+      </main>
+    </Layout>
   );
 };
 

--- a/src/pages/security.tsx
+++ b/src/pages/security.tsx
@@ -3,7 +3,6 @@ import { graphql } from 'gatsby';
 import { Page } from '../types';
 import Layout from '../components/Layout';
 import Article from '../components/Article';
-import Footer from '../components/Footer';
 import '../styles/article-reader.scss';
 import SideNavBar, { SideNavBarKeys } from '../components/SideNavBar';
 

--- a/src/pages/security.tsx
+++ b/src/pages/security.tsx
@@ -12,21 +12,18 @@ const SecurityPage = ({ data }: Page): JSX.Element => {
   const { body, tableOfContents } = data.page;
   const { authors } = data.page.fields;
   return (
-    <>
-      <Layout title={title} description={description} showFooter={false}>
-        <main className="grid-container">
-          <SideNavBar pageKey={SideNavBarKeys.security} />
-          <Article
-            title={title}
-            body={body}
-            tableOfContents={tableOfContents}
-            authors={authors}
-            editPath="content/about/security.md"
-          />
-        </main>
-      </Layout>
-      <Footer />
-    </>
+    <Layout title={title} description={description}>
+      <main className="grid-container">
+        <SideNavBar pageKey={SideNavBarKeys.security} />
+        <Article
+          title={title}
+          body={body}
+          tableOfContents={tableOfContents}
+          authors={authors}
+          editPath="content/about/security.md"
+        />
+      </main>
+    </Layout>
   );
 };
 

--- a/src/pages/trademark.tsx
+++ b/src/pages/trademark.tsx
@@ -3,7 +3,6 @@ import { graphql } from 'gatsby';
 import { Page } from '../types';
 import Layout from '../components/Layout';
 import Article from '../components/Article';
-import Footer from '../components/Footer';
 import '../styles/article-reader.scss';
 import SideNavBar, { SideNavBarKeys } from '../components/SideNavBar';
 

--- a/src/pages/trademark.tsx
+++ b/src/pages/trademark.tsx
@@ -13,21 +13,18 @@ const TrademarkPage = ({ data }: Page): JSX.Element => {
   const { authors } = data.page.fields;
 
   return (
-    <>
-      <Layout title={title} description={description} showFooter={false}>
-        <main className="grid-container">
-          <SideNavBar pageKey={SideNavBarKeys.trademark} />
-          <Article
-            title={title}
-            body={body}
-            tableOfContents={tableOfContents}
-            authors={authors}
-            editPath="content/about/trademark.md"
-          />
-        </main>
-      </Layout>
-      <Footer />
-    </>
+    <Layout title={title} description={description}>
+      <main className="grid-container">
+        <SideNavBar pageKey={SideNavBarKeys.trademark} />
+        <Article
+          title={title}
+          body={body}
+          tableOfContents={tableOfContents}
+          authors={authors}
+          editPath="content/about/trademark.md"
+        />
+      </main>
+    </Layout>
   );
 };
 

--- a/src/pages/working-groups.tsx
+++ b/src/pages/working-groups.tsx
@@ -3,7 +3,6 @@ import { graphql } from 'gatsby';
 import { Page } from '../types';
 import Layout from '../components/Layout';
 import Article from '../components/Article';
-import Footer from '../components/Footer';
 import '../styles/article-reader.scss';
 import SideNavBar, { SideNavBarKeys } from '../components/SideNavBar';
 

--- a/src/pages/working-groups.tsx
+++ b/src/pages/working-groups.tsx
@@ -12,20 +12,17 @@ const WorkingGroupsPage = ({ data }: Page): JSX.Element => {
   const { body } = data.page;
   const { authors } = data.page.fields;
   return (
-    <>
-      <Layout title={title} description={description} showFooter={false}>
-        <main className="grid-container">
-          <SideNavBar pageKey={SideNavBarKeys.workingGroups} />
-          <Article
-            title={title}
-            body={body}
-            authors={authors}
-            editPath="content/about/working-groups.md"
-          />
-        </main>
-      </Layout>
-      <Footer />
-    </>
+    <Layout title={title} description={description}>
+      <main className="grid-container">
+        <SideNavBar pageKey={SideNavBarKeys.workingGroups} />
+        <Article
+          title={title}
+          body={body}
+          authors={authors}
+          editPath="content/about/working-groups.md"
+        />
+      </main>
+    </Layout>
   );
 };
 

--- a/src/templates/blog.tsx
+++ b/src/templates/blog.tsx
@@ -6,7 +6,6 @@ import { BlogPageData, BlogPageContext } from '../types';
 
 import '../styles/article-reader.scss';
 import '../styles/learn.scss';
-import Footer from '../components/Footer';
 import RecentPosts from '../components/RecentPosts';
 
 interface Props {

--- a/src/templates/blog.tsx
+++ b/src/templates/blog.tsx
@@ -30,24 +30,21 @@ const BlogLayout = ({
   const { edges: recentPosts } = recent;
 
   return (
-    <>
-      <Layout title={title} description={excerpt} showFooter={false}>
-        <main className="grid-container blog-container">
-          <RecentPosts posts={recentPosts} />
-          <Article
-            title={title}
-            body={body}
-            next={next}
-            authors={author}
-            previous={previous}
-            relativePath={relativePath}
-            blog
-            date={date}
-          />
-        </main>
-      </Layout>
-      <Footer />
-    </>
+    <Layout title={title} description={excerpt}>
+      <main className="grid-container blog-container">
+        <RecentPosts posts={recentPosts} />
+        <Article
+          title={title}
+          body={body}
+          next={next}
+          authors={author}
+          previous={previous}
+          relativePath={relativePath}
+          blog
+          date={date}
+        />
+      </main>
+    </Layout>
   );
 };
 export default BlogLayout;

--- a/src/templates/learn.tsx
+++ b/src/templates/learn.tsx
@@ -7,7 +7,6 @@ import { LearnPageContext, LearnPageData } from '../types';
 
 import '../styles/article-reader.scss';
 import '../styles/learn.scss';
-import Footer from '../components/Footer';
 
 interface Props {
   data: LearnPageData;

--- a/src/templates/learn.tsx
+++ b/src/templates/learn.tsx
@@ -35,34 +35,26 @@ const LearnLayout = ({
   }
 
   return (
-    <>
-      <Layout
-        title={title}
-        description={description}
-        location={location}
-        showFooter={false}
-      >
-        <main className="grid-container">
-          <Navigation
-            currentSlug={slug}
-            previousSlug={previousSlug}
-            label="Secondary"
-            sections={navigationData}
-            category="learn"
-          />
-          <Article
-            title={title}
-            body={body}
-            tableOfContents={tableOfContents}
-            next={next}
-            authors={authors}
-            previous={previous}
-            relativePath={relativePath}
-          />
-        </main>
-      </Layout>
-      <Footer />
-    </>
+    <Layout title={title} description={description} location={location}>
+      <main className="grid-container">
+        <Navigation
+          currentSlug={slug}
+          previousSlug={previousSlug}
+          label="Secondary"
+          sections={navigationData}
+          category="learn"
+        />
+        <Article
+          title={title}
+          body={body}
+          tableOfContents={tableOfContents}
+          next={next}
+          authors={authors}
+          previous={previous}
+          relativePath={relativePath}
+        />
+      </main>
+    </Layout>
   );
 };
 export default LearnLayout;

--- a/test/pages/__snapshots__/about.test.tsx.snap
+++ b/test/pages/__snapshots__/about.test.tsx.snap
@@ -327,117 +327,117 @@ exports[`About page renders correctly 1`] = `
         </div>
       </article>
     </main>
-  </div>
-  <section
-    class="bottom-info"
-  >
-    <div
-      class="random-contributor"
-    />
-  </section>
-  <footer
-    class="footer"
-  >
-    <ul
-      class="footer__left"
+    <section
+      class="bottom-info"
     >
-      <li>
-        <a
-          class="footer__link"
-          href="/trademark"
-        >
-          Trademark Policy
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="/privacy"
-        >
-          Privacy Policy
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="https://github.com/openjs-foundation/cross-project-council/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct"
-        >
-          Code of Conduct
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="/security"
-        >
-          Security Reporting
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="/about"
-        >
-          About
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="https://nodejs.org/en/blog/"
-        >
-          Blog
-        </a>
-      </li>
-    </ul>
-    <ul
-      class="footer__right"
+      <div
+        class="random-contributor"
+      />
+    </section>
+    <footer
+      class="footer"
     >
-      <li>
-        © OpenJS Foundation
-      </li>
-      <li>
-        <a
-          aria-label="Node.js Github Page Link"
-          href="https://github.com/nodejs/node"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <span
-            class="sr-only"
+      <ul
+        class="footer__left"
+      >
+        <li>
+          <a
+            class="footer__link"
+            href="/trademark"
           >
-            GitHub
-          </span>
-          <svg
-            fill="var(--color-text-secondary)"
-          />
-        </a>
-      </li>
-      <li>
-        <a
-          aria-label="Node.js Twitter Link"
-          href="https://twitter.com/nodejs"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <svg
-            fill="var(--color-text-secondary)"
-          />
-        </a>
-      </li>
-      <li>
-        <a
-          aria-label="Node.js Slack Link"
-          href="https://slack.openjsf.org"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <svg
-            fill="var(--color-text-secondary)"
-          />
-        </a>
-      </li>
-    </ul>
-  </footer>
+            Trademark Policy
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="/privacy"
+          >
+            Privacy Policy
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="https://github.com/openjs-foundation/cross-project-council/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct"
+          >
+            Code of Conduct
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="/security"
+          >
+            Security Reporting
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="/about"
+          >
+            About
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="https://nodejs.org/en/blog/"
+          >
+            Blog
+          </a>
+        </li>
+      </ul>
+      <ul
+        class="footer__right"
+      >
+        <li>
+          © OpenJS Foundation
+        </li>
+        <li>
+          <a
+            aria-label="Node.js Github Page Link"
+            href="https://github.com/nodejs/node"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <span
+              class="sr-only"
+            >
+              GitHub
+            </span>
+            <svg
+              fill="var(--color-text-secondary)"
+            />
+          </a>
+        </li>
+        <li>
+          <a
+            aria-label="Node.js Twitter Link"
+            href="https://twitter.com/nodejs"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <svg
+              fill="var(--color-text-secondary)"
+            />
+          </a>
+        </li>
+        <li>
+          <a
+            aria-label="Node.js Slack Link"
+            href="https://slack.openjsf.org"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <svg
+              fill="var(--color-text-secondary)"
+            />
+          </a>
+        </li>
+      </ul>
+    </footer>
+  </div>
 </div>
 `;

--- a/test/pages/__snapshots__/community.test.tsx.snap
+++ b/test/pages/__snapshots__/community.test.tsx.snap
@@ -354,117 +354,117 @@ exports[`Community Page renders correctly 1`] = `
         </div>
       </article>
     </main>
-  </div>
-  <section
-    class="bottom-info"
-  >
-    <div
-      class="random-contributor"
-    />
-  </section>
-  <footer
-    class="footer"
-  >
-    <ul
-      class="footer__left"
+    <section
+      class="bottom-info"
     >
-      <li>
-        <a
-          class="footer__link"
-          href="/trademark"
-        >
-          Trademark Policy
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="/privacy"
-        >
-          Privacy Policy
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="https://github.com/openjs-foundation/cross-project-council/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct"
-        >
-          Code of Conduct
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="/security"
-        >
-          Security Reporting
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="/about"
-        >
-          About
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="https://nodejs.org/en/blog/"
-        >
-          Blog
-        </a>
-      </li>
-    </ul>
-    <ul
-      class="footer__right"
+      <div
+        class="random-contributor"
+      />
+    </section>
+    <footer
+      class="footer"
     >
-      <li>
-        © OpenJS Foundation
-      </li>
-      <li>
-        <a
-          aria-label="Node.js Github Page Link"
-          href="https://github.com/nodejs/node"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <span
-            class="sr-only"
+      <ul
+        class="footer__left"
+      >
+        <li>
+          <a
+            class="footer__link"
+            href="/trademark"
           >
-            GitHub
-          </span>
-          <svg
-            fill="var(--color-text-secondary)"
-          />
-        </a>
-      </li>
-      <li>
-        <a
-          aria-label="Node.js Twitter Link"
-          href="https://twitter.com/nodejs"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <svg
-            fill="var(--color-text-secondary)"
-          />
-        </a>
-      </li>
-      <li>
-        <a
-          aria-label="Node.js Slack Link"
-          href="https://slack.openjsf.org"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <svg
-            fill="var(--color-text-secondary)"
-          />
-        </a>
-      </li>
-    </ul>
-  </footer>
+            Trademark Policy
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="/privacy"
+          >
+            Privacy Policy
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="https://github.com/openjs-foundation/cross-project-council/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct"
+          >
+            Code of Conduct
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="/security"
+          >
+            Security Reporting
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="/about"
+          >
+            About
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="https://nodejs.org/en/blog/"
+          >
+            Blog
+          </a>
+        </li>
+      </ul>
+      <ul
+        class="footer__right"
+      >
+        <li>
+          © OpenJS Foundation
+        </li>
+        <li>
+          <a
+            aria-label="Node.js Github Page Link"
+            href="https://github.com/nodejs/node"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <span
+              class="sr-only"
+            >
+              GitHub
+            </span>
+            <svg
+              fill="var(--color-text-secondary)"
+            />
+          </a>
+        </li>
+        <li>
+          <a
+            aria-label="Node.js Twitter Link"
+            href="https://twitter.com/nodejs"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <svg
+              fill="var(--color-text-secondary)"
+            />
+          </a>
+        </li>
+        <li>
+          <a
+            aria-label="Node.js Slack Link"
+            href="https://slack.openjsf.org"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <svg
+              fill="var(--color-text-secondary)"
+            />
+          </a>
+        </li>
+      </ul>
+    </footer>
+  </div>
 </div>
 `;

--- a/test/pages/__snapshots__/governance.test.tsx.snap
+++ b/test/pages/__snapshots__/governance.test.tsx.snap
@@ -354,117 +354,117 @@ exports[`Governance Page renders correctly 1`] = `
         </div>
       </article>
     </main>
-  </div>
-  <section
-    class="bottom-info"
-  >
-    <div
-      class="random-contributor"
-    />
-  </section>
-  <footer
-    class="footer"
-  >
-    <ul
-      class="footer__left"
+    <section
+      class="bottom-info"
     >
-      <li>
-        <a
-          class="footer__link"
-          href="/trademark"
-        >
-          Trademark Policy
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="/privacy"
-        >
-          Privacy Policy
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="https://github.com/openjs-foundation/cross-project-council/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct"
-        >
-          Code of Conduct
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="/security"
-        >
-          Security Reporting
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="/about"
-        >
-          About
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="https://nodejs.org/en/blog/"
-        >
-          Blog
-        </a>
-      </li>
-    </ul>
-    <ul
-      class="footer__right"
+      <div
+        class="random-contributor"
+      />
+    </section>
+    <footer
+      class="footer"
     >
-      <li>
-        © OpenJS Foundation
-      </li>
-      <li>
-        <a
-          aria-label="Node.js Github Page Link"
-          href="https://github.com/nodejs/node"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <span
-            class="sr-only"
+      <ul
+        class="footer__left"
+      >
+        <li>
+          <a
+            class="footer__link"
+            href="/trademark"
           >
-            GitHub
-          </span>
-          <svg
-            fill="var(--color-text-secondary)"
-          />
-        </a>
-      </li>
-      <li>
-        <a
-          aria-label="Node.js Twitter Link"
-          href="https://twitter.com/nodejs"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <svg
-            fill="var(--color-text-secondary)"
-          />
-        </a>
-      </li>
-      <li>
-        <a
-          aria-label="Node.js Slack Link"
-          href="https://slack.openjsf.org"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <svg
-            fill="var(--color-text-secondary)"
-          />
-        </a>
-      </li>
-    </ul>
-  </footer>
+            Trademark Policy
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="/privacy"
+          >
+            Privacy Policy
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="https://github.com/openjs-foundation/cross-project-council/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct"
+          >
+            Code of Conduct
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="/security"
+          >
+            Security Reporting
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="/about"
+          >
+            About
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="https://nodejs.org/en/blog/"
+          >
+            Blog
+          </a>
+        </li>
+      </ul>
+      <ul
+        class="footer__right"
+      >
+        <li>
+          © OpenJS Foundation
+        </li>
+        <li>
+          <a
+            aria-label="Node.js Github Page Link"
+            href="https://github.com/nodejs/node"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <span
+              class="sr-only"
+            >
+              GitHub
+            </span>
+            <svg
+              fill="var(--color-text-secondary)"
+            />
+          </a>
+        </li>
+        <li>
+          <a
+            aria-label="Node.js Twitter Link"
+            href="https://twitter.com/nodejs"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <svg
+              fill="var(--color-text-secondary)"
+            />
+          </a>
+        </li>
+        <li>
+          <a
+            aria-label="Node.js Slack Link"
+            href="https://slack.openjsf.org"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <svg
+              fill="var(--color-text-secondary)"
+            />
+          </a>
+        </li>
+      </ul>
+    </footer>
+  </div>
 </div>
 `;

--- a/test/pages/__snapshots__/privacy.test.tsx.snap
+++ b/test/pages/__snapshots__/privacy.test.tsx.snap
@@ -354,117 +354,117 @@ exports[`Privacy Page renders correctly 1`] = `
         </div>
       </article>
     </main>
-  </div>
-  <section
-    class="bottom-info"
-  >
-    <div
-      class="random-contributor"
-    />
-  </section>
-  <footer
-    class="footer"
-  >
-    <ul
-      class="footer__left"
+    <section
+      class="bottom-info"
     >
-      <li>
-        <a
-          class="footer__link"
-          href="/trademark"
-        >
-          Trademark Policy
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="/privacy"
-        >
-          Privacy Policy
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="https://github.com/openjs-foundation/cross-project-council/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct"
-        >
-          Code of Conduct
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="/security"
-        >
-          Security Reporting
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="/about"
-        >
-          About
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="https://nodejs.org/en/blog/"
-        >
-          Blog
-        </a>
-      </li>
-    </ul>
-    <ul
-      class="footer__right"
+      <div
+        class="random-contributor"
+      />
+    </section>
+    <footer
+      class="footer"
     >
-      <li>
-        © OpenJS Foundation
-      </li>
-      <li>
-        <a
-          aria-label="Node.js Github Page Link"
-          href="https://github.com/nodejs/node"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <span
-            class="sr-only"
+      <ul
+        class="footer__left"
+      >
+        <li>
+          <a
+            class="footer__link"
+            href="/trademark"
           >
-            GitHub
-          </span>
-          <svg
-            fill="var(--color-text-secondary)"
-          />
-        </a>
-      </li>
-      <li>
-        <a
-          aria-label="Node.js Twitter Link"
-          href="https://twitter.com/nodejs"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <svg
-            fill="var(--color-text-secondary)"
-          />
-        </a>
-      </li>
-      <li>
-        <a
-          aria-label="Node.js Slack Link"
-          href="https://slack.openjsf.org"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <svg
-            fill="var(--color-text-secondary)"
-          />
-        </a>
-      </li>
-    </ul>
-  </footer>
+            Trademark Policy
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="/privacy"
+          >
+            Privacy Policy
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="https://github.com/openjs-foundation/cross-project-council/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct"
+          >
+            Code of Conduct
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="/security"
+          >
+            Security Reporting
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="/about"
+          >
+            About
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="https://nodejs.org/en/blog/"
+          >
+            Blog
+          </a>
+        </li>
+      </ul>
+      <ul
+        class="footer__right"
+      >
+        <li>
+          © OpenJS Foundation
+        </li>
+        <li>
+          <a
+            aria-label="Node.js Github Page Link"
+            href="https://github.com/nodejs/node"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <span
+              class="sr-only"
+            >
+              GitHub
+            </span>
+            <svg
+              fill="var(--color-text-secondary)"
+            />
+          </a>
+        </li>
+        <li>
+          <a
+            aria-label="Node.js Twitter Link"
+            href="https://twitter.com/nodejs"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <svg
+              fill="var(--color-text-secondary)"
+            />
+          </a>
+        </li>
+        <li>
+          <a
+            aria-label="Node.js Slack Link"
+            href="https://slack.openjsf.org"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <svg
+              fill="var(--color-text-secondary)"
+            />
+          </a>
+        </li>
+      </ul>
+    </footer>
+  </div>
 </div>
 `;

--- a/test/pages/__snapshots__/releases.test.tsx.snap
+++ b/test/pages/__snapshots__/releases.test.tsx.snap
@@ -455,117 +455,117 @@ exports[`Releases page renders correctly 1`] = `
         </div>
       </article>
     </main>
-  </div>
-  <section
-    class="bottom-info"
-  >
-    <div
-      class="random-contributor"
-    />
-  </section>
-  <footer
-    class="footer"
-  >
-    <ul
-      class="footer__left"
+    <section
+      class="bottom-info"
     >
-      <li>
-        <a
-          class="footer__link"
-          href="/trademark"
-        >
-          Trademark Policy
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="/privacy"
-        >
-          Privacy Policy
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="https://github.com/openjs-foundation/cross-project-council/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct"
-        >
-          Code of Conduct
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="/security"
-        >
-          Security Reporting
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="/about"
-        >
-          About
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="https://nodejs.org/en/blog/"
-        >
-          Blog
-        </a>
-      </li>
-    </ul>
-    <ul
-      class="footer__right"
+      <div
+        class="random-contributor"
+      />
+    </section>
+    <footer
+      class="footer"
     >
-      <li>
-        © OpenJS Foundation
-      </li>
-      <li>
-        <a
-          aria-label="Node.js Github Page Link"
-          href="https://github.com/nodejs/node"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <span
-            class="sr-only"
+      <ul
+        class="footer__left"
+      >
+        <li>
+          <a
+            class="footer__link"
+            href="/trademark"
           >
-            GitHub
-          </span>
-          <svg
-            fill="var(--color-text-secondary)"
-          />
-        </a>
-      </li>
-      <li>
-        <a
-          aria-label="Node.js Twitter Link"
-          href="https://twitter.com/nodejs"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <svg
-            fill="var(--color-text-secondary)"
-          />
-        </a>
-      </li>
-      <li>
-        <a
-          aria-label="Node.js Slack Link"
-          href="https://slack.openjsf.org"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <svg
-            fill="var(--color-text-secondary)"
-          />
-        </a>
-      </li>
-    </ul>
-  </footer>
+            Trademark Policy
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="/privacy"
+          >
+            Privacy Policy
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="https://github.com/openjs-foundation/cross-project-council/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct"
+          >
+            Code of Conduct
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="/security"
+          >
+            Security Reporting
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="/about"
+          >
+            About
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="https://nodejs.org/en/blog/"
+          >
+            Blog
+          </a>
+        </li>
+      </ul>
+      <ul
+        class="footer__right"
+      >
+        <li>
+          © OpenJS Foundation
+        </li>
+        <li>
+          <a
+            aria-label="Node.js Github Page Link"
+            href="https://github.com/nodejs/node"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <span
+              class="sr-only"
+            >
+              GitHub
+            </span>
+            <svg
+              fill="var(--color-text-secondary)"
+            />
+          </a>
+        </li>
+        <li>
+          <a
+            aria-label="Node.js Twitter Link"
+            href="https://twitter.com/nodejs"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <svg
+              fill="var(--color-text-secondary)"
+            />
+          </a>
+        </li>
+        <li>
+          <a
+            aria-label="Node.js Slack Link"
+            href="https://slack.openjsf.org"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <svg
+              fill="var(--color-text-secondary)"
+            />
+          </a>
+        </li>
+      </ul>
+    </footer>
+  </div>
 </div>
 `;

--- a/test/pages/__snapshots__/resources.test.tsx.snap
+++ b/test/pages/__snapshots__/resources.test.tsx.snap
@@ -327,117 +327,117 @@ exports[`About page renders correctly 1`] = `
         </div>
       </article>
     </main>
-  </div>
-  <section
-    class="bottom-info"
-  >
-    <div
-      class="random-contributor"
-    />
-  </section>
-  <footer
-    class="footer"
-  >
-    <ul
-      class="footer__left"
+    <section
+      class="bottom-info"
     >
-      <li>
-        <a
-          class="footer__link"
-          href="/trademark"
-        >
-          Trademark Policy
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="/privacy"
-        >
-          Privacy Policy
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="https://github.com/openjs-foundation/cross-project-council/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct"
-        >
-          Code of Conduct
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="/security"
-        >
-          Security Reporting
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="/about"
-        >
-          About
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="https://nodejs.org/en/blog/"
-        >
-          Blog
-        </a>
-      </li>
-    </ul>
-    <ul
-      class="footer__right"
+      <div
+        class="random-contributor"
+      />
+    </section>
+    <footer
+      class="footer"
     >
-      <li>
-        © OpenJS Foundation
-      </li>
-      <li>
-        <a
-          aria-label="Node.js Github Page Link"
-          href="https://github.com/nodejs/node"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <span
-            class="sr-only"
+      <ul
+        class="footer__left"
+      >
+        <li>
+          <a
+            class="footer__link"
+            href="/trademark"
           >
-            GitHub
-          </span>
-          <svg
-            fill="var(--color-text-secondary)"
-          />
-        </a>
-      </li>
-      <li>
-        <a
-          aria-label="Node.js Twitter Link"
-          href="https://twitter.com/nodejs"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <svg
-            fill="var(--color-text-secondary)"
-          />
-        </a>
-      </li>
-      <li>
-        <a
-          aria-label="Node.js Slack Link"
-          href="https://slack.openjsf.org"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <svg
-            fill="var(--color-text-secondary)"
-          />
-        </a>
-      </li>
-    </ul>
-  </footer>
+            Trademark Policy
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="/privacy"
+          >
+            Privacy Policy
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="https://github.com/openjs-foundation/cross-project-council/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct"
+          >
+            Code of Conduct
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="/security"
+          >
+            Security Reporting
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="/about"
+          >
+            About
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="https://nodejs.org/en/blog/"
+          >
+            Blog
+          </a>
+        </li>
+      </ul>
+      <ul
+        class="footer__right"
+      >
+        <li>
+          © OpenJS Foundation
+        </li>
+        <li>
+          <a
+            aria-label="Node.js Github Page Link"
+            href="https://github.com/nodejs/node"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <span
+              class="sr-only"
+            >
+              GitHub
+            </span>
+            <svg
+              fill="var(--color-text-secondary)"
+            />
+          </a>
+        </li>
+        <li>
+          <a
+            aria-label="Node.js Twitter Link"
+            href="https://twitter.com/nodejs"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <svg
+              fill="var(--color-text-secondary)"
+            />
+          </a>
+        </li>
+        <li>
+          <a
+            aria-label="Node.js Slack Link"
+            href="https://slack.openjsf.org"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <svg
+              fill="var(--color-text-secondary)"
+            />
+          </a>
+        </li>
+      </ul>
+    </footer>
+  </div>
 </div>
 `;

--- a/test/pages/__snapshots__/security.test.tsx.snap
+++ b/test/pages/__snapshots__/security.test.tsx.snap
@@ -354,117 +354,117 @@ exports[`Security page renders correctly 1`] = `
         </div>
       </article>
     </main>
-  </div>
-  <section
-    class="bottom-info"
-  >
-    <div
-      class="random-contributor"
-    />
-  </section>
-  <footer
-    class="footer"
-  >
-    <ul
-      class="footer__left"
+    <section
+      class="bottom-info"
     >
-      <li>
-        <a
-          class="footer__link"
-          href="/trademark"
-        >
-          Trademark Policy
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="/privacy"
-        >
-          Privacy Policy
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="https://github.com/openjs-foundation/cross-project-council/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct"
-        >
-          Code of Conduct
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="/security"
-        >
-          Security Reporting
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="/about"
-        >
-          About
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="https://nodejs.org/en/blog/"
-        >
-          Blog
-        </a>
-      </li>
-    </ul>
-    <ul
-      class="footer__right"
+      <div
+        class="random-contributor"
+      />
+    </section>
+    <footer
+      class="footer"
     >
-      <li>
-        © OpenJS Foundation
-      </li>
-      <li>
-        <a
-          aria-label="Node.js Github Page Link"
-          href="https://github.com/nodejs/node"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <span
-            class="sr-only"
+      <ul
+        class="footer__left"
+      >
+        <li>
+          <a
+            class="footer__link"
+            href="/trademark"
           >
-            GitHub
-          </span>
-          <svg
-            fill="var(--color-text-secondary)"
-          />
-        </a>
-      </li>
-      <li>
-        <a
-          aria-label="Node.js Twitter Link"
-          href="https://twitter.com/nodejs"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <svg
-            fill="var(--color-text-secondary)"
-          />
-        </a>
-      </li>
-      <li>
-        <a
-          aria-label="Node.js Slack Link"
-          href="https://slack.openjsf.org"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <svg
-            fill="var(--color-text-secondary)"
-          />
-        </a>
-      </li>
-    </ul>
-  </footer>
+            Trademark Policy
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="/privacy"
+          >
+            Privacy Policy
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="https://github.com/openjs-foundation/cross-project-council/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct"
+          >
+            Code of Conduct
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="/security"
+          >
+            Security Reporting
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="/about"
+          >
+            About
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="https://nodejs.org/en/blog/"
+          >
+            Blog
+          </a>
+        </li>
+      </ul>
+      <ul
+        class="footer__right"
+      >
+        <li>
+          © OpenJS Foundation
+        </li>
+        <li>
+          <a
+            aria-label="Node.js Github Page Link"
+            href="https://github.com/nodejs/node"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <span
+              class="sr-only"
+            >
+              GitHub
+            </span>
+            <svg
+              fill="var(--color-text-secondary)"
+            />
+          </a>
+        </li>
+        <li>
+          <a
+            aria-label="Node.js Twitter Link"
+            href="https://twitter.com/nodejs"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <svg
+              fill="var(--color-text-secondary)"
+            />
+          </a>
+        </li>
+        <li>
+          <a
+            aria-label="Node.js Slack Link"
+            href="https://slack.openjsf.org"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <svg
+              fill="var(--color-text-secondary)"
+            />
+          </a>
+        </li>
+      </ul>
+    </footer>
+  </div>
 </div>
 `;

--- a/test/pages/__snapshots__/trademark.test.tsx.snap
+++ b/test/pages/__snapshots__/trademark.test.tsx.snap
@@ -354,117 +354,117 @@ exports[`Trademark page renders correctly 1`] = `
         </div>
       </article>
     </main>
-  </div>
-  <section
-    class="bottom-info"
-  >
-    <div
-      class="random-contributor"
-    />
-  </section>
-  <footer
-    class="footer"
-  >
-    <ul
-      class="footer__left"
+    <section
+      class="bottom-info"
     >
-      <li>
-        <a
-          class="footer__link"
-          href="/trademark"
-        >
-          Trademark Policy
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="/privacy"
-        >
-          Privacy Policy
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="https://github.com/openjs-foundation/cross-project-council/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct"
-        >
-          Code of Conduct
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="/security"
-        >
-          Security Reporting
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="/about"
-        >
-          About
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="https://nodejs.org/en/blog/"
-        >
-          Blog
-        </a>
-      </li>
-    </ul>
-    <ul
-      class="footer__right"
+      <div
+        class="random-contributor"
+      />
+    </section>
+    <footer
+      class="footer"
     >
-      <li>
-        © OpenJS Foundation
-      </li>
-      <li>
-        <a
-          aria-label="Node.js Github Page Link"
-          href="https://github.com/nodejs/node"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <span
-            class="sr-only"
+      <ul
+        class="footer__left"
+      >
+        <li>
+          <a
+            class="footer__link"
+            href="/trademark"
           >
-            GitHub
-          </span>
-          <svg
-            fill="var(--color-text-secondary)"
-          />
-        </a>
-      </li>
-      <li>
-        <a
-          aria-label="Node.js Twitter Link"
-          href="https://twitter.com/nodejs"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <svg
-            fill="var(--color-text-secondary)"
-          />
-        </a>
-      </li>
-      <li>
-        <a
-          aria-label="Node.js Slack Link"
-          href="https://slack.openjsf.org"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <svg
-            fill="var(--color-text-secondary)"
-          />
-        </a>
-      </li>
-    </ul>
-  </footer>
+            Trademark Policy
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="/privacy"
+          >
+            Privacy Policy
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="https://github.com/openjs-foundation/cross-project-council/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct"
+          >
+            Code of Conduct
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="/security"
+          >
+            Security Reporting
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="/about"
+          >
+            About
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="https://nodejs.org/en/blog/"
+          >
+            Blog
+          </a>
+        </li>
+      </ul>
+      <ul
+        class="footer__right"
+      >
+        <li>
+          © OpenJS Foundation
+        </li>
+        <li>
+          <a
+            aria-label="Node.js Github Page Link"
+            href="https://github.com/nodejs/node"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <span
+              class="sr-only"
+            >
+              GitHub
+            </span>
+            <svg
+              fill="var(--color-text-secondary)"
+            />
+          </a>
+        </li>
+        <li>
+          <a
+            aria-label="Node.js Twitter Link"
+            href="https://twitter.com/nodejs"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <svg
+              fill="var(--color-text-secondary)"
+            />
+          </a>
+        </li>
+        <li>
+          <a
+            aria-label="Node.js Slack Link"
+            href="https://slack.openjsf.org"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <svg
+              fill="var(--color-text-secondary)"
+            />
+          </a>
+        </li>
+      </ul>
+    </footer>
+  </div>
 </div>
 `;

--- a/test/pages/__snapshots__/working-groups.test.tsx.snap
+++ b/test/pages/__snapshots__/working-groups.test.tsx.snap
@@ -327,117 +327,117 @@ exports[`Working Groups page renders correctly 1`] = `
         </div>
       </article>
     </main>
-  </div>
-  <section
-    class="bottom-info"
-  >
-    <div
-      class="random-contributor"
-    />
-  </section>
-  <footer
-    class="footer"
-  >
-    <ul
-      class="footer__left"
+    <section
+      class="bottom-info"
     >
-      <li>
-        <a
-          class="footer__link"
-          href="/trademark"
-        >
-          Trademark Policy
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="/privacy"
-        >
-          Privacy Policy
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="https://github.com/openjs-foundation/cross-project-council/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct"
-        >
-          Code of Conduct
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="/security"
-        >
-          Security Reporting
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="/about"
-        >
-          About
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="https://nodejs.org/en/blog/"
-        >
-          Blog
-        </a>
-      </li>
-    </ul>
-    <ul
-      class="footer__right"
+      <div
+        class="random-contributor"
+      />
+    </section>
+    <footer
+      class="footer"
     >
-      <li>
-        © OpenJS Foundation
-      </li>
-      <li>
-        <a
-          aria-label="Node.js Github Page Link"
-          href="https://github.com/nodejs/node"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <span
-            class="sr-only"
+      <ul
+        class="footer__left"
+      >
+        <li>
+          <a
+            class="footer__link"
+            href="/trademark"
           >
-            GitHub
-          </span>
-          <svg
-            fill="var(--color-text-secondary)"
-          />
-        </a>
-      </li>
-      <li>
-        <a
-          aria-label="Node.js Twitter Link"
-          href="https://twitter.com/nodejs"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <svg
-            fill="var(--color-text-secondary)"
-          />
-        </a>
-      </li>
-      <li>
-        <a
-          aria-label="Node.js Slack Link"
-          href="https://slack.openjsf.org"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <svg
-            fill="var(--color-text-secondary)"
-          />
-        </a>
-      </li>
-    </ul>
-  </footer>
+            Trademark Policy
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="/privacy"
+          >
+            Privacy Policy
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="https://github.com/openjs-foundation/cross-project-council/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct"
+          >
+            Code of Conduct
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="/security"
+          >
+            Security Reporting
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="/about"
+          >
+            About
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="https://nodejs.org/en/blog/"
+          >
+            Blog
+          </a>
+        </li>
+      </ul>
+      <ul
+        class="footer__right"
+      >
+        <li>
+          © OpenJS Foundation
+        </li>
+        <li>
+          <a
+            aria-label="Node.js Github Page Link"
+            href="https://github.com/nodejs/node"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <span
+              class="sr-only"
+            >
+              GitHub
+            </span>
+            <svg
+              fill="var(--color-text-secondary)"
+            />
+          </a>
+        </li>
+        <li>
+          <a
+            aria-label="Node.js Twitter Link"
+            href="https://twitter.com/nodejs"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <svg
+              fill="var(--color-text-secondary)"
+            />
+          </a>
+        </li>
+        <li>
+          <a
+            aria-label="Node.js Slack Link"
+            href="https://slack.openjsf.org"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <svg
+              fill="var(--color-text-secondary)"
+            />
+          </a>
+        </li>
+      </ul>
+    </footer>
+  </div>
 </div>
 `;

--- a/test/pages/download/__snapshots__/package-manager.test.tsx.snap
+++ b/test/pages/download/__snapshots__/package-manager.test.tsx.snap
@@ -354,117 +354,117 @@ exports[`Package Manager Page renders correctly 1`] = `
         </div>
       </article>
     </main>
-  </div>
-  <section
-    class="bottom-info"
-  >
-    <div
-      class="random-contributor"
-    />
-  </section>
-  <footer
-    class="footer"
-  >
-    <ul
-      class="footer__left"
+    <section
+      class="bottom-info"
     >
-      <li>
-        <a
-          class="footer__link"
-          href="/trademark"
-        >
-          Trademark Policy
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="/privacy"
-        >
-          Privacy Policy
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="https://github.com/openjs-foundation/cross-project-council/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct"
-        >
-          Code of Conduct
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="/security"
-        >
-          Security Reporting
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="/about"
-        >
-          About
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="https://nodejs.org/en/blog/"
-        >
-          Blog
-        </a>
-      </li>
-    </ul>
-    <ul
-      class="footer__right"
+      <div
+        class="random-contributor"
+      />
+    </section>
+    <footer
+      class="footer"
     >
-      <li>
-        © OpenJS Foundation
-      </li>
-      <li>
-        <a
-          aria-label="Node.js Github Page Link"
-          href="https://github.com/nodejs/node"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <span
-            class="sr-only"
+      <ul
+        class="footer__left"
+      >
+        <li>
+          <a
+            class="footer__link"
+            href="/trademark"
           >
-            GitHub
-          </span>
-          <svg
-            fill="var(--color-text-secondary)"
-          />
-        </a>
-      </li>
-      <li>
-        <a
-          aria-label="Node.js Twitter Link"
-          href="https://twitter.com/nodejs"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <svg
-            fill="var(--color-text-secondary)"
-          />
-        </a>
-      </li>
-      <li>
-        <a
-          aria-label="Node.js Slack Link"
-          href="https://slack.openjsf.org"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <svg
-            fill="var(--color-text-secondary)"
-          />
-        </a>
-      </li>
-    </ul>
-  </footer>
+            Trademark Policy
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="/privacy"
+          >
+            Privacy Policy
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="https://github.com/openjs-foundation/cross-project-council/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct"
+          >
+            Code of Conduct
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="/security"
+          >
+            Security Reporting
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="/about"
+          >
+            About
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="https://nodejs.org/en/blog/"
+          >
+            Blog
+          </a>
+        </li>
+      </ul>
+      <ul
+        class="footer__right"
+      >
+        <li>
+          © OpenJS Foundation
+        </li>
+        <li>
+          <a
+            aria-label="Node.js Github Page Link"
+            href="https://github.com/nodejs/node"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <span
+              class="sr-only"
+            >
+              GitHub
+            </span>
+            <svg
+              fill="var(--color-text-secondary)"
+            />
+          </a>
+        </li>
+        <li>
+          <a
+            aria-label="Node.js Twitter Link"
+            href="https://twitter.com/nodejs"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <svg
+              fill="var(--color-text-secondary)"
+            />
+          </a>
+        </li>
+        <li>
+          <a
+            aria-label="Node.js Slack Link"
+            href="https://slack.openjsf.org"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <svg
+              fill="var(--color-text-secondary)"
+            />
+          </a>
+        </li>
+      </ul>
+    </footer>
+  </div>
 </div>
 `;

--- a/test/templates/__snapshots__/blog.test.tsx.snap
+++ b/test/templates/__snapshots__/blog.test.tsx.snap
@@ -235,117 +235,117 @@ exports[`LearnLayout Template renders correctly 1`] = `
         </div>
       </article>
     </main>
-  </div>
-  <section
-    class="bottom-info"
-  >
-    <div
-      class="random-contributor"
-    />
-  </section>
-  <footer
-    class="footer"
-  >
-    <ul
-      class="footer__left"
+    <section
+      class="bottom-info"
     >
-      <li>
-        <a
-          class="footer__link"
-          href="/trademark"
-        >
-          Trademark Policy
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="/privacy"
-        >
-          Privacy Policy
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="https://github.com/openjs-foundation/cross-project-council/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct"
-        >
-          Code of Conduct
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="/security"
-        >
-          Security Reporting
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="/about"
-        >
-          About
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="https://nodejs.org/en/blog/"
-        >
-          Blog
-        </a>
-      </li>
-    </ul>
-    <ul
-      class="footer__right"
+      <div
+        class="random-contributor"
+      />
+    </section>
+    <footer
+      class="footer"
     >
-      <li>
-        © OpenJS Foundation
-      </li>
-      <li>
-        <a
-          aria-label="Node.js Github Page Link"
-          href="https://github.com/nodejs/node"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <span
-            class="sr-only"
+      <ul
+        class="footer__left"
+      >
+        <li>
+          <a
+            class="footer__link"
+            href="/trademark"
           >
-            GitHub
-          </span>
-          <svg
-            fill="var(--color-text-secondary)"
-          />
-        </a>
-      </li>
-      <li>
-        <a
-          aria-label="Node.js Twitter Link"
-          href="https://twitter.com/nodejs"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <svg
-            fill="var(--color-text-secondary)"
-          />
-        </a>
-      </li>
-      <li>
-        <a
-          aria-label="Node.js Slack Link"
-          href="https://slack.openjsf.org"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <svg
-            fill="var(--color-text-secondary)"
-          />
-        </a>
-      </li>
-    </ul>
-  </footer>
+            Trademark Policy
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="/privacy"
+          >
+            Privacy Policy
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="https://github.com/openjs-foundation/cross-project-council/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct"
+          >
+            Code of Conduct
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="/security"
+          >
+            Security Reporting
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="/about"
+          >
+            About
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="https://nodejs.org/en/blog/"
+          >
+            Blog
+          </a>
+        </li>
+      </ul>
+      <ul
+        class="footer__right"
+      >
+        <li>
+          © OpenJS Foundation
+        </li>
+        <li>
+          <a
+            aria-label="Node.js Github Page Link"
+            href="https://github.com/nodejs/node"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <span
+              class="sr-only"
+            >
+              GitHub
+            </span>
+            <svg
+              fill="var(--color-text-secondary)"
+            />
+          </a>
+        </li>
+        <li>
+          <a
+            aria-label="Node.js Twitter Link"
+            href="https://twitter.com/nodejs"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <svg
+              fill="var(--color-text-secondary)"
+            />
+          </a>
+        </li>
+        <li>
+          <a
+            aria-label="Node.js Slack Link"
+            href="https://slack.openjsf.org"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <svg
+              fill="var(--color-text-secondary)"
+            />
+          </a>
+        </li>
+      </ul>
+    </footer>
+  </div>
 </div>
 `;

--- a/test/templates/__snapshots__/learn.test.tsx.snap
+++ b/test/templates/__snapshots__/learn.test.tsx.snap
@@ -318,117 +318,117 @@ exports[`Learn Template renders correctly 1`] = `
         </ul>
       </article>
     </main>
-  </div>
-  <section
-    class="bottom-info"
-  >
-    <div
-      class="random-contributor"
-    />
-  </section>
-  <footer
-    class="footer"
-  >
-    <ul
-      class="footer__left"
+    <section
+      class="bottom-info"
     >
-      <li>
-        <a
-          class="footer__link"
-          href="/trademark"
-        >
-          Trademark Policy
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="/privacy"
-        >
-          Privacy Policy
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="https://github.com/openjs-foundation/cross-project-council/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct"
-        >
-          Code of Conduct
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="/security"
-        >
-          Security Reporting
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="/about"
-        >
-          About
-        </a>
-      </li>
-      <li>
-        <a
-          class="footer__link"
-          href="https://nodejs.org/en/blog/"
-        >
-          Blog
-        </a>
-      </li>
-    </ul>
-    <ul
-      class="footer__right"
+      <div
+        class="random-contributor"
+      />
+    </section>
+    <footer
+      class="footer"
     >
-      <li>
-        © OpenJS Foundation
-      </li>
-      <li>
-        <a
-          aria-label="Node.js Github Page Link"
-          href="https://github.com/nodejs/node"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <span
-            class="sr-only"
+      <ul
+        class="footer__left"
+      >
+        <li>
+          <a
+            class="footer__link"
+            href="/trademark"
           >
-            GitHub
-          </span>
-          <svg
-            fill="var(--color-text-secondary)"
-          />
-        </a>
-      </li>
-      <li>
-        <a
-          aria-label="Node.js Twitter Link"
-          href="https://twitter.com/nodejs"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <svg
-            fill="var(--color-text-secondary)"
-          />
-        </a>
-      </li>
-      <li>
-        <a
-          aria-label="Node.js Slack Link"
-          href="https://slack.openjsf.org"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <svg
-            fill="var(--color-text-secondary)"
-          />
-        </a>
-      </li>
-    </ul>
-  </footer>
+            Trademark Policy
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="/privacy"
+          >
+            Privacy Policy
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="https://github.com/openjs-foundation/cross-project-council/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct"
+          >
+            Code of Conduct
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="/security"
+          >
+            Security Reporting
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="/about"
+          >
+            About
+          </a>
+        </li>
+        <li>
+          <a
+            class="footer__link"
+            href="https://nodejs.org/en/blog/"
+          >
+            Blog
+          </a>
+        </li>
+      </ul>
+      <ul
+        class="footer__right"
+      >
+        <li>
+          © OpenJS Foundation
+        </li>
+        <li>
+          <a
+            aria-label="Node.js Github Page Link"
+            href="https://github.com/nodejs/node"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <span
+              class="sr-only"
+            >
+              GitHub
+            </span>
+            <svg
+              fill="var(--color-text-secondary)"
+            />
+          </a>
+        </li>
+        <li>
+          <a
+            aria-label="Node.js Twitter Link"
+            href="https://twitter.com/nodejs"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <svg
+              fill="var(--color-text-secondary)"
+            />
+          </a>
+        </li>
+        <li>
+          <a
+            aria-label="Node.js Slack Link"
+            href="https://slack.openjsf.org"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <svg
+              fill="var(--color-text-secondary)"
+            />
+          </a>
+        </li>
+      </ul>
+    </footer>
+  </div>
 </div>
 `;


### PR DESCRIPTION
## Description

Going through the code I found that Footer component is added manually along with fragment in so many layouts. Although layout itself has a footer inside of it 
- https://github.com/nodejs/nodejs.dev/blob/0b3901550fdece75d7d573f6776b66788d0261de/src/components/Layout/index.tsx#L40

It is better that we have it only in layout and not in all components separately. I checked with all pages and changes are working fine 👍🏻 in UI