### PR TITLE
fix: calculate Edit on GitHub link at build

### DIFF
--- a/content/api/v18/addons.en.md
+++ b/content/api/v18/addons.en.md
@@ -2,7 +2,6 @@
 title: 'addons'
 displayTitle: 'C++ addons'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/addons.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/assert.en.md
+++ b/content/api/v18/assert.en.md
@@ -2,7 +2,6 @@
 title: 'assert'
 displayTitle: 'Assert'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/assert.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/async_context.en.md
+++ b/content/api/v18/async_context.en.md
@@ -2,7 +2,6 @@
 title: 'async_context'
 displayTitle: 'Asynchronous context tracking'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/async_context.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/async_hooks.en.md
+++ b/content/api/v18/async_hooks.en.md
@@ -2,7 +2,6 @@
 title: 'async_hooks'
 displayTitle: 'Async hooks'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/async_hooks.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/buffer.en.md
+++ b/content/api/v18/buffer.en.md
@@ -2,7 +2,6 @@
 title: 'buffer'
 displayTitle: 'Buffer'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/buffer.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/child_process.en.md
+++ b/content/api/v18/child_process.en.md
@@ -2,7 +2,6 @@
 title: 'child_process'
 displayTitle: 'Child process'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/child_process.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/cli.en.md
+++ b/content/api/v18/cli.en.md
@@ -2,7 +2,6 @@
 title: 'cli'
 displayTitle: 'Command-line API'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/cli.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/cluster.en.md
+++ b/content/api/v18/cluster.en.md
@@ -2,7 +2,6 @@
 title: 'cluster'
 displayTitle: 'Cluster'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/cluster.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/console.en.md
+++ b/content/api/v18/console.en.md
@@ -2,7 +2,6 @@
 title: 'console'
 displayTitle: 'Console'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/console.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/corepack.en.md
+++ b/content/api/v18/corepack.en.md
@@ -2,7 +2,6 @@
 title: 'corepack'
 displayTitle: 'Corepack'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/corepack.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/crypto.en.md
+++ b/content/api/v18/crypto.en.md
@@ -2,7 +2,6 @@
 title: 'crypto'
 displayTitle: 'Crypto'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/crypto.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/debugger.en.md
+++ b/content/api/v18/debugger.en.md
@@ -2,7 +2,6 @@
 title: 'debugger'
 displayTitle: 'Debugger'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/debugger.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/deprecations.en.md
+++ b/content/api/v18/deprecations.en.md
@@ -2,7 +2,6 @@
 title: 'deprecations'
 displayTitle: 'Deprecated APIs'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/deprecations.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/dgram.en.md
+++ b/content/api/v18/dgram.en.md
@@ -2,7 +2,6 @@
 title: 'dgram'
 displayTitle: 'UDP/datagram sockets'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/dgram.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/diagnostics_channel.en.md
+++ b/content/api/v18/diagnostics_channel.en.md
@@ -2,7 +2,6 @@
 title: 'diagnostics_channel'
 displayTitle: 'Diagnostics Channel'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/diagnostics_channel.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/dns.en.md
+++ b/content/api/v18/dns.en.md
@@ -2,7 +2,6 @@
 title: 'dns'
 displayTitle: 'DNS'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/dns.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/documentation.en.md
+++ b/content/api/v18/documentation.en.md
@@ -2,7 +2,6 @@
 title: 'documentation'
 displayTitle: 'About this documentation'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/documentation.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/domain.en.md
+++ b/content/api/v18/domain.en.md
@@ -2,7 +2,6 @@
 title: 'domain'
 displayTitle: 'Domain'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/domain.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/embedding.en.md
+++ b/content/api/v18/embedding.en.md
@@ -2,7 +2,6 @@
 title: 'embedding'
 displayTitle: 'C++ embedder API'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/embedding.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/errors.en.md
+++ b/content/api/v18/errors.en.md
@@ -2,7 +2,6 @@
 title: 'errors'
 displayTitle: 'Errors'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/errors.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/esm.en.md
+++ b/content/api/v18/esm.en.md
@@ -2,7 +2,6 @@
 title: 'esm'
 displayTitle: 'ECMAScript modules'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/esm.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/events.en.md
+++ b/content/api/v18/events.en.md
@@ -2,7 +2,6 @@
 title: 'events'
 displayTitle: 'Events'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/events.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/fs.en.md
+++ b/content/api/v18/fs.en.md
@@ -2,7 +2,6 @@
 title: 'fs'
 displayTitle: 'File system'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/fs.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/globals.en.md
+++ b/content/api/v18/globals.en.md
@@ -2,7 +2,6 @@
 title: 'globals'
 displayTitle: 'Global objects'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/globals.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/http.en.md
+++ b/content/api/v18/http.en.md
@@ -2,7 +2,6 @@
 title: 'http'
 displayTitle: 'HTTP'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/http.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/http2.en.md
+++ b/content/api/v18/http2.en.md
@@ -2,7 +2,6 @@
 title: 'http2'
 displayTitle: 'HTTP/2'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/http2.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/https.en.md
+++ b/content/api/v18/https.en.md
@@ -2,7 +2,6 @@
 title: 'https'
 displayTitle: 'HTTPS'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/https.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/inspector.en.md
+++ b/content/api/v18/inspector.en.md
@@ -2,7 +2,6 @@
 title: 'inspector'
 displayTitle: 'Inspector'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/inspector.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/intl.en.md
+++ b/content/api/v18/intl.en.md
@@ -2,7 +2,6 @@
 title: 'intl'
 displayTitle: 'Internationalization support'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/intl.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/module.en.md
+++ b/content/api/v18/module.en.md
@@ -2,7 +2,6 @@
 title: 'module'
 displayTitle: '`node:module` API'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/module.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/modules.en.md
+++ b/content/api/v18/modules.en.md
@@ -2,7 +2,6 @@
 title: 'modules'
 displayTitle: 'CommonJS modules'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/modules.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/n-api.en.md
+++ b/content/api/v18/n-api.en.md
@@ -2,7 +2,6 @@
 title: 'n-api'
 displayTitle: 'Node-API'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/n-api.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/navigation.json
+++ b/content/api/v18/navigation.json
@@ -20,24 +20,6 @@
       "name": "async_context"
     },
     {
-      "slug": "/api/v18/assert/",
-      "title": "Assert",
-      "type": "module",
-      "name": "assert"
-    },
-    {
-      "slug": "/api/v18/assert/#assertassertionerror",
-      "title": "assertAssertionError",
-      "type": "class",
-      "name": "assert"
-    },
-    {
-      "slug": "/api/v18/assert/#assertcalltracker",
-      "title": "assertCallTracker",
-      "type": "class",
-      "name": "assert"
-    },
-    {
       "slug": "/api/v18/async_hooks/",
       "title": "Async hooks",
       "type": "module",
@@ -68,6 +50,24 @@
       "name": "addons"
     },
     {
+      "slug": "/api/v18/assert/",
+      "title": "Assert",
+      "type": "module",
+      "name": "assert"
+    },
+    {
+      "slug": "/api/v18/assert/#assertassertionerror",
+      "title": "assertAssertionError",
+      "type": "class",
+      "name": "assert"
+    },
+    {
+      "slug": "/api/v18/assert/#assertcalltracker",
+      "title": "assertCallTracker",
+      "type": "class",
+      "name": "assert"
+    },
+    {
       "slug": "/api/v18/cluster/",
       "title": "Cluster",
       "type": "module",
@@ -80,12 +80,6 @@
       "name": "cluster"
     },
     {
-      "slug": "/api/v18/cli/",
-      "title": "Command-line API",
-      "type": "module",
-      "name": "cli"
-    },
-    {
       "slug": "/api/v18/child_process/",
       "title": "Child process",
       "type": "module",
@@ -96,6 +90,12 @@
       "title": "ChildProcess",
       "type": "class",
       "name": "child_process"
+    },
+    {
+      "slug": "/api/v18/cli/",
+      "title": "Command-line API",
+      "type": "module",
+      "name": "cli"
     },
     {
       "slug": "/api/v18/buffer/",
@@ -122,6 +122,12 @@
       "name": "buffer"
     },
     {
+      "slug": "/api/v18/corepack/",
+      "title": "Corepack",
+      "type": "module",
+      "name": "corepack"
+    },
+    {
       "slug": "/api/v18/console/",
       "title": "Console",
       "type": "module",
@@ -138,66 +144,6 @@
       "title": "Console",
       "type": "class",
       "name": "console"
-    },
-    {
-      "slug": "/api/v18/corepack/",
-      "title": "Corepack",
-      "type": "module",
-      "name": "corepack"
-    },
-    {
-      "slug": "/api/v18/debugger/",
-      "title": "Debugger",
-      "type": "module",
-      "name": "debugger"
-    },
-    {
-      "slug": "/api/v18/deprecations/",
-      "title": "Deprecated APIs",
-      "type": "module",
-      "name": "deprecations"
-    },
-    {
-      "slug": "/api/v18/dgram/",
-      "title": "UDPdatagram sockets",
-      "type": "module",
-      "name": "dgram"
-    },
-    {
-      "slug": "/api/v18/dgram/#dgramsocket",
-      "title": "dgramSocket",
-      "type": "class",
-      "name": "dgram"
-    },
-    {
-      "slug": "/api/v18/diagnostics_channel/",
-      "title": "Diagnostics Channel",
-      "type": "module",
-      "name": "diagnostics_channel"
-    },
-    {
-      "slug": "/api/v18/diagnostics_channel/#channel",
-      "title": "Channel",
-      "type": "class",
-      "name": "diagnostics_channel"
-    },
-    {
-      "slug": "/api/v18/dns/",
-      "title": "DNS",
-      "type": "module",
-      "name": "dns"
-    },
-    {
-      "slug": "/api/v18/dns/#dnsresolver",
-      "title": "dnsResolver",
-      "type": "class",
-      "name": "dns"
-    },
-    {
-      "slug": "/api/v18/dns/#dnspromisesresolver",
-      "title": "dnsPromisesResolver",
-      "type": "class",
-      "name": "dns"
     },
     {
       "slug": "/api/v18/crypto/",
@@ -278,16 +224,58 @@
       "name": "crypto"
     },
     {
-      "slug": "/api/v18/documentation/",
-      "title": "About this documentation",
+      "slug": "/api/v18/debugger/",
+      "title": "Debugger",
       "type": "module",
-      "name": "documentation"
+      "name": "debugger"
     },
     {
-      "slug": "/api/v18/embedding/",
-      "title": "C embedder API",
+      "slug": "/api/v18/diagnostics_channel/",
+      "title": "Diagnostics Channel",
       "type": "module",
-      "name": "embedding"
+      "name": "diagnostics_channel"
+    },
+    {
+      "slug": "/api/v18/diagnostics_channel/#channel",
+      "title": "Channel",
+      "type": "class",
+      "name": "diagnostics_channel"
+    },
+    {
+      "slug": "/api/v18/deprecations/",
+      "title": "Deprecated APIs",
+      "type": "module",
+      "name": "deprecations"
+    },
+    {
+      "slug": "/api/v18/dns/",
+      "title": "DNS",
+      "type": "module",
+      "name": "dns"
+    },
+    {
+      "slug": "/api/v18/dns/#dnsresolver",
+      "title": "dnsResolver",
+      "type": "class",
+      "name": "dns"
+    },
+    {
+      "slug": "/api/v18/dns/#dnspromisesresolver",
+      "title": "dnsPromisesResolver",
+      "type": "class",
+      "name": "dns"
+    },
+    {
+      "slug": "/api/v18/dgram/",
+      "title": "UDPdatagram sockets",
+      "type": "module",
+      "name": "dgram"
+    },
+    {
+      "slug": "/api/v18/dgram/#dgramsocket",
+      "title": "dgramSocket",
+      "type": "class",
+      "name": "dgram"
     },
     {
       "slug": "/api/v18/domain/",
@@ -300,6 +288,18 @@
       "title": "Domain",
       "type": "class",
       "name": "domain"
+    },
+    {
+      "slug": "/api/v18/documentation/",
+      "title": "About this documentation",
+      "type": "module",
+      "name": "documentation"
+    },
+    {
+      "slug": "/api/v18/embedding/",
+      "title": "C embedder API",
+      "type": "module",
+      "name": "embedding"
     },
     {
       "slug": "/api/v18/events/",
@@ -348,6 +348,60 @@
       "title": "ECMAScript modules",
       "type": "module",
       "name": "esm"
+    },
+    {
+      "slug": "/api/v18/errors/",
+      "title": "Errors",
+      "type": "module",
+      "name": "errors"
+    },
+    {
+      "slug": "/api/v18/errors/#error",
+      "title": "Error",
+      "type": "class",
+      "name": "errors"
+    },
+    {
+      "slug": "/api/v18/errors/#error",
+      "title": "Error",
+      "type": "class",
+      "name": "errors"
+    },
+    {
+      "slug": "/api/v18/errors/#assertionerror",
+      "title": "AssertionError",
+      "type": "class",
+      "name": "errors"
+    },
+    {
+      "slug": "/api/v18/errors/#rangeerror",
+      "title": "RangeError",
+      "type": "class",
+      "name": "errors"
+    },
+    {
+      "slug": "/api/v18/errors/#referenceerror",
+      "title": "ReferenceError",
+      "type": "class",
+      "name": "errors"
+    },
+    {
+      "slug": "/api/v18/errors/#syntaxerror",
+      "title": "SyntaxError",
+      "type": "class",
+      "name": "errors"
+    },
+    {
+      "slug": "/api/v18/errors/#systemerror",
+      "title": "SystemError",
+      "type": "class",
+      "name": "errors"
+    },
+    {
+      "slug": "/api/v18/errors/#typeerror",
+      "title": "TypeError",
+      "type": "class",
+      "name": "errors"
     },
     {
       "slug": "/api/v18/globals/",
@@ -686,60 +740,6 @@
       "name": "fs"
     },
     {
-      "slug": "/api/v18/errors/",
-      "title": "Errors",
-      "type": "module",
-      "name": "errors"
-    },
-    {
-      "slug": "/api/v18/errors/#error",
-      "title": "Error",
-      "type": "class",
-      "name": "errors"
-    },
-    {
-      "slug": "/api/v18/errors/#error",
-      "title": "Error",
-      "type": "class",
-      "name": "errors"
-    },
-    {
-      "slug": "/api/v18/errors/#assertionerror",
-      "title": "AssertionError",
-      "type": "class",
-      "name": "errors"
-    },
-    {
-      "slug": "/api/v18/errors/#rangeerror",
-      "title": "RangeError",
-      "type": "class",
-      "name": "errors"
-    },
-    {
-      "slug": "/api/v18/errors/#referenceerror",
-      "title": "ReferenceError",
-      "type": "class",
-      "name": "errors"
-    },
-    {
-      "slug": "/api/v18/errors/#syntaxerror",
-      "title": "SyntaxError",
-      "type": "class",
-      "name": "errors"
-    },
-    {
-      "slug": "/api/v18/errors/#systemerror",
-      "title": "SystemError",
-      "type": "class",
-      "name": "errors"
-    },
-    {
-      "slug": "/api/v18/errors/#typeerror",
-      "title": "TypeError",
-      "type": "class",
-      "name": "errors"
-    },
-    {
       "slug": "/api/v18/https/",
       "title": "HTTPS",
       "type": "module",
@@ -756,6 +756,24 @@
       "title": "httpsServer",
       "type": "class",
       "name": "https"
+    },
+    {
+      "slug": "/api/v18/intl/",
+      "title": "Internationalization support",
+      "type": "module",
+      "name": "intl"
+    },
+    {
+      "slug": "/api/v18/inspector/",
+      "title": "Inspector",
+      "type": "module",
+      "name": "inspector"
+    },
+    {
+      "slug": "/api/v18/inspector/#inspectorsession",
+      "title": "inspectorSession",
+      "type": "class",
+      "name": "inspector"
     },
     {
       "slug": "/api/v18/http/",
@@ -878,34 +896,40 @@
       "name": "module"
     },
     {
-      "slug": "/api/v18/intl/",
-      "title": "Internationalization support",
-      "type": "module",
-      "name": "intl"
-    },
-    {
-      "slug": "/api/v18/inspector/",
-      "title": "Inspector",
-      "type": "module",
-      "name": "inspector"
-    },
-    {
-      "slug": "/api/v18/inspector/#inspectorsession",
-      "title": "inspectorSession",
-      "type": "class",
-      "name": "inspector"
-    },
-    {
       "slug": "/api/v18/modules/",
       "title": "CommonJS modules",
       "type": "module",
       "name": "modules"
     },
     {
+      "slug": "/api/v18/packages/",
+      "title": "Packages",
+      "type": "module",
+      "name": "packages"
+    },
+    {
+      "slug": "/api/v18/n-api/",
+      "title": "Node-API",
+      "type": "module",
+      "name": "n-api"
+    },
+    {
       "slug": "/api/v18/os/",
       "title": "OS",
       "type": "module",
       "name": "os"
+    },
+    {
+      "slug": "/api/v18/path/",
+      "title": "Path",
+      "type": "module",
+      "name": "path"
+    },
+    {
+      "slug": "/api/v18/policy/",
+      "title": "Policies",
+      "type": "module",
+      "name": "policy"
     },
     {
       "slug": "/api/v18/net/",
@@ -936,24 +960,6 @@
       "title": "netSocket",
       "type": "class",
       "name": "net"
-    },
-    {
-      "slug": "/api/v18/n-api/",
-      "title": "Node-API",
-      "type": "module",
-      "name": "n-api"
-    },
-    {
-      "slug": "/api/v18/packages/",
-      "title": "Packages",
-      "type": "module",
-      "name": "packages"
-    },
-    {
-      "slug": "/api/v18/policy/",
-      "title": "Policies",
-      "type": "module",
-      "name": "policy"
     },
     {
       "slug": "/api/v18/perf_hooks/",
@@ -1022,10 +1028,22 @@
       "name": "punycode"
     },
     {
-      "slug": "/api/v18/querystring/",
-      "title": "Query string",
+      "slug": "/api/v18/string_decoder/",
+      "title": "String decoder",
       "type": "module",
-      "name": "querystring"
+      "name": "string_decoder"
+    },
+    {
+      "slug": "/api/v18/string_decoder/#stringdecoder",
+      "title": "StringDecoder",
+      "type": "class",
+      "name": "string_decoder"
+    },
+    {
+      "slug": "/api/v18/report/",
+      "title": "Diagnostic report",
+      "type": "module",
+      "name": "report"
     },
     {
       "slug": "/api/v18/readline/",
@@ -1058,10 +1076,10 @@
       "name": "readline"
     },
     {
-      "slug": "/api/v18/report/",
-      "title": "Diagnostic report",
+      "slug": "/api/v18/querystring/",
+      "title": "Query string",
       "type": "module",
-      "name": "report"
+      "name": "querystring"
     },
     {
       "slug": "/api/v18/repl/",
@@ -1074,12 +1092,6 @@
       "title": "REPLServer",
       "type": "class",
       "name": "repl"
-    },
-    {
-      "slug": "/api/v18/path/",
-      "title": "Path",
-      "type": "module",
-      "name": "path"
     },
     {
       "slug": "/api/v18/stream/",
@@ -1142,18 +1154,6 @@
       "name": "stream"
     },
     {
-      "slug": "/api/v18/string_decoder/",
-      "title": "String decoder",
-      "type": "module",
-      "name": "string_decoder"
-    },
-    {
-      "slug": "/api/v18/string_decoder/#stringdecoder",
-      "title": "StringDecoder",
-      "type": "class",
-      "name": "string_decoder"
-    },
-    {
       "slug": "/api/v18/synopsis/",
       "title": "Usage and example",
       "type": "module",
@@ -1202,6 +1202,30 @@
       "name": "timers"
     },
     {
+      "slug": "/api/v18/tracing/",
+      "title": "Trace events",
+      "type": "module",
+      "name": "tracing"
+    },
+    {
+      "slug": "/api/v18/tty/",
+      "title": "TTY",
+      "type": "module",
+      "name": "tty"
+    },
+    {
+      "slug": "/api/v18/tty/#ttyreadstream",
+      "title": "ttyReadStream",
+      "type": "class",
+      "name": "tty"
+    },
+    {
+      "slug": "/api/v18/tty/#ttywritestream",
+      "title": "ttyWriteStream",
+      "type": "class",
+      "name": "tty"
+    },
+    {
       "slug": "/api/v18/tls/",
       "title": "TLS ",
       "type": "module",
@@ -1232,30 +1256,6 @@
       "name": "tls"
     },
     {
-      "slug": "/api/v18/tty/",
-      "title": "TTY",
-      "type": "module",
-      "name": "tty"
-    },
-    {
-      "slug": "/api/v18/tty/#ttyreadstream",
-      "title": "ttyReadStream",
-      "type": "class",
-      "name": "tty"
-    },
-    {
-      "slug": "/api/v18/tty/#ttywritestream",
-      "title": "ttyWriteStream",
-      "type": "class",
-      "name": "tty"
-    },
-    {
-      "slug": "/api/v18/tracing/",
-      "title": "Trace events",
-      "type": "module",
-      "name": "tracing"
-    },
-    {
       "slug": "/api/v18/url/",
       "title": "URL",
       "type": "module",
@@ -1274,36 +1274,6 @@
       "name": "url"
     },
     {
-      "slug": "/api/v18/v8/",
-      "title": "V8",
-      "type": "module",
-      "name": "v8"
-    },
-    {
-      "slug": "/api/v18/v8/#v8serializer",
-      "title": "v8Serializer",
-      "type": "class",
-      "name": "v8"
-    },
-    {
-      "slug": "/api/v18/v8/#v8deserializer",
-      "title": "v8Deserializer",
-      "type": "class",
-      "name": "v8"
-    },
-    {
-      "slug": "/api/v18/v8/#v8defaultserializer",
-      "title": "v8DefaultSerializer",
-      "type": "class",
-      "name": "v8"
-    },
-    {
-      "slug": "/api/v18/v8/#v8defaultdeserializer",
-      "title": "v8DefaultDeserializer",
-      "type": "class",
-      "name": "v8"
-    },
-    {
       "slug": "/api/v18/util/",
       "title": "Util",
       "type": "module",
@@ -1320,6 +1290,18 @@
       "title": "utilTextEncoder",
       "type": "class",
       "name": "util"
+    },
+    {
+      "slug": "/api/v18/wasi/",
+      "title": "WebAssembly System Interface ",
+      "type": "module",
+      "name": "wasi"
+    },
+    {
+      "slug": "/api/v18/wasi/#wasi",
+      "title": "WASI",
+      "type": "class",
+      "name": "wasi"
     },
     {
       "slug": "/api/v18/vm/",
@@ -1352,16 +1334,34 @@
       "name": "vm"
     },
     {
-      "slug": "/api/v18/wasi/",
-      "title": "WebAssembly System Interface ",
+      "slug": "/api/v18/v8/",
+      "title": "V8",
       "type": "module",
-      "name": "wasi"
+      "name": "v8"
     },
     {
-      "slug": "/api/v18/wasi/#wasi",
-      "title": "WASI",
+      "slug": "/api/v18/v8/#v8serializer",
+      "title": "v8Serializer",
       "type": "class",
-      "name": "wasi"
+      "name": "v8"
+    },
+    {
+      "slug": "/api/v18/v8/#v8deserializer",
+      "title": "v8Deserializer",
+      "type": "class",
+      "name": "v8"
+    },
+    {
+      "slug": "/api/v18/v8/#v8defaultserializer",
+      "title": "v8DefaultSerializer",
+      "type": "class",
+      "name": "v8"
+    },
+    {
+      "slug": "/api/v18/v8/#v8defaultdeserializer",
+      "title": "v8DefaultDeserializer",
+      "type": "class",
+      "name": "v8"
     },
     {
       "slug": "/api/v18/webcrypto/",
@@ -1502,36 +1502,6 @@
       "name": "webcrypto"
     },
     {
-      "slug": "/api/v18/worker_threads/",
-      "title": "Worker threads",
-      "type": "module",
-      "name": "worker_threads"
-    },
-    {
-      "slug": "/api/v18/worker_threads/#broadcastchannel-extends-eventtarget",
-      "title": "BroadcastChannel extends EventTarget",
-      "type": "class",
-      "name": "worker_threads"
-    },
-    {
-      "slug": "/api/v18/worker_threads/#messagechannel",
-      "title": "MessageChannel",
-      "type": "class",
-      "name": "worker_threads"
-    },
-    {
-      "slug": "/api/v18/worker_threads/#messageport",
-      "title": "MessagePort",
-      "type": "class",
-      "name": "worker_threads"
-    },
-    {
-      "slug": "/api/v18/worker_threads/#worker",
-      "title": "Worker",
-      "type": "class",
-      "name": "worker_threads"
-    },
-    {
       "slug": "/api/v18/webstreams/",
       "title": "Web Streams API",
       "type": "module",
@@ -1638,6 +1608,36 @@
       "title": "DecompressionStream",
       "type": "class",
       "name": "webstreams"
+    },
+    {
+      "slug": "/api/v18/worker_threads/",
+      "title": "Worker threads",
+      "type": "module",
+      "name": "worker_threads"
+    },
+    {
+      "slug": "/api/v18/worker_threads/#broadcastchannel-extends-eventtarget",
+      "title": "BroadcastChannel extends EventTarget",
+      "type": "class",
+      "name": "worker_threads"
+    },
+    {
+      "slug": "/api/v18/worker_threads/#messagechannel",
+      "title": "MessageChannel",
+      "type": "class",
+      "name": "worker_threads"
+    },
+    {
+      "slug": "/api/v18/worker_threads/#messageport",
+      "title": "MessagePort",
+      "type": "class",
+      "name": "worker_threads"
+    },
+    {
+      "slug": "/api/v18/worker_threads/#worker",
+      "title": "Worker",
+      "type": "class",
+      "name": "worker_threads"
     },
     {
       "slug": "/api/v18/zlib/",

--- a/content/api/v18/net.en.md
+++ b/content/api/v18/net.en.md
@@ -2,7 +2,6 @@
 title: 'net'
 displayTitle: 'Net'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/net.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/os.en.md
+++ b/content/api/v18/os.en.md
@@ -2,7 +2,6 @@
 title: 'os'
 displayTitle: 'OS'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/os.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/packages.en.md
+++ b/content/api/v18/packages.en.md
@@ -2,7 +2,6 @@
 title: 'packages'
 displayTitle: 'Packages'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/packages.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/path.en.md
+++ b/content/api/v18/path.en.md
@@ -2,7 +2,6 @@
 title: 'path'
 displayTitle: 'Path'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/path.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/perf_hooks.en.md
+++ b/content/api/v18/perf_hooks.en.md
@@ -2,7 +2,6 @@
 title: 'perf_hooks'
 displayTitle: 'Performance measurement APIs'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/perf_hooks.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/policy.en.md
+++ b/content/api/v18/policy.en.md
@@ -2,7 +2,6 @@
 title: 'policy'
 displayTitle: 'Policies'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/policy.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/process.en.md
+++ b/content/api/v18/process.en.md
@@ -2,7 +2,6 @@
 title: 'process'
 displayTitle: 'Process'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/process.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/punycode.en.md
+++ b/content/api/v18/punycode.en.md
@@ -2,7 +2,6 @@
 title: 'punycode'
 displayTitle: 'Punycode'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/punycode.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/querystring.en.md
+++ b/content/api/v18/querystring.en.md
@@ -2,7 +2,6 @@
 title: 'querystring'
 displayTitle: 'Query string'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/querystring.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/readline.en.md
+++ b/content/api/v18/readline.en.md
@@ -2,7 +2,6 @@
 title: 'readline'
 displayTitle: 'Readline'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/readline.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/repl.en.md
+++ b/content/api/v18/repl.en.md
@@ -2,7 +2,6 @@
 title: 'repl'
 displayTitle: 'REPL'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/repl.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/report.en.md
+++ b/content/api/v18/report.en.md
@@ -2,7 +2,6 @@
 title: 'report'
 displayTitle: 'Diagnostic report'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/report.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/stream.en.md
+++ b/content/api/v18/stream.en.md
@@ -2,7 +2,6 @@
 title: 'stream'
 displayTitle: 'Stream'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/stream.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/string_decoder.en.md
+++ b/content/api/v18/string_decoder.en.md
@@ -2,7 +2,6 @@
 title: 'string_decoder'
 displayTitle: 'String decoder'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/string_decoder.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/synopsis.en.md
+++ b/content/api/v18/synopsis.en.md
@@ -2,7 +2,6 @@
 title: 'synopsis'
 displayTitle: 'Usage and example'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/synopsis.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/test.en.md
+++ b/content/api/v18/test.en.md
@@ -2,7 +2,6 @@
 title: 'test'
 displayTitle: 'Test runner'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/test.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/timers.en.md
+++ b/content/api/v18/timers.en.md
@@ -2,7 +2,6 @@
 title: 'timers'
 displayTitle: 'Timers'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/timers.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/tls.en.md
+++ b/content/api/v18/tls.en.md
@@ -2,7 +2,6 @@
 title: 'tls'
 displayTitle: 'TLS (SSL)'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/tls.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/tracing.en.md
+++ b/content/api/v18/tracing.en.md
@@ -2,7 +2,6 @@
 title: 'tracing'
 displayTitle: 'Trace events'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/tracing.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/tty.en.md
+++ b/content/api/v18/tty.en.md
@@ -2,7 +2,6 @@
 title: 'tty'
 displayTitle: 'TTY'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/tty.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/url.en.md
+++ b/content/api/v18/url.en.md
@@ -2,7 +2,6 @@
 title: 'url'
 displayTitle: 'URL'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/url.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/util.en.md
+++ b/content/api/v18/util.en.md
@@ -2,7 +2,6 @@
 title: 'util'
 displayTitle: 'Util'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/util.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/v8.en.md
+++ b/content/api/v18/v8.en.md
@@ -2,7 +2,6 @@
 title: 'v8'
 displayTitle: 'V8'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/v8.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/vm.en.md
+++ b/content/api/v18/vm.en.md
@@ -2,7 +2,6 @@
 title: 'vm'
 displayTitle: 'VM (executing JavaScript)'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/vm.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/wasi.en.md
+++ b/content/api/v18/wasi.en.md
@@ -2,7 +2,6 @@
 title: 'wasi'
 displayTitle: 'WebAssembly System Interface (WASI)'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/wasi.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/webcrypto.en.md
+++ b/content/api/v18/webcrypto.en.md
@@ -2,7 +2,6 @@
 title: 'webcrypto'
 displayTitle: 'Web Crypto API'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/webcrypto.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/webstreams.en.md
+++ b/content/api/v18/webstreams.en.md
@@ -2,7 +2,6 @@
 title: 'webstreams'
 displayTitle: 'Web Streams API'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/webstreams.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/worker_threads.en.md
+++ b/content/api/v18/worker_threads.en.md
@@ -2,7 +2,6 @@
 title: 'worker_threads'
 displayTitle: 'Worker threads'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/worker_threads.md'
 version: 'v18'
 ---
 

--- a/content/api/v18/zlib.en.md
+++ b/content/api/v18/zlib.en.md
@@ -2,7 +2,6 @@
 title: 'zlib'
 displayTitle: 'Zlib'
 category: 'api'
-editPage: 'https://github.com/nodejs/node/blob/v18.9.0/doc/api/zlib.md'
 version: 'v18'
 ---
 

--- a/src/templates/api.tsx
+++ b/src/templates/api.tsx
@@ -26,7 +26,7 @@ const components = {
 const Api = ({
   data: {
     mdx: {
-      frontmatter: { title, displayTitle, editPage, version },
+      frontmatter: { title, displayTitle, version },
       body,
       tableOfContents,
     },
@@ -61,7 +61,7 @@ const Api = ({
         body={body}
         next={next}
         previous={previous}
-        absolutePath={editPage}
+        absolutePath={`https://github.com/nodejs/node/edit/main/doc/api/${title}.md`}
         authors={[]}
         extraComponents={components}
         childrenPosition="before"
@@ -82,7 +82,6 @@ export const query = graphql`
       frontmatter {
         title
         displayTitle
-        editPage
         version
       }
       fields {

--- a/src/types/pages/api.ts
+++ b/src/types/pages/api.ts
@@ -11,7 +11,6 @@ export interface ApiTemplateData {
       title: string;
       version: string;
       displayTitle: string;
-      editPage: string;
     };
   };
 }

--- a/util-node/apiDocsTransformUtils.js
+++ b/util-node/apiDocsTransformUtils.js
@@ -102,10 +102,8 @@ function createNavigationCreator({ version, name }) {
 
 // This utility creates the Frontmatter of the Documentation page
 // It uses the metadata to create a YAML that will be inserted at the top of the page
-function createApiDocsFrontmatter(firstLine, { version, name, fullVersion }) {
+function createApiDocsFrontmatter(firstLine, { version, name }) {
   if (firstLine.startsWith('#')) {
-    const editPageLink = `https://github.com/nodejs/node/blob/${fullVersion}/doc/api/${name}.md`;
-
     // Does some special treatment to the pageTitle
     const pageTitle = parseHeading(firstLine.replace(/^# /, ''));
 
@@ -113,7 +111,6 @@ function createApiDocsFrontmatter(firstLine, { version, name, fullVersion }) {
       title: name,
       displayTitle: pageTitle,
       category: 'api',
-      editPage: editPageLink,
       version,
     };
 


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Calculate the "Edit on GitHub" link for the API pages during build, so they don't cause diff noise when embbed in the Markdown files.
This swaps the `blob/VERSION` part of the URL for `/edit/main/` to bring the user to the GitHub edit page for the file

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `npm run lint:js -- --fix` and/or `npm run lint:md -- --fix` for my JavaScript and/or Markdown changes.
  - This is important as most of the cases your code changes might not be correctly linted
- [ ] I have run `npm run test` to check if all tests are passing, and/or `npm run test -- -u` to update snapshots if I created and/or updated React Components.
- [ ] I have checked that the build works locally and that `npm run build` work fine.
- [ ] I've covered new added functionality with unit tests if necessary.
