### PR TITLE
Proposing to push Checklist down in PR description

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,17 @@
 Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) before opening a pull request.
 -->
 
+## Description
+
+<!-- Write a brief description of the changes introduced by this PR -->
+
+## Related Issues
+
+<!--
+  Link to the issue that is fixed by this PR (if there is one)
+  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
+-->
+
 ### Check List
 
 <!--
@@ -15,14 +26,3 @@ Please follow this check list to ensure that you've followed all items before op
 - [ ] I have run `npm run test` to check if all tests are passing, and/or `npm run test -- -u` to update snapshots if I created and/or updated React Components.
 - [ ] I have checked that the build works locally and that `npm run build` work fine.
 - [ ] I've covered new added functionality with unit tests if necessary.
-
-## Description
-
-<!-- Write a brief description of the changes introduced by this PR -->
-
-## Related Issues
-
-<!--
-  Link to the issue that is fixed by this PR (if there is one)
-  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
--->


### PR DESCRIPTION
Having checklist on the top of the description makes quite hard to catch visually what was PR created for.
