### PR TITLE
fix: add aria-pressed to dark mode toggle

### DIFF
--- a/src/components/DarkModeToggle/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/components/DarkModeToggle/__tests__/__snapshots__/index.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`DarkModeToggle Component render dark mode toggle 1`] = `
 <div>
   <button
+    aria-pressed="false"
     class="darkModeToggle"
     type="button"
   >

--- a/src/components/DarkModeToggle/index.tsx
+++ b/src/components/DarkModeToggle/index.tsx
@@ -26,6 +26,7 @@ const DarkModeToggle = () => {
       className={styles.darkModeToggle}
       onClick={() => handleThemeOnClick()}
       onKeyPress={() => handleThemeOnClick(true)}
+      aria-pressed={theme === 'dark'}
     >
       <span className="sr-only">Toggle Dark Mode</span>
       <ModeNightIcon className="light-mode-only" />

--- a/src/components/Header/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/components/Header/__tests__/__snapshots__/index.test.tsx.snap
@@ -120,6 +120,7 @@ exports[`Tests for Header component Theme color switcher skips rendering in case
           </li>
           <li>
             <button
+              aria-pressed="true"
               class="darkModeToggle"
               type="button"
             >
@@ -309,6 +310,7 @@ exports[`Tests for Header component renders correctly 1`] = `
           </li>
           <li>
             <button
+              aria-pressed="true"
               class="darkModeToggle"
               type="button"
             >
@@ -498,6 +500,7 @@ exports[`Tests for Header component renders shorter menu items for mobile 1`] = 
           </li>
           <li>
             <button
+              aria-pressed="true"
               class="darkModeToggle"
               type="button"
             >

--- a/src/components/Layout/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/components/Layout/__tests__/__snapshots__/index.test.tsx.snap
@@ -123,6 +123,7 @@ exports[`Layout component renders correctly with data 1`] = `
             </li>
             <li>
               <button
+                aria-pressed="false"
                 class="darkModeToggle"
                 type="button"
               >

--- a/src/components/Layout/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/components/Layout/__tests__/__snapshots__/page.test.tsx.snap
@@ -123,6 +123,7 @@ exports[`PageLayout component renders correctly with data 1`] = `
             </li>
             <li>
               <button
+                aria-pressed="false"
                 class="darkModeToggle"
                 type="button"
               >

--- a/src/pages/about/__tests__/__snapshots__/resources.test.tsx.snap
+++ b/src/pages/about/__tests__/__snapshots__/resources.test.tsx.snap
@@ -123,6 +123,7 @@ exports[`Resources page renders correctly 1`] = `
             </li>
             <li>
               <button
+                aria-pressed="false"
                 class="darkModeToggle"
                 type="button"
               >

--- a/src/pages/download/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/pages/download/__tests__/__snapshots__/index.test.tsx.snap
@@ -123,6 +123,7 @@ exports[`Download page renders correctly 1`] = `
             </li>
             <li>
               <button
+                aria-pressed="false"
                 class="darkModeToggle"
                 type="button"
               >
@@ -1064,6 +1065,7 @@ exports[`Download page should handle LTS to Current switch 1`] = `
             </li>
             <li>
               <button
+                aria-pressed="false"
                 class="darkModeToggle"
                 type="button"
               >

--- a/src/pages/download/__tests__/__snapshots__/package-manager.test.tsx.snap
+++ b/src/pages/download/__tests__/__snapshots__/package-manager.test.tsx.snap
@@ -123,6 +123,7 @@ exports[`Package Manager Page renders correctly 1`] = `
             </li>
             <li>
               <button
+                aria-pressed="false"
                 class="darkModeToggle"
                 type="button"
               >

--- a/src/templates/__tests__/__snapshots__/learn.test.tsx.snap
+++ b/src/templates/__tests__/__snapshots__/learn.test.tsx.snap
@@ -123,6 +123,7 @@ exports[`Learn Template renders correctly 1`] = `
             </li>
             <li>
               <button
+                aria-pressed="false"
                 class="darkModeToggle"
                 type="button"
               >

--- a/src/templates/__tests__/__snapshots__/post.test.tsx.snap
+++ b/src/templates/__tests__/__snapshots__/post.test.tsx.snap
@@ -123,6 +123,7 @@ exports[`LearnLayout Template renders correctly 1`] = `
             </li>
             <li>
               <button
+                aria-pressed="false"
                 class="darkModeToggle"
                 type="button"
               >


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Just a small change but now the dark mode toggle reads out the state of the button (pressed when dark mode is activated and not-pressed when lightmode is activated) for better feedback for screen reader users.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run lint:js -- --fix` and/or `npm run lint:md -- --fix` for my JavaScript and/or Markdown changes.
  - This is important as most of the cases your code changes might not be correctly linted
- [x] I have run `npm run test` to check if all tests are passing, and/or `npm run test -- -u` to update snapshots if I created and/or updated React Components.
- [ ] I have checked that the build works locally and that `npm run build` work fine.
- [ ] I've covered new added functionality with unit tests if necessary.
