### PR TITLE
refactor(organisation): added displayTitle field, organised pages and moved random contributor component

### DIFF
--- a/content/about/about.en.md
+++ b/content/about/about.en.md
@@ -1,5 +1,6 @@
 ---
-title: About
+title: about
+displayTitle: About
 description: "About | Node.js"
 authors: XhmikosR, mikeal, fhemberger, Fishrock123, yous, tomgco, tniessen, SMcCandlish, saadq, Trott, Gornstats, piperchester, naoufal,  lpinca, j9t, bnoordhuis, harshadsabne, Chris911, benhalverson
 category: about

--- a/content/about/governance.en.md
+++ b/content/about/governance.en.md
@@ -1,8 +1,9 @@
 ---
-title: Governance
+title: governance
+displayTitle: Governance
 description: 'Project Governance | Node.js'
 authors: XhmikosR, fhemberger, thefourtheye, ryanmurakami, refack
-category: governance
+category: about
 ---
 
 ## Consensus Seeking Process

--- a/content/about/privacy.en.md
+++ b/content/about/privacy.en.md
@@ -1,8 +1,9 @@
 ---
-title: Privacy Policy
+title: privacy-policy
+displayTitle: Privacy Policy
 description: 'Privacy Policy | Node.js'
 authors: XhmikosR, nschonni, brianwarner, hackygolucky, sindelio, sonicdoe, marsonya
-category: privacy
+category: about
 ---
 
 Effective Date: November 21, 2019

--- a/content/about/releases.en.md
+++ b/content/about/releases.en.md
@@ -1,8 +1,9 @@
 ---
-title: Releases
+title: releases
+displayTitle: Releases
 description: "Releases | Node.js"
 authors: ZYSzys, nstanard,  mikeal, fhemberger, garybernhardt, piepmatz, boneskull, bjb568
-category: releases
+category: about
 ---
 
 Major Node.js versions enter _Current_ release status for six months, which gives library authors time to add support for them.

--- a/content/about/resources.en.md
+++ b/content/about/resources.en.md
@@ -1,5 +1,6 @@
 ---
-title: Resources
+title: resources
+displayTitle: Resources
 description: 'Resources | Node.js'
 authors: XhmikosR, mikeal, fhemberger, Fishrock123, yous, tomgco, tniessen, SMcCandlish, saadq, Trott, Gornstats, piperchester, naoufal, lpinca, j9t, bnoordhuis, harshadsabne, Chris911, MrJithil
 category: about

--- a/content/about/security.en.md
+++ b/content/about/security.en.md
@@ -1,8 +1,9 @@
 ---
-title: Security
-description: 'This is security page'
+title: security
+displayTitle: Security
+description: "Security | Node.js"
 authors: reedloden,XhmikosR,Trott,fhemberger,MaledongGit,yous,sam-github,vdeturckheim,tniessen,richardlau,nschonni,mikeal,e-jigsaw,parthlaw
-category: security
+category: about
 ---
 
 ## Reporting a Bug in Node.js

--- a/content/about/trademark.en.md
+++ b/content/about/trademark.en.md
@@ -1,8 +1,9 @@
 ---
-title: Trademark Policy
+title: trademark-policy
+displayTitle: Trademark Policy
 description: "Trademark Policy | Node.js"
 authors: fhemberger, XhmikosR, mikeal,  brianwarner, bf4
-category: trademark
+category: about
 ---
 
 The Node.js trademarks, service marks, and graphics marks are symbols of the

--- a/content/about/working-groups.en.md
+++ b/content/about/working-groups.en.md
@@ -1,8 +1,9 @@
 ---
-title: Working Groups
-description: "Working Groups| Node.js"
+title: working-groups
+displayTitle: Working Groups
+description: "Working Groups | Node.js"
 authors: williamkapke,Trott,fhemberger,rxmarbles,mhdawson,XhmikosR,ryanmurakami,outsideris,MaledongGit,vsemozhetbyt,wonderdogone,sotayamashita,richardlau,pierreneter,nschonni,marocchino,stevemao,lpinca,phillipj,jasnell,sejaljain123
-category: working-groups
+category: about
 ---
 
 Core Working Groups are created by the

--- a/content/community/index.md
+++ b/content/community/index.md
@@ -1,5 +1,6 @@
 ---
-title: Node.js Community
+title: node.js-community
+displayTitle: Node.js Community
 description: "Node.js has one of the largest, most vibrant and innovative open source communities in the world. Node.js is built, used, and maintained by the community. We believe the community to be at the core of Node.js popularity. Amazing people from every part of the world, with a common interest, collaborate and shape this community."
 authors: ahmadawais, maedahbatool, saqibameen, msaaddev
 category: community

--- a/content/download/package-manager.en.md
+++ b/content/download/package-manager.en.md
@@ -1,6 +1,7 @@
 ---
-title: Installing Node.js via package manager
-description: Installing Node.js via package manager
+title: installing-node.js-via-package-manager
+displayTitle: Installing Node.js via Package Manager
+description: "Installing Node.js via Package Manager | Node.js"
 authors: fhemberger, XhmikosR, shadowspawn, vsemozhetbyt, nschonni, wildcard, MrJithil, kasicka, cassidyjames, Trott, richardlau, Qantas94Heavy, pierreneter, 0mp, ThePrez, PoojaDurgad, MaledongGit, Megajin, marc-maurer, yodeyer, geek, sudowork, strawbrary, ryanmurakami, rbnswartz, arkwright, oliversalzburg, mweagle, Mohamed3on, Ginden, kapouer, jperkin, jericopulvera, jedsmith, jasonkarns, sonicdoe, mcollina, fornwall, danbev, naskapal, awochna, AdamMajer, ahmetanilgur, bnb, qbit
 category: download
 ---

--- a/firebase.json
+++ b/firebase.json
@@ -2,17 +2,7 @@
   "hosting": {
     "target": "nodejs-dev",
     "public": "public",
-    "ignore": [
-      "firebase.json",
-      "**/.*",
-      "**/node_modules/**"
-    ]
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
   },
-  "redirects": [
-    {
-      "source": "/en/get-involved",
-      "destination": "/community",
-      "type": "301"
-    }
-  ]
+  "redirects": []
 }

--- a/src/components/Footer/__tests__/__snapshots__/footer.test.tsx.snap
+++ b/src/components/Footer/__tests__/__snapshots__/footer.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`Tests for Footer component renders correctly 1`] = `
       <li>
         <a
           class="footer__link"
-          href="/trademark"
+          href="/about/trademark"
         >
           Trademark Policy
         </a>
@@ -19,7 +19,7 @@ exports[`Tests for Footer component renders correctly 1`] = `
       <li>
         <a
           class="footer__link"
-          href="/privacy"
+          href="/about/privacy"
         >
           Privacy Policy
         </a>
@@ -35,7 +35,7 @@ exports[`Tests for Footer component renders correctly 1`] = `
       <li>
         <a
           class="footer__link"
-          href="/security"
+          href="/about/security"
         >
           Security Reporting
         </a>

--- a/src/components/Footer/__tests__/__snapshots__/footer.test.tsx.snap
+++ b/src/components/Footer/__tests__/__snapshots__/footer.test.tsx.snap
@@ -2,13 +2,6 @@
 
 exports[`Tests for Footer component renders correctly 1`] = `
 <div>
-  <section
-    class="bottom-info"
-  >
-    <div
-      class="random-contributor"
-    />
-  </section>
   <footer
     class="footer"
   >

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -16,12 +16,12 @@ const Footer = (): JSX.Element => {
     <footer className="footer">
       <ul className="footer__left">
         <li>
-          <Link className="footer__link" to="/trademark">
+          <Link className="footer__link" to="/about/trademark">
             Trademark Policy
           </Link>
         </li>
         <li>
-          <Link className="footer__link" to="/privacy">
+          <Link className="footer__link" to="/about/privacy">
             Privacy Policy
           </Link>
         </li>
@@ -34,7 +34,7 @@ const Footer = (): JSX.Element => {
           </a>
         </li>
         <li>
-          <Link className="footer__link" to="/security">
+          <Link className="footer__link" to="/about/security">
             Security Reporting
           </Link>
         </li>
@@ -44,6 +44,7 @@ const Footer = (): JSX.Element => {
           </Link>
         </li>
         <li>
+          {/* @TODO: Once our Blog components are completely read, move this link to our Blog page */}
           <a className="footer__link" href="https://nodejs.org/en/blog/">
             Blog
           </a>

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -1,6 +1,5 @@
 import { LocalizedLink as Link } from 'gatsby-theme-i18n';
 import React from 'react';
-import RandomContributor from '../RandomContributor';
 import { ReactComponent as GitHubLogo } from '../../images/logos/github-logo.svg';
 import { ReactComponent as TwitterLogo } from '../../images/logos/twitter-logo.svg';
 import { ReactComponent as SlackLogo } from '../../images/logos/slack-logo.svg';
@@ -14,82 +13,77 @@ export interface DropDownState {
 
 const Footer = (): JSX.Element => {
   return (
-    <>
-      <section className="bottom-info">
-        <RandomContributor />
-      </section>
-      <footer className="footer">
-        <ul className="footer__left">
-          <li>
-            <Link className="footer__link" to="/trademark">
-              Trademark Policy
-            </Link>
-          </li>
-          <li>
-            <Link className="footer__link" to="/privacy">
-              Privacy Policy
-            </Link>
-          </li>
-          <li>
-            <a
-              className="footer__link"
-              href="https://github.com/openjs-foundation/cross-project-council/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct"
-            >
-              Code of Conduct
-            </a>
-          </li>
-          <li>
-            <Link className="footer__link" to="/security">
-              Security Reporting
-            </Link>
-          </li>
-          <li>
-            <Link className="footer__link" to="/about">
-              About
-            </Link>
-          </li>
-          <li>
-            <a className="footer__link" href="https://nodejs.org/en/blog/">
-              Blog
-            </a>
-          </li>
-        </ul>
-        <ul className="footer__right">
-          <li>&copy; OpenJS Foundation</li>
-          <li>
-            <a
-              target="_blank"
-              href="https://github.com/nodejs/node"
-              rel="noopener noreferrer"
-              aria-label="Node.js Github Page Link"
-            >
-              <span className="sr-only">GitHub</span>
-              <GitHubLogo fill="var(--color-text-secondary)" />
-            </a>
-          </li>
-          <li>
-            <a
-              target="_blank"
-              href="https://twitter.com/nodejs"
-              rel="noopener noreferrer"
-              aria-label="Node.js Twitter Link"
-            >
-              <TwitterLogo fill="var(--color-text-secondary)" />
-            </a>
-          </li>
-          <li>
-            <a
-              target="_blank"
-              href="https://slack.openjsf.org"
-              rel="noopener noreferrer"
-              aria-label="Node.js Slack Link"
-            >
-              <SlackLogo fill="var(--color-text-secondary)" />
-            </a>
-          </li>
-        </ul>
-      </footer>
-    </>
+    <footer className="footer">
+      <ul className="footer__left">
+        <li>
+          <Link className="footer__link" to="/trademark">
+            Trademark Policy
+          </Link>
+        </li>
+        <li>
+          <Link className="footer__link" to="/privacy">
+            Privacy Policy
+          </Link>
+        </li>
+        <li>
+          <a
+            className="footer__link"
+            href="https://github.com/openjs-foundation/cross-project-council/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct"
+          >
+            Code of Conduct
+          </a>
+        </li>
+        <li>
+          <Link className="footer__link" to="/security">
+            Security Reporting
+          </Link>
+        </li>
+        <li>
+          <Link className="footer__link" to="/about">
+            About
+          </Link>
+        </li>
+        <li>
+          <a className="footer__link" href="https://nodejs.org/en/blog/">
+            Blog
+          </a>
+        </li>
+      </ul>
+      <ul className="footer__right">
+        <li>&copy; OpenJS Foundation</li>
+        <li>
+          <a
+            target="_blank"
+            href="https://github.com/nodejs/node"
+            rel="noopener noreferrer"
+            aria-label="Node.js Github Page Link"
+          >
+            <span className="sr-only">GitHub</span>
+            <GitHubLogo fill="var(--color-text-secondary)" />
+          </a>
+        </li>
+        <li>
+          <a
+            target="_blank"
+            href="https://twitter.com/nodejs"
+            rel="noopener noreferrer"
+            aria-label="Node.js Twitter Link"
+          >
+            <TwitterLogo fill="var(--color-text-secondary)" />
+          </a>
+        </li>
+        <li>
+          <a
+            target="_blank"
+            href="https://slack.openjsf.org"
+            rel="noopener noreferrer"
+            aria-label="Node.js Slack Link"
+          >
+            <SlackLogo fill="var(--color-text-secondary)" />
+          </a>
+        </li>
+      </ul>
+    </footer>
   );
 };
 

--- a/src/components/Layout/__tests__/__snapshots__/centered-layout.test.tsx.snap
+++ b/src/components/Layout/__tests__/__snapshots__/centered-layout.test.tsx.snap
@@ -144,7 +144,7 @@ exports[`CenteredLayout component renders correctly with footer 1`] = `
       <li>
         <a
           class="footer__link"
-          href="/trademark"
+          href="/about/trademark"
         >
           Trademark Policy
         </a>
@@ -152,7 +152,7 @@ exports[`CenteredLayout component renders correctly with footer 1`] = `
       <li>
         <a
           class="footer__link"
-          href="/privacy"
+          href="/about/privacy"
         >
           Privacy Policy
         </a>
@@ -168,7 +168,7 @@ exports[`CenteredLayout component renders correctly with footer 1`] = `
       <li>
         <a
           class="footer__link"
-          href="/security"
+          href="/about/security"
         >
           Security Reporting
         </a>

--- a/src/components/Layout/__tests__/__snapshots__/centered-layout.test.tsx.snap
+++ b/src/components/Layout/__tests__/__snapshots__/centered-layout.test.tsx.snap
@@ -135,13 +135,6 @@ exports[`CenteredLayout component renders correctly with footer 1`] = `
   >
     mock-children
   </main>
-  <section
-    class="bottom-info"
-  >
-    <div
-      class="random-contributor"
-    />
-  </section>
   <footer
     class="footer"
   >

--- a/src/components/Layout/__tests__/__snapshots__/page-layout.test.tsx.snap
+++ b/src/components/Layout/__tests__/__snapshots__/page-layout.test.tsx.snap
@@ -268,13 +268,6 @@ exports[`PageLayout component renders correctly with data 1`] = `
         </div>
       </article>
     </main>
-    <section
-      class="bottom-info"
-    >
-      <div
-        class="random-contributor"
-      />
-    </section>
     <footer
       class="footer"
     >

--- a/src/components/Layout/__tests__/__snapshots__/page-layout.test.tsx.snap
+++ b/src/components/Layout/__tests__/__snapshots__/page-layout.test.tsx.snap
@@ -277,7 +277,7 @@ exports[`PageLayout component renders correctly with data 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/trademark"
+            href="/about/trademark"
           >
             Trademark Policy
           </a>
@@ -285,7 +285,7 @@ exports[`PageLayout component renders correctly with data 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/privacy"
+            href="/about/privacy"
           >
             Privacy Policy
           </a>
@@ -301,7 +301,7 @@ exports[`PageLayout component renders correctly with data 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/security"
+            href="/about/security"
           >
             Security Reporting
           </a>

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -3,6 +3,7 @@ import 'prismjs/themes/prism-okaidia.css';
 
 import React from 'react';
 import { MotionConfig } from 'framer-motion';
+import RandomContributor from '../RandomContributor';
 import { FeatureToggleProvider } from '../FeatureToggleProvider';
 
 import Header from '../Header';
@@ -20,6 +21,7 @@ interface Props {
   img?: string;
   href?: string;
   showFooter?: boolean;
+  showRandomContributor?: boolean;
 }
 
 const Layout = ({
@@ -28,6 +30,7 @@ const Layout = ({
   description,
   img,
   showFooter = true,
+  showRandomContributor = false,
 }: Props): JSX.Element => (
   <FeatureToggleProvider>
     <SEO title={title} description={description} img={img} />
@@ -35,6 +38,11 @@ const Layout = ({
       <div className="layout-container">
         <Header />
         {children}
+        {showRandomContributor && (
+          <section className="bottom-info">
+            <RandomContributor />
+          </section>
+        )}
         {showFooter && <Footer />}
       </div>
     </MotionConfig>

--- a/src/components/SideNavBar/index.tsx
+++ b/src/components/SideNavBar/index.tsx
@@ -6,14 +6,14 @@ import '../../styles/about.scss';
 // eslint-disable-next-line no-shadow
 export enum SideNavBarKeys {
   about = 'about',
-  governance = 'governance',
+  governance = 'about/governance',
   community = 'community',
-  workingGroups = 'working-groups',
-  releases = 'releases',
+  workingGroups = 'about/working-groups',
+  releases = 'about/releases',
   resources = 'resources',
-  trademark = 'trademark',
-  privacy = 'privacy',
-  security = 'security',
+  trademark = 'about/trademark',
+  privacy = 'about/privacy',
+  security = 'about/security',
   packageManager = 'download/package-manager',
 }
 

--- a/src/components/connectGraphQlArticle.tsx
+++ b/src/components/connectGraphQlArticle.tsx
@@ -79,6 +79,7 @@ const connectGraphQlArticle = (
 
     const articleLayoutProps = {
       title: article.frontmatter.title,
+      displayTitle: article.frontmatter.displayTitle,
       description: article.frontmatter.description,
       authors: article.fields.authors,
       body: article.body,
@@ -96,7 +97,7 @@ const connectGraphQlArticle = (
 
     return (
       <Component
-        title={articleLayoutProps.title}
+        title={articleLayoutProps.displayTitle || articleLayoutProps.title}
         description={articleLayoutProps.description}
         authors={articleLayoutProps.authors}
         body={articleLayoutProps.body}

--- a/src/pages/about/governance.tsx
+++ b/src/pages/about/governance.tsx
@@ -1,36 +1,38 @@
 import { graphql } from 'gatsby';
-import ArticleLayout from '../components/Layout/article';
-import { SideNavBarKeys } from '../components/SideNavBar';
-import connectGraphQlArticle from '../components/connectGraphQlArticle';
+import ArticleLayout from '../../components/Layout/article';
+import { SideNavBarKeys } from '../../components/SideNavBar';
+import connectGraphQlArticle from '../../components/connectGraphQlArticle';
 
 export default connectGraphQlArticle(ArticleLayout, {
-  editPath: 'content/about/security.md',
-  sidenavKey: SideNavBarKeys.security,
+  editPath: 'content/about/governance.md',
+  sidenavKey: SideNavBarKeys.governance,
 });
 
 export const query = graphql`
   query ($locale: String!, $defaultLocale: String!) {
     articleCurrentLanguage: mdx(
-      fields: { slug: { eq: "security" }, locale: { eq: $locale } }
+      fields: { slug: { eq: "governance" }, locale: { eq: $locale } }
     ) {
       body
       tableOfContents
       frontmatter {
         title
         description
+        displayTitle
       }
       fields {
         authors
       }
     }
     articleDefaultLanguage: mdx(
-      fields: { slug: { eq: "security" }, locale: { eq: $defaultLocale } }
+      fields: { slug: { eq: "governance" }, locale: { eq: $defaultLocale } }
     ) {
       body
       tableOfContents
       frontmatter {
         title
         description
+        displayTitle
       }
       fields {
         authors

--- a/src/pages/about/index.tsx
+++ b/src/pages/about/index.tsx
@@ -1,36 +1,38 @@
 import { graphql } from 'gatsby';
-import ArticleLayout from '../components/Layout/article';
-import { SideNavBarKeys } from '../components/SideNavBar';
-import connectGraphQlArticle from '../components/connectGraphQlArticle';
+import ArticleLayout from '../../components/Layout/article';
+import { SideNavBarKeys } from '../../components/SideNavBar';
+import connectGraphQlArticle from '../../components/connectGraphQlArticle';
 
 export default connectGraphQlArticle(ArticleLayout, {
-  editPath: 'content/about/privacy.md',
-  sidenavKey: SideNavBarKeys.privacy,
+  editPath: 'content/about/about.md',
+  sidenavKey: SideNavBarKeys.about,
 });
 
 export const query = graphql`
   query ($locale: String!, $defaultLocale: String!) {
     articleCurrentLanguage: mdx(
-      fields: { slug: { eq: "privacy-policy" }, locale: { eq: $locale } }
+      fields: { slug: { eq: "about" }, locale: { eq: $locale } }
     ) {
       body
       tableOfContents
       frontmatter {
         title
         description
+        displayTitle
       }
       fields {
         authors
       }
     }
     articleDefaultLanguage: mdx(
-      fields: { slug: { eq: "privacy-policy" }, locale: { eq: $defaultLocale } }
+      fields: { slug: { eq: "about" }, locale: { eq: $defaultLocale } }
     ) {
       body
       tableOfContents
       frontmatter {
         title
         description
+        displayTitle
       }
       fields {
         authors

--- a/src/pages/about/privacy.tsx
+++ b/src/pages/about/privacy.tsx
@@ -1,36 +1,38 @@
 import { graphql } from 'gatsby';
-import ArticleLayout from '../components/Layout/article';
-import { SideNavBarKeys } from '../components/SideNavBar';
-import connectGraphQlArticle from '../components/connectGraphQlArticle';
+import ArticleLayout from '../../components/Layout/article';
+import { SideNavBarKeys } from '../../components/SideNavBar';
+import connectGraphQlArticle from '../../components/connectGraphQlArticle';
 
 export default connectGraphQlArticle(ArticleLayout, {
-  editPath: 'content/about/governance.md',
-  sidenavKey: SideNavBarKeys.governance,
+  editPath: 'content/about/privacy.md',
+  sidenavKey: SideNavBarKeys.privacy,
 });
 
 export const query = graphql`
   query ($locale: String!, $defaultLocale: String!) {
     articleCurrentLanguage: mdx(
-      fields: { slug: { eq: "governance" }, locale: { eq: $locale } }
+      fields: { slug: { eq: "privacy-policy" }, locale: { eq: $locale } }
     ) {
       body
       tableOfContents
       frontmatter {
         title
         description
+        displayTitle
       }
       fields {
         authors
       }
     }
     articleDefaultLanguage: mdx(
-      fields: { slug: { eq: "governance" }, locale: { eq: $defaultLocale } }
+      fields: { slug: { eq: "privacy-policy" }, locale: { eq: $defaultLocale } }
     ) {
       body
       tableOfContents
       frontmatter {
         title
         description
+        displayTitle
       }
       fields {
         authors

--- a/src/pages/about/releases.tsx
+++ b/src/pages/about/releases.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { graphql } from 'gatsby';
-import ArticleLayout from '../components/Layout/article';
-import { NodeReleaseData } from '../types';
-import { SideNavBarKeys } from '../components/SideNavBar';
-import DownloadTable from '../components/DownloadReleases/DownloadTable';
-import connectGraphQlArticle from '../components/connectGraphQlArticle';
+import ArticleLayout from '../../components/Layout/article';
+import { NodeReleaseData } from '../../types';
+import { SideNavBarKeys } from '../../components/SideNavBar';
+import DownloadTable from '../../components/DownloadReleases/DownloadTable';
+import connectGraphQlArticle from '../../components/connectGraphQlArticle';
 
 export interface ReleasesNodeReleases {
   nodeReleases: {
@@ -30,6 +30,7 @@ export const query = graphql`
       frontmatter {
         title
         description
+        displayTitle
       }
       fields {
         authors
@@ -43,6 +44,7 @@ export const query = graphql`
       frontmatter {
         title
         description
+        displayTitle
       }
       fields {
         authors

--- a/src/pages/about/security.tsx
+++ b/src/pages/about/security.tsx
@@ -1,39 +1,38 @@
 import { graphql } from 'gatsby';
-import ArticleLayout from '../components/Layout/article';
-import { SideNavBarKeys } from '../components/SideNavBar';
-import connectGraphQlArticle from '../components/connectGraphQlArticle';
+import ArticleLayout from '../../components/Layout/article';
+import { SideNavBarKeys } from '../../components/SideNavBar';
+import connectGraphQlArticle from '../../components/connectGraphQlArticle';
 
 export default connectGraphQlArticle(ArticleLayout, {
-  editPath: 'content/about/trademark.md',
-  sidenavKey: SideNavBarKeys.trademark,
+  editPath: 'content/about/security.md',
+  sidenavKey: SideNavBarKeys.security,
 });
 
 export const query = graphql`
   query ($locale: String!, $defaultLocale: String!) {
     articleCurrentLanguage: mdx(
-      fields: { slug: { eq: "trademark-policy" }, locale: { eq: $locale } }
+      fields: { slug: { eq: "security" }, locale: { eq: $locale } }
     ) {
       body
       tableOfContents
       frontmatter {
         title
         description
+        displayTitle
       }
       fields {
         authors
       }
     }
     articleDefaultLanguage: mdx(
-      fields: {
-        slug: { eq: "trademark-policy" }
-        locale: { eq: $defaultLocale }
-      }
+      fields: { slug: { eq: "security" }, locale: { eq: $defaultLocale } }
     ) {
       body
       tableOfContents
       frontmatter {
         title
         description
+        displayTitle
       }
       fields {
         authors

--- a/src/pages/about/trademark.tsx
+++ b/src/pages/about/trademark.tsx
@@ -1,36 +1,41 @@
 import { graphql } from 'gatsby';
-import ArticleLayout from '../components/Layout/article';
-import { SideNavBarKeys } from '../components/SideNavBar';
-import connectGraphQlArticle from '../components/connectGraphQlArticle';
+import ArticleLayout from '../../components/Layout/article';
+import { SideNavBarKeys } from '../../components/SideNavBar';
+import connectGraphQlArticle from '../../components/connectGraphQlArticle';
 
 export default connectGraphQlArticle(ArticleLayout, {
-  editPath: 'content/about/about.md',
-  sidenavKey: SideNavBarKeys.about,
+  editPath: 'content/about/trademark.md',
+  sidenavKey: SideNavBarKeys.trademark,
 });
 
 export const query = graphql`
   query ($locale: String!, $defaultLocale: String!) {
     articleCurrentLanguage: mdx(
-      fields: { slug: { eq: "about" }, locale: { eq: $locale } }
+      fields: { slug: { eq: "trademark-policy" }, locale: { eq: $locale } }
     ) {
       body
       tableOfContents
       frontmatter {
         title
         description
+        displayTitle
       }
       fields {
         authors
       }
     }
     articleDefaultLanguage: mdx(
-      fields: { slug: { eq: "about" }, locale: { eq: $defaultLocale } }
+      fields: {
+        slug: { eq: "trademark-policy" }
+        locale: { eq: $defaultLocale }
+      }
     ) {
       body
       tableOfContents
       frontmatter {
         title
         description
+        displayTitle
       }
       fields {
         authors

--- a/src/pages/about/working-groups.tsx
+++ b/src/pages/about/working-groups.tsx
@@ -1,36 +1,38 @@
 import { graphql } from 'gatsby';
-import ArticleLayout from '../components/Layout/article';
-import { SideNavBarKeys } from '../components/SideNavBar';
-import connectGraphQlArticle from '../components/connectGraphQlArticle';
+import ArticleLayout from '../../components/Layout/article';
+import { SideNavBarKeys } from '../../components/SideNavBar';
+import connectGraphQlArticle from '../../components/connectGraphQlArticle';
 
 export default connectGraphQlArticle(ArticleLayout, {
-  editPath: 'content/resources/resources.md',
-  sidenavKey: SideNavBarKeys.resources,
+  editPath: 'content/about/working-groups.md',
+  sidenavKey: SideNavBarKeys.workingGroups,
 });
 
 export const query = graphql`
   query ($locale: String!, $defaultLocale: String!) {
     articleCurrentLanguage: mdx(
-      fields: { slug: { eq: "resources" }, locale: { eq: $locale } }
+      fields: { slug: { eq: "working-groups" }, locale: { eq: $locale } }
     ) {
       body
       tableOfContents
       frontmatter {
         title
         description
+        displayTitle
       }
       fields {
         authors
       }
     }
     articleDefaultLanguage: mdx(
-      fields: { slug: { eq: "resources" }, locale: { eq: $defaultLocale } }
+      fields: { slug: { eq: "working-groups" }, locale: { eq: $defaultLocale } }
     ) {
       body
       tableOfContents
       frontmatter {
         title
         description
+        displayTitle
       }
       fields {
         authors

--- a/src/pages/community.tsx
+++ b/src/pages/community.tsx
@@ -20,6 +20,7 @@ export const query = graphql`
       frontmatter {
         title
         description
+        displayTitle
       }
       fields {
         authors
@@ -36,6 +37,7 @@ export const query = graphql`
       frontmatter {
         title
         description
+        displayTitle
       }
       fields {
         authors

--- a/src/pages/download/package-manager.tsx
+++ b/src/pages/download/package-manager.tsx
@@ -21,6 +21,7 @@ export const query = graphql`
       frontmatter {
         title
         description
+        displayTitle
       }
       fields {
         authors
@@ -37,6 +38,7 @@ export const query = graphql`
       frontmatter {
         title
         description
+        displayTitle
       }
       fields {
         authors

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -68,7 +68,7 @@ const Index = ({
     banners: { bannersIndex },
   },
 }: HomepageProps): JSX.Element => (
-  <Layout title={displayTitle} description={description}>
+  <Layout title={displayTitle} description={description} showRandomContributor>
     <main className="home-page">
       <Banner bannersIndex={bannersIndex} />
       <Hero

--- a/src/pages/resources/index.tsx
+++ b/src/pages/resources/index.tsx
@@ -1,36 +1,38 @@
 import { graphql } from 'gatsby';
-import ArticleLayout from '../components/Layout/article';
-import { SideNavBarKeys } from '../components/SideNavBar';
-import connectGraphQlArticle from '../components/connectGraphQlArticle';
+import ArticleLayout from '../../components/Layout/article';
+import { SideNavBarKeys } from '../../components/SideNavBar';
+import connectGraphQlArticle from '../../components/connectGraphQlArticle';
 
 export default connectGraphQlArticle(ArticleLayout, {
-  editPath: 'content/about/working-groups.md',
-  sidenavKey: SideNavBarKeys.workingGroups,
+  editPath: 'content/resources/resources.md',
+  sidenavKey: SideNavBarKeys.resources,
 });
 
 export const query = graphql`
   query ($locale: String!, $defaultLocale: String!) {
     articleCurrentLanguage: mdx(
-      fields: { slug: { eq: "working-groups" }, locale: { eq: $locale } }
+      fields: { slug: { eq: "resources" }, locale: { eq: $locale } }
     ) {
       body
       tableOfContents
       frontmatter {
         title
         description
+        displayTitle
       }
       fields {
         authors
       }
     }
     articleDefaultLanguage: mdx(
-      fields: { slug: { eq: "working-groups" }, locale: { eq: $defaultLocale } }
+      fields: { slug: { eq: "resources" }, locale: { eq: $defaultLocale } }
     ) {
       body
       tableOfContents
       frontmatter {
         title
         description
+        displayTitle
       }
       fields {
         authors

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -98,6 +98,7 @@ export interface ArticleData {
   frontmatter: {
     title: string;
     description: string;
+    displayTitle?: string;
   };
   fields: { authors: string[]; slug?: string };
 }

--- a/test/components/SideNavBar.test.tsx
+++ b/test/components/SideNavBar.test.tsx
@@ -53,7 +53,9 @@ describe('SideNavBar', () => {
   it('should contain a href to `~/governance`', () => {
     render(<SideNavBar pageKey={SideNavBarKeys.governance} />);
     const governanceNavBarElement = screen.getByText('Project Governance');
-    expect(governanceNavBarElement.getAttribute('href')).toBe('/governance');
+    expect(governanceNavBarElement.getAttribute('href')).toBe(
+      '/about/governance'
+    );
   });
 
   it('should contain a href to `~/community`', () => {
@@ -66,14 +68,14 @@ describe('SideNavBar', () => {
     render(<SideNavBar pageKey={SideNavBarKeys.workingGroups} />);
     const workingGroupsNavBarElement = screen.getByText('Working Groups');
     expect(workingGroupsNavBarElement.getAttribute('href')).toBe(
-      '/working-groups'
+      '/about/working-groups'
     );
   });
 
   it('should contain a href to `~/releases`', () => {
     render(<SideNavBar pageKey={SideNavBarKeys.releases} />);
     const releasesNavBarElement = screen.getByText('Releases');
-    expect(releasesNavBarElement.getAttribute('href')).toBe('/releases');
+    expect(releasesNavBarElement.getAttribute('href')).toBe('/about/releases');
   });
 
   it('should contain a href to `~/resources`', () => {
@@ -85,19 +87,21 @@ describe('SideNavBar', () => {
   it('should contain a href to `~/trademark`', () => {
     render(<SideNavBar pageKey={SideNavBarKeys.trademark} />);
     const trademarkNavBarElement = screen.getByText('Trademark Policy');
-    expect(trademarkNavBarElement.getAttribute('href')).toBe('/trademark');
+    expect(trademarkNavBarElement.getAttribute('href')).toBe(
+      '/about/trademark'
+    );
   });
 
   it('should contain a href to `~/privacy`', () => {
     render(<SideNavBar pageKey={SideNavBarKeys.privacy} />);
     const privacyNavBarElement = screen.getByText('Privacy Policy');
-    expect(privacyNavBarElement.getAttribute('href')).toBe('/privacy');
+    expect(privacyNavBarElement.getAttribute('href')).toBe('/about/privacy');
   });
 
   it('should contain a href to `~/security`', () => {
     render(<SideNavBar pageKey={SideNavBarKeys.security} />);
     const securityNavBarElement = screen.getByText('Security Reporting');
-    expect(securityNavBarElement.getAttribute('href')).toBe('/security');
+    expect(securityNavBarElement.getAttribute('href')).toBe('/about/security');
   });
 
   it('should contain a href to `~/package-manager`', () => {

--- a/test/components/__snapshots__/SideNavBar.test.tsx.snap
+++ b/test/components/__snapshots__/SideNavBar.test.tsx.snap
@@ -37,22 +37,22 @@ exports[`SideNavBar renders correctly 1`] = `
       </a>
       <a
         class="t-body2 side-nav__item-community"
-        href="/privacy"
-        id="link-privacy"
+        href="/about/privacy"
+        id="link-about/privacy"
       >
         Privacy Policy
       </a>
       <a
         class="t-body2 side-nav__item-community"
-        href="/governance"
-        id="link-governance"
+        href="/about/governance"
+        id="link-about/governance"
       >
         Project Governance
       </a>
       <a
         class="t-body2 side-nav__item-community"
-        href="/releases"
-        id="link-releases"
+        href="/about/releases"
+        id="link-about/releases"
       >
         Releases
       </a>
@@ -65,22 +65,22 @@ exports[`SideNavBar renders correctly 1`] = `
       </a>
       <a
         class="t-body2 side-nav__item-community"
-        href="/security"
-        id="link-security"
+        href="/about/security"
+        id="link-about/security"
       >
         Security Reporting
       </a>
       <a
         class="t-body2 side-nav__item-community side-nav__item-community--active"
-        href="/trademark"
-        id="link-trademark"
+        href="/about/trademark"
+        id="link-about/trademark"
       >
         Trademark Policy
       </a>
       <a
         class="t-body2 side-nav__item-community"
-        href="/working-groups"
-        id="link-working-groups"
+        href="/about/working-groups"
+        id="link-about/working-groups"
       >
         Working Groups
       </a>

--- a/test/pages/404.test.tsx
+++ b/test/pages/404.test.tsx
@@ -5,7 +5,7 @@ import '../__mocks__/intersectionObserverMock';
 
 describe('404 page', () => {
   it('renders correctly', () => {
-    const { container } = render(<NotFound location={window.location} />);
+    const { container } = render(<NotFound />);
     expect(container).toMatchSnapshot();
   });
 });

--- a/test/pages/__snapshots__/404.test.tsx.snap
+++ b/test/pages/__snapshots__/404.test.tsx.snap
@@ -152,13 +152,6 @@ exports[`404 page renders correctly 1`] = `
         </a>
       </p>
     </main>
-    <section
-      class="bottom-info"
-    >
-      <div
-        class="random-contributor"
-      />
-    </section>
     <footer
       class="footer"
     >

--- a/test/pages/__snapshots__/404.test.tsx.snap
+++ b/test/pages/__snapshots__/404.test.tsx.snap
@@ -161,7 +161,7 @@ exports[`404 page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/trademark"
+            href="/about/trademark"
           >
             Trademark Policy
           </a>
@@ -169,7 +169,7 @@ exports[`404 page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/privacy"
+            href="/about/privacy"
           >
             Privacy Policy
           </a>
@@ -185,7 +185,7 @@ exports[`404 page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/security"
+            href="/about/security"
           >
             Security Reporting
           </a>

--- a/test/pages/__snapshots__/about.test.tsx.snap
+++ b/test/pages/__snapshots__/about.test.tsx.snap
@@ -171,22 +171,22 @@ exports[`About page renders correctly 1`] = `
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/privacy"
-            id="link-privacy"
+            href="/about/privacy"
+            id="link-about/privacy"
           >
             Privacy Policy
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/governance"
-            id="link-governance"
+            href="/about/governance"
+            id="link-about/governance"
           >
             Project Governance
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/releases"
-            id="link-releases"
+            href="/about/releases"
+            id="link-about/releases"
           >
             Releases
           </a>
@@ -199,22 +199,22 @@ exports[`About page renders correctly 1`] = `
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/security"
-            id="link-security"
+            href="/about/security"
+            id="link-about/security"
           >
             Security Reporting
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/trademark"
-            id="link-trademark"
+            href="/about/trademark"
+            id="link-about/trademark"
           >
             Trademark Policy
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/working-groups"
-            id="link-working-groups"
+            href="/about/working-groups"
+            id="link-about/working-groups"
           >
             Working Groups
           </a>
@@ -352,13 +352,6 @@ exports[`About page renders correctly 1`] = `
         </div>
       </article>
     </main>
-    <section
-      class="bottom-info"
-    >
-      <div
-        class="random-contributor"
-      />
-    </section>
     <footer
       class="footer"
     >

--- a/test/pages/__snapshots__/about.test.tsx.snap
+++ b/test/pages/__snapshots__/about.test.tsx.snap
@@ -361,7 +361,7 @@ exports[`About page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/trademark"
+            href="/about/trademark"
           >
             Trademark Policy
           </a>
@@ -369,7 +369,7 @@ exports[`About page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/privacy"
+            href="/about/privacy"
           >
             Privacy Policy
           </a>
@@ -385,7 +385,7 @@ exports[`About page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/security"
+            href="/about/security"
           >
             Security Reporting
           </a>

--- a/test/pages/__snapshots__/blog.test.tsx.snap
+++ b/test/pages/__snapshots__/blog.test.tsx.snap
@@ -171,13 +171,6 @@ exports[`Blog page renders correctly 1`] = `
         </div>
       </div>
     </div>
-    <section
-      class="bottom-info"
-    >
-      <div
-        class="random-contributor"
-      />
-    </section>
     <footer
       class="footer"
     >
@@ -419,13 +412,6 @@ exports[`Blog page renders correctly for empty blogs list 1`] = `
         </div>
       </div>
     </nav>
-    <section
-      class="bottom-info"
-    >
-      <div
-        class="random-contributor"
-      />
-    </section>
     <footer
       class="footer"
     >

--- a/test/pages/__snapshots__/blog.test.tsx.snap
+++ b/test/pages/__snapshots__/blog.test.tsx.snap
@@ -180,7 +180,7 @@ exports[`Blog page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/trademark"
+            href="/about/trademark"
           >
             Trademark Policy
           </a>
@@ -188,7 +188,7 @@ exports[`Blog page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/privacy"
+            href="/about/privacy"
           >
             Privacy Policy
           </a>
@@ -204,7 +204,7 @@ exports[`Blog page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/security"
+            href="/about/security"
           >
             Security Reporting
           </a>
@@ -421,7 +421,7 @@ exports[`Blog page renders correctly for empty blogs list 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/trademark"
+            href="/about/trademark"
           >
             Trademark Policy
           </a>
@@ -429,7 +429,7 @@ exports[`Blog page renders correctly for empty blogs list 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/privacy"
+            href="/about/privacy"
           >
             Privacy Policy
           </a>
@@ -445,7 +445,7 @@ exports[`Blog page renders correctly for empty blogs list 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/security"
+            href="/about/security"
           >
             Security Reporting
           </a>

--- a/test/pages/__snapshots__/community.test.tsx.snap
+++ b/test/pages/__snapshots__/community.test.tsx.snap
@@ -171,22 +171,22 @@ exports[`Community Page renders correctly 1`] = `
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/privacy"
-            id="link-privacy"
+            href="/about/privacy"
+            id="link-about/privacy"
           >
             Privacy Policy
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/governance"
-            id="link-governance"
+            href="/about/governance"
+            id="link-about/governance"
           >
             Project Governance
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/releases"
-            id="link-releases"
+            href="/about/releases"
+            id="link-about/releases"
           >
             Releases
           </a>
@@ -199,22 +199,22 @@ exports[`Community Page renders correctly 1`] = `
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/security"
-            id="link-security"
+            href="/about/security"
+            id="link-about/security"
           >
             Security Reporting
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/trademark"
-            id="link-trademark"
+            href="/about/trademark"
+            id="link-about/trademark"
           >
             Trademark Policy
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/working-groups"
-            id="link-working-groups"
+            href="/about/working-groups"
+            id="link-about/working-groups"
           >
             Working Groups
           </a>
@@ -352,13 +352,6 @@ exports[`Community Page renders correctly 1`] = `
         </div>
       </article>
     </main>
-    <section
-      class="bottom-info"
-    >
-      <div
-        class="random-contributor"
-      />
-    </section>
     <footer
       class="footer"
     >

--- a/test/pages/__snapshots__/community.test.tsx.snap
+++ b/test/pages/__snapshots__/community.test.tsx.snap
@@ -361,7 +361,7 @@ exports[`Community Page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/trademark"
+            href="/about/trademark"
           >
             Trademark Policy
           </a>
@@ -369,7 +369,7 @@ exports[`Community Page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/privacy"
+            href="/about/privacy"
           >
             Privacy Policy
           </a>
@@ -385,7 +385,7 @@ exports[`Community Page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/security"
+            href="/about/security"
           >
             Security Reporting
           </a>

--- a/test/pages/__snapshots__/governance.test.tsx.snap
+++ b/test/pages/__snapshots__/governance.test.tsx.snap
@@ -171,22 +171,22 @@ exports[`Governance Page renders correctly 1`] = `
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/privacy"
-            id="link-privacy"
+            href="/about/privacy"
+            id="link-about/privacy"
           >
             Privacy Policy
           </a>
           <a
             class="t-body2 side-nav__item-community side-nav__item-community--active"
-            href="/governance"
-            id="link-governance"
+            href="/about/governance"
+            id="link-about/governance"
           >
             Project Governance
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/releases"
-            id="link-releases"
+            href="/about/releases"
+            id="link-about/releases"
           >
             Releases
           </a>
@@ -199,22 +199,22 @@ exports[`Governance Page renders correctly 1`] = `
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/security"
-            id="link-security"
+            href="/about/security"
+            id="link-about/security"
           >
             Security Reporting
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/trademark"
-            id="link-trademark"
+            href="/about/trademark"
+            id="link-about/trademark"
           >
             Trademark Policy
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/working-groups"
-            id="link-working-groups"
+            href="/about/working-groups"
+            id="link-about/working-groups"
           >
             Working Groups
           </a>
@@ -352,13 +352,6 @@ exports[`Governance Page renders correctly 1`] = `
         </div>
       </article>
     </main>
-    <section
-      class="bottom-info"
-    >
-      <div
-        class="random-contributor"
-      />
-    </section>
     <footer
       class="footer"
     >

--- a/test/pages/__snapshots__/governance.test.tsx.snap
+++ b/test/pages/__snapshots__/governance.test.tsx.snap
@@ -361,7 +361,7 @@ exports[`Governance Page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/trademark"
+            href="/about/trademark"
           >
             Trademark Policy
           </a>
@@ -369,7 +369,7 @@ exports[`Governance Page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/privacy"
+            href="/about/privacy"
           >
             Privacy Policy
           </a>
@@ -385,7 +385,7 @@ exports[`Governance Page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/security"
+            href="/about/security"
           >
             Security Reporting
           </a>

--- a/test/pages/__snapshots__/home.test.tsx.snap
+++ b/test/pages/__snapshots__/home.test.tsx.snap
@@ -486,7 +486,7 @@ exports[`Home page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/trademark"
+            href="/about/trademark"
           >
             Trademark Policy
           </a>
@@ -494,7 +494,7 @@ exports[`Home page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/privacy"
+            href="/about/privacy"
           >
             Privacy Policy
           </a>
@@ -510,7 +510,7 @@ exports[`Home page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/security"
+            href="/about/security"
           >
             Security Reporting
           </a>
@@ -1111,7 +1111,7 @@ exports[`Home page renders i18n when feature toggle is present 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/trademark"
+            href="/about/trademark"
           >
             Trademark Policy
           </a>
@@ -1119,7 +1119,7 @@ exports[`Home page renders i18n when feature toggle is present 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/privacy"
+            href="/about/privacy"
           >
             Privacy Policy
           </a>
@@ -1135,7 +1135,7 @@ exports[`Home page renders i18n when feature toggle is present 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/security"
+            href="/about/security"
           >
             Security Reporting
           </a>

--- a/test/pages/__snapshots__/privacy.test.tsx.snap
+++ b/test/pages/__snapshots__/privacy.test.tsx.snap
@@ -171,22 +171,22 @@ exports[`Privacy Page renders correctly 1`] = `
           </a>
           <a
             class="t-body2 side-nav__item-community side-nav__item-community--active"
-            href="/privacy"
-            id="link-privacy"
+            href="/about/privacy"
+            id="link-about/privacy"
           >
             Privacy Policy
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/governance"
-            id="link-governance"
+            href="/about/governance"
+            id="link-about/governance"
           >
             Project Governance
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/releases"
-            id="link-releases"
+            href="/about/releases"
+            id="link-about/releases"
           >
             Releases
           </a>
@@ -199,22 +199,22 @@ exports[`Privacy Page renders correctly 1`] = `
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/security"
-            id="link-security"
+            href="/about/security"
+            id="link-about/security"
           >
             Security Reporting
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/trademark"
-            id="link-trademark"
+            href="/about/trademark"
+            id="link-about/trademark"
           >
             Trademark Policy
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/working-groups"
-            id="link-working-groups"
+            href="/about/working-groups"
+            id="link-about/working-groups"
           >
             Working Groups
           </a>
@@ -352,13 +352,6 @@ exports[`Privacy Page renders correctly 1`] = `
         </div>
       </article>
     </main>
-    <section
-      class="bottom-info"
-    >
-      <div
-        class="random-contributor"
-      />
-    </section>
     <footer
       class="footer"
     >

--- a/test/pages/__snapshots__/privacy.test.tsx.snap
+++ b/test/pages/__snapshots__/privacy.test.tsx.snap
@@ -361,7 +361,7 @@ exports[`Privacy Page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/trademark"
+            href="/about/trademark"
           >
             Trademark Policy
           </a>
@@ -369,7 +369,7 @@ exports[`Privacy Page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/privacy"
+            href="/about/privacy"
           >
             Privacy Policy
           </a>
@@ -385,7 +385,7 @@ exports[`Privacy Page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/security"
+            href="/about/security"
           >
             Security Reporting
           </a>

--- a/test/pages/__snapshots__/releases.test.tsx.snap
+++ b/test/pages/__snapshots__/releases.test.tsx.snap
@@ -462,7 +462,7 @@ exports[`Releases page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/trademark"
+            href="/about/trademark"
           >
             Trademark Policy
           </a>
@@ -470,7 +470,7 @@ exports[`Releases page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/privacy"
+            href="/about/privacy"
           >
             Privacy Policy
           </a>
@@ -486,7 +486,7 @@ exports[`Releases page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/security"
+            href="/about/security"
           >
             Security Reporting
           </a>

--- a/test/pages/__snapshots__/releases.test.tsx.snap
+++ b/test/pages/__snapshots__/releases.test.tsx.snap
@@ -171,22 +171,22 @@ exports[`Releases page renders correctly 1`] = `
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/privacy"
-            id="link-privacy"
+            href="/about/privacy"
+            id="link-about/privacy"
           >
             Privacy Policy
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/governance"
-            id="link-governance"
+            href="/about/governance"
+            id="link-about/governance"
           >
             Project Governance
           </a>
           <a
             class="t-body2 side-nav__item-community side-nav__item-community--active"
-            href="/releases"
-            id="link-releases"
+            href="/about/releases"
+            id="link-about/releases"
           >
             Releases
           </a>
@@ -199,22 +199,22 @@ exports[`Releases page renders correctly 1`] = `
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/security"
-            id="link-security"
+            href="/about/security"
+            id="link-about/security"
           >
             Security Reporting
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/trademark"
-            id="link-trademark"
+            href="/about/trademark"
+            id="link-about/trademark"
           >
             Trademark Policy
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/working-groups"
-            id="link-working-groups"
+            href="/about/working-groups"
+            id="link-about/working-groups"
           >
             Working Groups
           </a>
@@ -453,13 +453,6 @@ exports[`Releases page renders correctly 1`] = `
         </div>
       </article>
     </main>
-    <section
-      class="bottom-info"
-    >
-      <div
-        class="random-contributor"
-      />
-    </section>
     <footer
       class="footer"
     >

--- a/test/pages/__snapshots__/resources.test.tsx.snap
+++ b/test/pages/__snapshots__/resources.test.tsx.snap
@@ -171,22 +171,22 @@ exports[`About page renders correctly 1`] = `
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/privacy"
-            id="link-privacy"
+            href="/about/privacy"
+            id="link-about/privacy"
           >
             Privacy Policy
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/governance"
-            id="link-governance"
+            href="/about/governance"
+            id="link-about/governance"
           >
             Project Governance
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/releases"
-            id="link-releases"
+            href="/about/releases"
+            id="link-about/releases"
           >
             Releases
           </a>
@@ -199,22 +199,22 @@ exports[`About page renders correctly 1`] = `
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/security"
-            id="link-security"
+            href="/about/security"
+            id="link-about/security"
           >
             Security Reporting
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/trademark"
-            id="link-trademark"
+            href="/about/trademark"
+            id="link-about/trademark"
           >
             Trademark Policy
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/working-groups"
-            id="link-working-groups"
+            href="/about/working-groups"
+            id="link-about/working-groups"
           >
             Working Groups
           </a>
@@ -352,13 +352,6 @@ exports[`About page renders correctly 1`] = `
         </div>
       </article>
     </main>
-    <section
-      class="bottom-info"
-    >
-      <div
-        class="random-contributor"
-      />
-    </section>
     <footer
       class="footer"
     >

--- a/test/pages/__snapshots__/resources.test.tsx.snap
+++ b/test/pages/__snapshots__/resources.test.tsx.snap
@@ -361,7 +361,7 @@ exports[`About page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/trademark"
+            href="/about/trademark"
           >
             Trademark Policy
           </a>
@@ -369,7 +369,7 @@ exports[`About page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/privacy"
+            href="/about/privacy"
           >
             Privacy Policy
           </a>
@@ -385,7 +385,7 @@ exports[`About page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/security"
+            href="/about/security"
           >
             Security Reporting
           </a>

--- a/test/pages/__snapshots__/security.test.tsx.snap
+++ b/test/pages/__snapshots__/security.test.tsx.snap
@@ -171,22 +171,22 @@ exports[`Security page renders correctly 1`] = `
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/privacy"
-            id="link-privacy"
+            href="/about/privacy"
+            id="link-about/privacy"
           >
             Privacy Policy
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/governance"
-            id="link-governance"
+            href="/about/governance"
+            id="link-about/governance"
           >
             Project Governance
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/releases"
-            id="link-releases"
+            href="/about/releases"
+            id="link-about/releases"
           >
             Releases
           </a>
@@ -199,22 +199,22 @@ exports[`Security page renders correctly 1`] = `
           </a>
           <a
             class="t-body2 side-nav__item-community side-nav__item-community--active"
-            href="/security"
-            id="link-security"
+            href="/about/security"
+            id="link-about/security"
           >
             Security Reporting
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/trademark"
-            id="link-trademark"
+            href="/about/trademark"
+            id="link-about/trademark"
           >
             Trademark Policy
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/working-groups"
-            id="link-working-groups"
+            href="/about/working-groups"
+            id="link-about/working-groups"
           >
             Working Groups
           </a>
@@ -352,13 +352,6 @@ exports[`Security page renders correctly 1`] = `
         </div>
       </article>
     </main>
-    <section
-      class="bottom-info"
-    >
-      <div
-        class="random-contributor"
-      />
-    </section>
     <footer
       class="footer"
     >

--- a/test/pages/__snapshots__/security.test.tsx.snap
+++ b/test/pages/__snapshots__/security.test.tsx.snap
@@ -361,7 +361,7 @@ exports[`Security page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/trademark"
+            href="/about/trademark"
           >
             Trademark Policy
           </a>
@@ -369,7 +369,7 @@ exports[`Security page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/privacy"
+            href="/about/privacy"
           >
             Privacy Policy
           </a>
@@ -385,7 +385,7 @@ exports[`Security page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/security"
+            href="/about/security"
           >
             Security Reporting
           </a>

--- a/test/pages/__snapshots__/trademark.test.tsx.snap
+++ b/test/pages/__snapshots__/trademark.test.tsx.snap
@@ -171,22 +171,22 @@ exports[`Trademark page renders correctly 1`] = `
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/privacy"
-            id="link-privacy"
+            href="/about/privacy"
+            id="link-about/privacy"
           >
             Privacy Policy
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/governance"
-            id="link-governance"
+            href="/about/governance"
+            id="link-about/governance"
           >
             Project Governance
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/releases"
-            id="link-releases"
+            href="/about/releases"
+            id="link-about/releases"
           >
             Releases
           </a>
@@ -199,22 +199,22 @@ exports[`Trademark page renders correctly 1`] = `
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/security"
-            id="link-security"
+            href="/about/security"
+            id="link-about/security"
           >
             Security Reporting
           </a>
           <a
             class="t-body2 side-nav__item-community side-nav__item-community--active"
-            href="/trademark"
-            id="link-trademark"
+            href="/about/trademark"
+            id="link-about/trademark"
           >
             Trademark Policy
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/working-groups"
-            id="link-working-groups"
+            href="/about/working-groups"
+            id="link-about/working-groups"
           >
             Working Groups
           </a>
@@ -352,13 +352,6 @@ exports[`Trademark page renders correctly 1`] = `
         </div>
       </article>
     </main>
-    <section
-      class="bottom-info"
-    >
-      <div
-        class="random-contributor"
-      />
-    </section>
     <footer
       class="footer"
     >

--- a/test/pages/__snapshots__/trademark.test.tsx.snap
+++ b/test/pages/__snapshots__/trademark.test.tsx.snap
@@ -361,7 +361,7 @@ exports[`Trademark page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/trademark"
+            href="/about/trademark"
           >
             Trademark Policy
           </a>
@@ -369,7 +369,7 @@ exports[`Trademark page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/privacy"
+            href="/about/privacy"
           >
             Privacy Policy
           </a>
@@ -385,7 +385,7 @@ exports[`Trademark page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/security"
+            href="/about/security"
           >
             Security Reporting
           </a>

--- a/test/pages/__snapshots__/working-groups.test.tsx.snap
+++ b/test/pages/__snapshots__/working-groups.test.tsx.snap
@@ -171,22 +171,22 @@ exports[`Working Groups page renders correctly 1`] = `
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/privacy"
-            id="link-privacy"
+            href="/about/privacy"
+            id="link-about/privacy"
           >
             Privacy Policy
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/governance"
-            id="link-governance"
+            href="/about/governance"
+            id="link-about/governance"
           >
             Project Governance
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/releases"
-            id="link-releases"
+            href="/about/releases"
+            id="link-about/releases"
           >
             Releases
           </a>
@@ -199,22 +199,22 @@ exports[`Working Groups page renders correctly 1`] = `
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/security"
-            id="link-security"
+            href="/about/security"
+            id="link-about/security"
           >
             Security Reporting
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/trademark"
-            id="link-trademark"
+            href="/about/trademark"
+            id="link-about/trademark"
           >
             Trademark Policy
           </a>
           <a
             class="t-body2 side-nav__item-community side-nav__item-community--active"
-            href="/working-groups"
-            id="link-working-groups"
+            href="/about/working-groups"
+            id="link-about/working-groups"
           >
             Working Groups
           </a>
@@ -352,13 +352,6 @@ exports[`Working Groups page renders correctly 1`] = `
         </div>
       </article>
     </main>
-    <section
-      class="bottom-info"
-    >
-      <div
-        class="random-contributor"
-      />
-    </section>
     <footer
       class="footer"
     >

--- a/test/pages/__snapshots__/working-groups.test.tsx.snap
+++ b/test/pages/__snapshots__/working-groups.test.tsx.snap
@@ -361,7 +361,7 @@ exports[`Working Groups page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/trademark"
+            href="/about/trademark"
           >
             Trademark Policy
           </a>
@@ -369,7 +369,7 @@ exports[`Working Groups page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/privacy"
+            href="/about/privacy"
           >
             Privacy Policy
           </a>
@@ -385,7 +385,7 @@ exports[`Working Groups page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/security"
+            href="/about/security"
           >
             Security Reporting
           </a>

--- a/test/pages/download/__snapshots__/index.test.tsx.snap
+++ b/test/pages/download/__snapshots__/index.test.tsx.snap
@@ -703,7 +703,7 @@ exports[`Download page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/trademark"
+            href="/about/trademark"
           >
             Trademark Policy
           </a>
@@ -711,7 +711,7 @@ exports[`Download page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/privacy"
+            href="/about/privacy"
           >
             Privacy Policy
           </a>
@@ -727,7 +727,7 @@ exports[`Download page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/security"
+            href="/about/security"
           >
             Security Reporting
           </a>
@@ -1412,7 +1412,7 @@ exports[`Download page should handle LTS to Current switch 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/trademark"
+            href="/about/trademark"
           >
             Trademark Policy
           </a>
@@ -1420,7 +1420,7 @@ exports[`Download page should handle LTS to Current switch 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/privacy"
+            href="/about/privacy"
           >
             Privacy Policy
           </a>
@@ -1436,7 +1436,7 @@ exports[`Download page should handle LTS to Current switch 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/security"
+            href="/about/security"
           >
             Security Reporting
           </a>

--- a/test/pages/download/__snapshots__/index.test.tsx.snap
+++ b/test/pages/download/__snapshots__/index.test.tsx.snap
@@ -694,13 +694,6 @@ exports[`Download page renders correctly 1`] = `
         </div>
       </div>
     </span>
-    <section
-      class="bottom-info"
-    >
-      <div
-        class="random-contributor"
-      />
-    </section>
     <footer
       class="footer"
     >
@@ -1410,13 +1403,6 @@ exports[`Download page should handle LTS to Current switch 1`] = `
         />
       </div>
     </span>
-    <section
-      class="bottom-info"
-    >
-      <div
-        class="random-contributor"
-      />
-    </section>
     <footer
       class="footer"
     >

--- a/test/pages/download/__snapshots__/package-manager.test.tsx.snap
+++ b/test/pages/download/__snapshots__/package-manager.test.tsx.snap
@@ -361,7 +361,7 @@ exports[`Package Manager Page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/trademark"
+            href="/about/trademark"
           >
             Trademark Policy
           </a>
@@ -369,7 +369,7 @@ exports[`Package Manager Page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/privacy"
+            href="/about/privacy"
           >
             Privacy Policy
           </a>
@@ -385,7 +385,7 @@ exports[`Package Manager Page renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/security"
+            href="/about/security"
           >
             Security Reporting
           </a>

--- a/test/pages/download/__snapshots__/package-manager.test.tsx.snap
+++ b/test/pages/download/__snapshots__/package-manager.test.tsx.snap
@@ -171,22 +171,22 @@ exports[`Package Manager Page renders correctly 1`] = `
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/privacy"
-            id="link-privacy"
+            href="/about/privacy"
+            id="link-about/privacy"
           >
             Privacy Policy
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/governance"
-            id="link-governance"
+            href="/about/governance"
+            id="link-about/governance"
           >
             Project Governance
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/releases"
-            id="link-releases"
+            href="/about/releases"
+            id="link-about/releases"
           >
             Releases
           </a>
@@ -199,22 +199,22 @@ exports[`Package Manager Page renders correctly 1`] = `
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/security"
-            id="link-security"
+            href="/about/security"
+            id="link-about/security"
           >
             Security Reporting
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/trademark"
-            id="link-trademark"
+            href="/about/trademark"
+            id="link-about/trademark"
           >
             Trademark Policy
           </a>
           <a
             class="t-body2 side-nav__item-community"
-            href="/working-groups"
-            id="link-working-groups"
+            href="/about/working-groups"
+            id="link-about/working-groups"
           >
             Working Groups
           </a>
@@ -352,13 +352,6 @@ exports[`Package Manager Page renders correctly 1`] = `
         </div>
       </article>
     </main>
-    <section
-      class="bottom-info"
-    >
-      <div
-        class="random-contributor"
-      />
-    </section>
     <footer
       class="footer"
     >

--- a/test/pages/governance.test.tsx
+++ b/test/pages/governance.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import GovernancePage from '../../src/pages/governance';
+import GovernancePage from '../../src/pages/about/governance';
 import '../__mocks__/intersectionObserverMock';
 
 import { createGeneralPageData } from '../__fixtures__/page';

--- a/test/pages/privacy.test.tsx
+++ b/test/pages/privacy.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import PrivacyPage from '../../src/pages/privacy';
+import PrivacyPage from '../../src/pages/about/privacy';
 import '../__mocks__/intersectionObserverMock';
 
 import { createPrivacyData } from '../__fixtures__/page';

--- a/test/pages/releases.test.tsx
+++ b/test/pages/releases.test.tsx
@@ -5,7 +5,9 @@ import {
   createGeneralPageData,
   createNodeReleasesData,
 } from '../__fixtures__/page';
-import ReleasesPage, { ReleasesNodeReleases } from '../../src/pages/releases';
+import ReleasesPage, {
+  ReleasesNodeReleases,
+} from '../../src/pages/about/releases';
 
 const mockNodeReleasesData = createNodeReleasesData();
 const mockReleasesNodeReleases: ReleasesNodeReleases = {

--- a/test/pages/security.test.tsx
+++ b/test/pages/security.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import SecurityPage from '../../src/pages/security';
+import SecurityPage from '../../src/pages/about/security';
 import '../__mocks__/intersectionObserverMock';
 import { createGeneralPageData } from '../__fixtures__/page';
 

--- a/test/pages/trademark.test.tsx
+++ b/test/pages/trademark.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import TrademarkPage from '../../src/pages/trademark';
+import TrademarkPage from '../../src/pages/about/trademark';
 import '../__mocks__/intersectionObserverMock';
 
 import { createGeneralPageData } from '../__fixtures__/page';

--- a/test/pages/working-groups.test.tsx
+++ b/test/pages/working-groups.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import WorkingGroupsPage from '../../src/pages/working-groups';
+import WorkingGroupsPage from '../../src/pages/about/working-groups';
 import '../__mocks__/intersectionObserverMock';
 import { createGeneralPageData } from '../__fixtures__/page';
 

--- a/test/templates/__snapshots__/blog.test.tsx.snap
+++ b/test/templates/__snapshots__/blog.test.tsx.snap
@@ -241,7 +241,7 @@ exports[`LearnLayout Template renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/trademark"
+            href="/about/trademark"
           >
             Trademark Policy
           </a>
@@ -249,7 +249,7 @@ exports[`LearnLayout Template renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/privacy"
+            href="/about/privacy"
           >
             Privacy Policy
           </a>
@@ -265,7 +265,7 @@ exports[`LearnLayout Template renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/security"
+            href="/about/security"
           >
             Security Reporting
           </a>

--- a/test/templates/__snapshots__/blog.test.tsx.snap
+++ b/test/templates/__snapshots__/blog.test.tsx.snap
@@ -232,13 +232,6 @@ exports[`LearnLayout Template renders correctly 1`] = `
         </div>
       </article>
     </main>
-    <section
-      class="bottom-info"
-    >
-      <div
-        class="random-contributor"
-      />
-    </section>
     <footer
       class="footer"
     >

--- a/test/templates/__snapshots__/learn.test.tsx.snap
+++ b/test/templates/__snapshots__/learn.test.tsx.snap
@@ -316,13 +316,6 @@ exports[`Learn Template renders correctly 1`] = `
         </ul>
       </article>
     </main>
-    <section
-      class="bottom-info"
-    >
-      <div
-        class="random-contributor"
-      />
-    </section>
     <footer
       class="footer"
     >

--- a/test/templates/__snapshots__/learn.test.tsx.snap
+++ b/test/templates/__snapshots__/learn.test.tsx.snap
@@ -325,7 +325,7 @@ exports[`Learn Template renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/trademark"
+            href="/about/trademark"
           >
             Trademark Policy
           </a>
@@ -333,7 +333,7 @@ exports[`Learn Template renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/privacy"
+            href="/about/privacy"
           >
             Privacy Policy
           </a>
@@ -349,7 +349,7 @@ exports[`Learn Template renders correctly 1`] = `
         <li>
           <a
             class="footer__link"
-            href="/security"
+            href="/about/security"
           >
             Security Reporting
           </a>

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["./**/*"]
+}

--- a/test/util/onCreateNode.test.ts
+++ b/test/util/onCreateNode.test.ts
@@ -3,7 +3,7 @@ import createSlug from '../../util-node/createSlug';
 
 jest.mock('../../util-node/createSlug', () => jest.fn(() => 'slug'));
 
-function createMockNodeOfType(type) {
+function createMockNodeOfType(type: string) {
   return {
     actions: { createNodeField: jest.fn() },
     getNode: jest.fn(),
@@ -16,7 +16,7 @@ function createMockNodeOfType(type) {
 
 describe('Tests for onCreateNode', () => {
   beforeEach(() => {
-    createSlug.mockClear();
+    (createSlug as jest.Mock).mockClear();
   });
   it('generates a slug for Mdx nodes', () => {
     const { node, getNode, actions } = createMockNodeOfType('Mdx');

--- a/test/util/outlineOnKeyboardNav.test.ts
+++ b/test/util/outlineOnKeyboardNav.test.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 import {
   handleMouseDown,
   handleFocus,
@@ -17,20 +18,36 @@ describe('Tests for focus and blur handlers', () => {
     };
   });
   it('hides outline for mouse focus', () => {
-    handleMouseDown(event);
-    handleFocus(event);
-    expect(event.target.getAttribute(FOCUS_ATTR)).toEqual('true');
+    handleMouseDown(event as Event);
+    handleFocus(event as Event);
+    expect(
+      (event as React.KeyboardEvent<HTMLDivElement>).target.getAttribute(
+        FOCUS_ATTR
+      )
+    ).toEqual('true');
   });
   it('doesnt hide outline for keyboard focus', () => {
-    handleKeyDown(event);
-    handleFocus(event);
-    expect(event.target.getAttribute(FOCUS_ATTR)).toBeNull();
+    handleKeyDown(event as KeyboardEvent);
+    handleFocus(event as Event);
+    expect(
+      (event as React.KeyboardEvent<HTMLDivElement>).target.getAttribute(
+        FOCUS_ATTR
+      )
+    ).toBeNull();
   });
   it('Blurs after leaving focus', () => {
-    handleMouseDown(event);
-    handleFocus(event);
-    expect(event.target.getAttribute(FOCUS_ATTR)).toEqual('true');
-    handleBlur(event);
-    expect(event.target.getAttribute(FOCUS_ATTR)).toBeNull();
+    handleMouseDown(event as Event);
+    handleFocus(event as Event);
+    expect(
+      (event as React.KeyboardEvent<HTMLDivElement>).target.getAttribute(
+        FOCUS_ATTR
+      )
+    ).toEqual('true');
+    handleBlur(event as Event);
+    expect(
+      (event as React.KeyboardEvent<HTMLDivElement>).target.getAttribute(
+        FOCUS_ATTR
+      )
+    ).toBeNull();
   });
 });

--- a/util-node/redirects.js
+++ b/util-node/redirects.js
@@ -1,5 +1,14 @@
 // This file is used to define all the changed slugs from original nodejs.org site to our new site.
+// Note.: Gatsby requires trailing slashes on the path names
 module.exports = {
   // Redirects Node.js Get Involved to Community
-  '/en/get-involved': '/community',
+  '/en/get-involved/': '/community/',
+  '/get-involved/': '/community/',
+  // Redirects old About pages path to the new ones
+  '/governance/': '/about/governance/',
+  '/working-groups/': '/about/working-groups/',
+  '/releases/': '/about/releases/',
+  '/trademark/': '/about/trademark/',
+  '/privacy/': '/about/privacy/',
+  '/security/': '/about/security/',
 };


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run lint:js -- --fix` and/or `npm run lint:md -- --fix` for my JavaScript and/or Markdown changes.
  - This is important as most of the cases your code changes might not be correctly linted
- [x] I have run `npm run test` to check if all tests are passing, and/or `npm run test -- -u` to update snapshots if I created and/or updated React Components.
- [x] I have checked that the build works locally and that `npm run build` and `npm run build-storybook` work fine.
- [x] I've covered new added functionality with unit tests if necessary.

## Description

This PR adds a couple of changes by:

- Adding `displayTitle` field which will be used for the localised pages (i18n)
- Moved pages to directories that correspond to their categories
- Moved the Random Contributor Component to Layout and made it optional

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
