### PR TITLE
refactor(blogs): revert active post filtration for recent posts list

### DIFF
--- a/src/templates/blog.tsx
+++ b/src/templates/blog.tsx
@@ -28,14 +28,10 @@ const BlogLayout = ({
 
   const { edges: recentPosts } = recent;
 
-  const recentPostsWithoutCurrent = recentPosts.filter(
-    post => post.node.frontmatter.title !== title
-  );
-
   return (
     <Layout title={title} description={excerpt}>
       <main className="grid-container blog-container">
-        <RecentPosts posts={recentPostsWithoutCurrent} />
+        <RecentPosts posts={recentPosts} />
         <Article
           title={title}
           body={body}


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run lint:js -- --fix` and/or `npm run lint:md -- --fix` for my JavaScript and/or Markdown changes.
  - This is important as most of the cases your code changes might not be correctly linted
- [x] I have run `npm run test` to check if all tests are passing, and/or `npm run test -- -u` to update snapshots if I created and/or updated React Components.
- [x] I have checked that the build works locally and that `npm run build` and `npm run build-storybook` work fine.
- [ ] I've covered new added functionality with unit tests if necessary.

## Description

The recent posts on blog has some visual issue which kind of looks like the list is not stable and is changing whenever we visit a different post. We have removed the filtration added to the recent posts list which removed the current active post from the recent section causing the visual error.

## Related Issues

Fixes #2570 
