### PR TITLE
refactor(util): change appVersion property to platform

### DIFF
--- a/src/util/__tests__/detectOS.test.ts
+++ b/src/util/__tests__/detectOS.test.ts
@@ -5,42 +5,42 @@ describe('Detect the user OS function', () => {
     expect(detectOS).toBeDefined();
   });
   it('should detect Windows', () => {
-    Object.defineProperty(window.navigator, 'appVersion', {
+    Object.defineProperty(window.navigator, 'platform', {
       writable: true,
       value: 'Windows',
     });
     expect(detectOS()).toBe('WIN');
   });
   it('should detect Mac', () => {
-    Object.defineProperty(window.navigator, 'appVersion', {
+    Object.defineProperty(window.navigator, 'platform', {
       writable: true,
       value: 'Mac',
     });
     expect(detectOS()).toBe('MAC');
   });
   it('should detect Unix', () => {
-    Object.defineProperty(window.navigator, 'appVersion', {
+    Object.defineProperty(window.navigator, 'platform', {
       writable: true,
       value: 'X11',
     });
     expect(detectOS()).toBe('UNIX');
   });
   it('should detect Linux', () => {
-    Object.defineProperty(window.navigator, 'appVersion', {
+    Object.defineProperty(window.navigator, 'platform', {
       writable: true,
       value: 'Linux',
     });
     expect(detectOS()).toBe('LINUX');
   });
   it('should detect Mobile', () => {
-    Object.defineProperty(window.navigator, 'appVersion', {
+    Object.defineProperty(window.navigator, 'platform', {
       writable: true,
       value: 'Mobi',
     });
     expect(detectOS()).toBe('MOBILE');
   });
   it('should detect others as unknown', () => {
-    Object.defineProperty(window.navigator, 'appVersion', {
+    Object.defineProperty(window.navigator, 'platform', {
       writable: true,
       value: 'mock',
     });

--- a/src/util/detectOS.ts
+++ b/src/util/detectOS.ts
@@ -12,19 +12,19 @@ export function detectOS(): UserOS {
   let OS = UserOS.UNKNOWN;
   if (typeof window !== 'undefined') {
     switch (typeof navigator !== 'undefined') {
-      case navigator.appVersion.includes('Win'):
+      case navigator.platform.includes('Win'):
         OS = UserOS.WIN;
         break;
-      case navigator.appVersion.includes('Mac'):
+      case navigator.platform.includes('Mac'):
         OS = UserOS.MAC;
         break;
-      case navigator.appVersion.includes('X11'):
+      case navigator.platform.includes('X11'):
         OS = UserOS.UNIX;
         break;
-      case navigator.appVersion.includes('Linux'):
+      case navigator.platform.includes('Linux'):
         OS = UserOS.LINUX;
         break;
-      case navigator.appVersion.includes('Mobi'):
+      case navigator.platform.includes('Mobi'):
         OS = UserOS.MOBILE;
         break;
       default:


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
navigator.appVersion is deprecated in typescript, so changed to navigator.platform.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run lint:js -- --fix` and/or `npm run lint:md -- --fix` for my JavaScript and/or Markdown changes.
  - This is important as most of the cases your code changes might not be correctly linted
- [x] I have run `npm run test` to check if all tests are passing, and/or `npm run test -- -u` to update snapshots if I created and/or updated React Components.
- [x] I have checked that the build works locally and that `npm run build` work fine.
- [x] I've covered new added functionality with unit tests if necessary.
