### PR TITLE
chore(commcomm): removed commcomm mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,6 @@ participated in that process.
 
 ## 🔗 Links
 
-[Community Committee][]
-
 [Code of Conduct][]
 
 [Contributing Guidelines][]


### PR DESCRIPTION
This PR simply removes the orphan "Community Commitee" mention.