### PR TITLE
Fixed typo at line 120 in documentation/0045-node-module-fs/index.md

### DIFF
--- a/src/documentation/0045-node-module-fs/index.md
+++ b/src/documentation/0045-node-module-fs/index.md
@@ -117,7 +117,7 @@ fs.readFile(fileName, 'utf8', (err, data) => {
 });
 ```
 
-The callback-based API may rises callback hell when there are too many nested callbacks. We can simply use promise-based API to avoid it:
+The callback-based API may raise callback hell when there are too many nested callbacks. We can simply use promise-based API to avoid it:
 
 ```js
 // Example: Read a file and change its content and read


### PR DESCRIPTION
In file src/documentation/0045-node-module-fs/index.md at line 120:
Changed "The callback-based API may rises callback hell" to "The callback-based API may raise callback hell"