### PR TITLE
feat(useSetBodyOverflow): set body overflow css hook

### DIFF
--- a/src/components/SideNavBar/index.tsx
+++ b/src/components/SideNavBar/index.tsx
@@ -1,10 +1,11 @@
-import React, { useRef, useState, useMemo, useEffect } from 'react';
+import React, { useRef, useState, useMemo } from 'react';
 import { LocalizedLink as Link } from 'gatsby-theme-i18n';
 import { FormattedMessage, useIntl } from 'react-intl';
 import GroupsIcon from '@mui/icons-material/Groups';
 import InfoIcon from '@mui/icons-material/Info';
 import CloudDownloadIcon from '@mui/icons-material/CloudDownload';
 import classnames from 'classnames';
+import { useSetBodyOverflow } from '../../hooks/useSetBodyOverflow';
 import { SideNavBarItem } from '../../types';
 import NavigationItem from '../NavigationItem';
 import styles from './index.module.scss';
@@ -112,13 +113,7 @@ const SideNavBar = ({ pageKey, items = sideNavBarItems }: NavBarProps) => {
     [styles.sideNavFixed]: navOpen,
   });
 
-  useEffect(() => {
-    if (typeof document === 'object' && document.body) {
-      document.body.style.overflow = navOpen
-        ? OverflowTypes.hidden
-        : OverflowTypes.unset;
-    }
-  }, [navOpen]);
+  useSetBodyOverflow(navOpen ? OverflowTypes.hidden : OverflowTypes.unset);
 
   const navElement = useRef<HTMLElement | null>(null);
 

--- a/src/hooks/useSetBodyOverflow.ts
+++ b/src/hooks/useSetBodyOverflow.ts
@@ -1,0 +1,9 @@
+import { useEffect } from 'react';
+
+export function useSetBodyOverflow(overflow: 'unset' | 'hidden') {
+  useEffect(() => {
+    if (typeof document === 'object' && document.body) {
+      document.body.style.overflow = overflow;
+    }
+  }, [overflow]);
+}


### PR DESCRIPTION
## Description

Introduced a react hook to set document body's overflow css.

## Related Issues

#2674

### Check List

- [X] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [X] I have run `npm run lint:js -- --fix` and/or `npm run lint:md -- --fix` for my JavaScript and/or Markdown changes.
  - This is important as most of the cases your code changes might not be correctly linted
- [X] I have run `npm run test` to check if all tests are passing, and/or `npm run test -- -u` to update snapshots if I created and/or updated React Components.
- [X] I have checked that the build works locally and that `npm run build` work fine.
- [X] I've covered new added functionality with unit tests if necessary.
