### PR TITLE
fix(page-creation): refactored how we create pages to permanently fix…

### DIFF
--- a/util-node/createLearnQuery.js
+++ b/util-node/createLearnQuery.js
@@ -3,22 +3,7 @@ module.exports = `
   allMdx(
     filter: {
       fields: {
-        slug: {
-          nin: [
-            ""
-            "nodejs-community"
-            "homepage"
-            "trademark-policy"
-            "working-groups"
-            "resources"
-            "privacy-policy"
-            "about"
-            "governance"
-            "security"
-            "package-manager"
-          ]
-        }
-        categoryName: { ne: "learn" }
+        categoryName: { eq: "learn" }
       }
     }
     sort: { fields: [fileAbsolutePath], order: ASC }

--- a/util-node/createMarkdownPages.js
+++ b/util-node/createMarkdownPages.js
@@ -6,12 +6,8 @@ function getYamlPageIdentifier(relativePath) {
     : relativePath.replace(/(\.[a-z]+)?\.(mdx|md)/, '');
 }
 
-function createLearnPages(edges, yamlNavigationData) {
-  const navigationData = {};
-  const markdownPages = [];
-
-  // Handles the parsing of all Markdown Pages
-  edges.forEach(({ node }, index) => {
+function iterateEdges(edges) {
+  function updateMarkdownPage({ node }, index) {
     const {
       fields: { slug, categoryName },
       parent: { relativePath },
@@ -42,7 +38,7 @@ function createLearnPages(edges, yamlNavigationData) {
       };
     }
 
-    markdownPages.push({
+    return {
       slug,
       title,
       realPath: fileAbsolutePath || '',
@@ -50,20 +46,21 @@ function createLearnPages(edges, yamlNavigationData) {
       previous: previousNodeData,
       relativePath,
       category: categoryName,
-    });
-  });
+    };
+  }
 
-  // We collect all pages that have category set to Learn
-  // As we want to build a navigation data for learn
-  // Then we get their unique identifiers based on the relativePath
-  // To match the ones defined on `src/data/learn.yaml`
-  const learnPages = markdownPages
-    .filter(page => page.category === 'learn')
-    .reduce((acc, page) => {
-      const pageId = getYamlPageIdentifier(page.relativePath);
+  return edges.map(updateMarkdownPage);
+}
 
-      return { ...acc, [pageId]: page };
-    }, {});
+function createMarkdownPages(pagesEdges, learnEdges, yamlNavigationData) {
+  const learnPages = [];
+  const navigationData = {};
+
+  // Iterates the non-Learn edges and transforms them in Pages
+  const markdownPages = iterateEdges(pagesEdges);
+
+  const getLearnEdgeByPageId = pageId => edge =>
+    getYamlPageIdentifier(edge.node.parent.relativePath) === pageId;
 
   // Handles the Navigation Data only of Learn pages
   yamlNavigationData.forEach(({ section, items }) => {
@@ -74,12 +71,24 @@ function createLearnPages(edges, yamlNavigationData) {
 
     // This adds the items to the navigation section data based on the order defined within the YAML file
     // If the page doesn't exist it will be set as null and then removed via Array.filter()
-    navigationData[section].data = items
-      .map(pageId => learnPages[pageId] || null)
-      .filter(page => page !== null);
+    navigationData[section].data = iterateEdges(
+      items
+        // Iterates the items of the section and retrieve their respective edges
+        // then we transform them into pages and add to the navigation data
+        .map(pageId => learnEdges.find(getLearnEdgeByPageId(pageId)))
+        .filter(edge => edge && edge.node)
+    );
+
+    // Then we push them to the resulting learn pages object
+    learnPages.push(...navigationData[section].data);
   });
 
-  return { markdownPages, navigationData };
+  return {
+    markdownPages,
+    learnPages,
+    navigationData,
+    firstLearnPage: learnPages[0],
+  };
 }
 
-module.exports = createLearnPages;
+module.exports = createMarkdownPages;


### PR DESCRIPTION
… navigation

<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run lint:js -- --fix` and/or `npm run lint:md -- --fix` for my JavaScript and/or Markdown changes.
  - This is important as most of the cases your code changes might not be correctly linted
- [x] I have run `npm run test` to check if all tests are passing, and/or `npm run test -- -u` to update snapshots if I created and/or updated React Components.
- [x] I have checked that the build works locally and that `npm run build` and `npm run build-storybook` work fine.
- [x] I've covered new added functionality with unit tests if necessary.

## Description

This PR refactors the `gatsby-node` page creation part. By separating two queries (one for the pages and the other for the learning pages. And then, it correctly sorts and maps the page data.

It also increases the O-time performance of the `createMarkdownPages` utility.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
