### PR TITLE
chore: explicit dependency gatsbyjs/reach-router

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.1.2",
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@gatsby-contrib/gatsby-plugin-elasticlunr-search": "^3.0.2",
+        "@gatsbyjs/reach-router": "^1.3.9",
         "@mdx-js/mdx": "^1.6.22",
         "@mdx-js/react": "^1.6.22",
         "@mui/icons-material": "^5.10.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.1.2",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@gatsby-contrib/gatsby-plugin-elasticlunr-search": "^3.0.2",
+    "@gatsbyjs/reach-router": "^1.3.9",
     "@mdx-js/mdx": "^1.6.22",
     "@mdx-js/react": "^1.6.22",
     "@mui/icons-material": "^5.10.2",


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Running `npm test` locally, ESLint is giving an error for the import without an explicit dependency

```

Z:\nodejs.dev\src\components\Seo\index.tsx
  3:1  error  '@gatsbyjs/reach-router' should be listed in the project's dependencies. Run 'npm i -S @gatsbyjs/reach-router' to add it  import/no-extraneous-dependencies

Z:\nodejs.dev\src\hooks\useNavigateToDifferentLocale.ts
  2:1  error  '@gatsbyjs/reach-router' should be listed in the project's dependencies. Run 'npm i -S @gatsbyjs/reach-router' to add it  import/no-extraneous-dependencies

✖ 2 problems (2 errors, 0 warnings)
```

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [ ] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `npm run lint:js -- --fix` and/or `npm run lint:md -- --fix` for my JavaScript and/or Markdown changes.
  - This is important as most of the cases your code changes might not be correctly linted
- [ ] I have run `npm run test` to check if all tests are passing, and/or `npm run test -- -u` to update snapshots if I created and/or updated React Components.
- [ ] I have checked that the build works locally and that `npm run build` work fine.
- [ ] I've covered new added functionality with unit tests if necessary.
