### PR TITLE
fix(i18n/config): fix hrefLang for zh-cn & zh-tw

### DIFF
--- a/src/i18n/config.json
+++ b/src/i18n/config.json
@@ -148,7 +148,7 @@
     "localName": "简体中文",
     "name": "Simplified Chinese",
     "langDir": "ltr",
-    "dateFormat": "YYYY.MM.DD",
+    "dateFormat": "YYYY/MM/DD",
     "hrefLang": "zh-Hans",
     "enabled": false
   },
@@ -157,7 +157,7 @@
     "localName": "繁體中文",
     "name": "Traditional Chinese",
     "langDir": "ltr",
-    "dateFormat": "YYYY.MM.DD",
+    "dateFormat": "YYYY/MM/DD",
     "hrefLang": "zh-Hant",
     "enabled": false
   }

--- a/src/i18n/config.json
+++ b/src/i18n/config.json
@@ -146,10 +146,10 @@
   {
     "code": "zh-cn",
     "localName": "简体中文",
-    "name": "Chinese",
+    "name": "Simplified Chinese",
     "langDir": "ltr",
     "dateFormat": "YYYY.MM.DD",
-    "hrefLang": "zh-Hant",
+    "hrefLang": "zh-Hans",
     "enabled": false
   },
   {
@@ -158,7 +158,7 @@
     "name": "Traditional Chinese",
     "langDir": "ltr",
     "dateFormat": "YYYY.MM.DD",
-    "hrefLang": "zh-Hans",
+    "hrefLang": "zh-Hant",
     "enabled": false
   }
 ]


### PR DESCRIPTION
### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.

## Description

The `hrefLang` code for "Simplified Chinese" should be `zh-Hans`, while `zh-Hant` for "Traditional Chinese".

> The `t` in `zh-Hant` means "traditional" while `s` in `zh-Hans` means "Simplified".

See references under "Script codes" section on https://hreflang.org/list-of-hreflang-codes/ for "Han (Simplified variant)" and Han (Traditional variant).

## Related Issues

This PR tries to fix a mistake in PR #2644
