### PR TITLE
test(util): add test for parseApiDocsVersion in util

### DIFF
--- a/src/util/__tests__/parseApiDocsVersion.test.ts
+++ b/src/util/__tests__/parseApiDocsVersion.test.ts
@@ -1,0 +1,19 @@
+import { parseApiDocsVersion } from '../parseApiDocsVersion';
+
+describe('parseApiDocsVersion', (): void => {
+  it('should be defined', (): void => {
+    expect(parseApiDocsVersion).toBeDefined();
+  });
+
+  it(`should return the version when passing string`, (): void => {
+    const stringVersion = '1.0';
+    expect(parseApiDocsVersion(stringVersion)).toEqual(stringVersion);
+  });
+
+  it(`should return joined version with comma when passing array`, (): void => {
+    const arrayVersion = ['1.0', '1.1', '2.4'];
+    const expectedJoinedArray = '1.0, 1.1, 2.4';
+
+    expect(parseApiDocsVersion(arrayVersion)).toEqual(expectedJoinedArray);
+  });
+});


### PR DESCRIPTION
## Description
Added unit tests for parseApiDocsVersion function in util.
directory :- /src/util/test/

Add total of 3 new unit tests.

## Related Issues

Related to #2744 

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run lint:js -- --fix` and/or `npm run lint:md -- --fix` for my JavaScript and/or Markdown changes.
  - This is important as most of the cases your code changes might not be correctly linted
- [x] I have run `npm run test` to check if all tests are passing, and/or `npm run test -- -u` to update snapshots if I created and/or updated React Components.
- [x] I have checked that the build works locally and that `npm run build` work fine.
- [x] I've covered new added functionality with unit tests if necessary.
