### PR TITLE
Added Link to package-manager page from the downloads page release-description

### DIFF
--- a/src/pages/download/index.tsx
+++ b/src/pages/download/index.tsx
@@ -55,7 +55,8 @@ const DownloadPage = ({
         <DownloadHeader release={selectedType} />
         <p className="release-description">
           Download the Node.js source code, a pre-built installer for your
-          platform, or install via <Link to="/download/package-manager">package manager</Link>.
+          platform, or install via{' '}
+          <Link to="/download/package-manager">package manager</Link>.
         </p>
         <DownloadToggle
           selected={typeRelease}

--- a/src/pages/download/index.tsx
+++ b/src/pages/download/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { graphql } from 'gatsby';
+import { graphql, Link } from 'gatsby';
 import { detectOS } from '../../util/detectOS';
 import { getUpcomingReleases } from '../../util/getUpcomingReleases';
 import Layout from '../../components/Layout';
@@ -55,7 +55,7 @@ const DownloadPage = ({
         <DownloadHeader release={selectedType} />
         <p className="release-description">
           Download the Node.js source code, a pre-built installer for your
-          platform, or install via package manager.
+          platform, or install via <Link to="/download/package-manager">package manager</Link>.
         </p>
         <DownloadToggle
           selected={typeRelease}

--- a/test/pages/download/__snapshots__/index.test.tsx.snap
+++ b/test/pages/download/__snapshots__/index.test.tsx.snap
@@ -193,7 +193,14 @@ exports[`Download page renders correctly 1`] = `
       <p
         class="release-description"
       >
-        Download the Node.js source code, a pre-built installer for your platform, or install via package manager.
+        Download the Node.js source code, a pre-built installer for your platform, or install via
+         
+        <a
+          href="/download/package-manager"
+        >
+          package manager
+        </a>
+        .
       </p>
       <div
         class="download-toogle"
@@ -1008,7 +1015,14 @@ exports[`Download page should handle LTS to Current switch 1`] = `
       <p
         class="release-description"
       >
-        Download the Node.js source code, a pre-built installer for your platform, or install via package manager.
+        Download the Node.js source code, a pre-built installer for your platform, or install via
+         
+        <a
+          href="/download/package-manager"
+        >
+          package manager
+        </a>
+        .
       </p>
       <div
         class="download-toogle"


### PR DESCRIPTION
<!--## Description
Added a redirect link to "/download/package-manager" page from the "/download" page in the header description.

## Related Issues
This PR fixes #2567 