### PR TITLE
fix(issue-templates): docs template padding

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -11,8 +11,8 @@ body:
         - Incorrect
         - Confusing
         - Not sure?
-      validations:
-        required: true
+    validations:
+      required: true
   - type: textarea
     attributes:
       label: "Please Explain in details:"


### PR DESCRIPTION


### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.

## Description

This commit fixes the `validations` field on the wrong indentation level. Invalidating this config.
