### PR TITLE
fix: contributors list screen reader announcement

### DIFF
--- a/src/components/Article/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/components/Article/__tests__/__snapshots__/index.test.tsx.snap
@@ -90,29 +90,29 @@ exports[`Article component renders correctly 1`] = `
       <ul>
         <li>
           <a
+            aria-label="test-user1 Github - opens in new tab"
             class="link"
             href="https://github.com/test-user1"
             rel="noopener noreferrer"
             style="margin-left: 0px;"
             target="_blank"
-            title="test-user1"
           >
             <img
-              alt="test-user1"
+              alt=""
               src="https://github.com/test-user1.png?size=60"
             />
           </a>
         </li>
         <li>
           <a
+            aria-label="test-user2 Github - opens in new tab"
             class="link"
             href="https://github.com/test-user2"
             rel="noopener noreferrer"
             target="_blank"
-            title="test-user2"
           >
             <img
-              alt="test-user2"
+              alt=""
               src="https://github.com/test-user2.png?size=60"
             />
           </a>
@@ -363,29 +363,29 @@ exports[`Article component renders correctly in case body ref is null 1`] = `
       <ul>
         <li>
           <a
+            aria-label="test-user1 Github - opens in new tab"
             class="link"
             href="https://github.com/test-user1"
             rel="noopener noreferrer"
             style="margin-left: 0px;"
             target="_blank"
-            title="test-user1"
           >
             <img
-              alt="test-user1"
+              alt=""
               src="https://github.com/test-user1.png?size=60"
             />
           </a>
         </li>
         <li>
           <a
+            aria-label="test-user2 Github - opens in new tab"
             class="link"
             href="https://github.com/test-user2"
             rel="noopener noreferrer"
             target="_blank"
-            title="test-user2"
           >
             <img
-              alt="test-user2"
+              alt=""
               src="https://github.com/test-user2.png?size=60"
             />
           </a>
@@ -569,29 +569,29 @@ exports[`Article component should accept and render child components 1`] = `
       <ul>
         <li>
           <a
+            aria-label="test-user1 Github - opens in new tab"
             class="link"
             href="https://github.com/test-user1"
             rel="noopener noreferrer"
             style="margin-left: 0px;"
             target="_blank"
-            title="test-user1"
           >
             <img
-              alt="test-user1"
+              alt=""
               src="https://github.com/test-user1.png?size=60"
             />
           </a>
         </li>
         <li>
           <a
+            aria-label="test-user2 Github - opens in new tab"
             class="link"
             href="https://github.com/test-user2"
             rel="noopener noreferrer"
             target="_blank"
-            title="test-user2"
           >
             <img
-              alt="test-user2"
+              alt=""
               src="https://github.com/test-user2.png?size=60"
             />
           </a>

--- a/src/components/Author/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/components/Author/__tests__/__snapshots__/index.test.tsx.snap
@@ -6,14 +6,14 @@ exports[`Author component renders correctly 1`] = `
 <div>
   <li>
     <a
+      aria-label="test-author Github - opens in new tab"
       class="link"
       href="https://github.com/test-author"
       rel="noopener noreferrer"
       target="_blank"
-      title="test-author"
     >
       <img
-        alt="test-author"
+        alt=""
         src="https://github.com/test-author.png?size=60"
       />
     </a>

--- a/src/components/Author/index.tsx
+++ b/src/components/Author/index.tsx
@@ -26,13 +26,13 @@ const Author = ({
         <a
           className={styles.link}
           href={githubLink}
-          title={username}
+          aria-label={`${username} Github - opens in new tab`}
           key={username}
           target="_blank"
           rel="noopener noreferrer"
           style={mleft}
         >
-          <img src={githubImgLink} alt={username} />
+          <img src={githubImgLink} alt="" />
         </a>
       </li>
     );

--- a/src/components/Layout/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/components/Layout/__tests__/__snapshots__/page.test.tsx.snap
@@ -280,15 +280,15 @@ exports[`PageLayout component renders correctly with data 1`] = `
           <ul>
             <li>
               <a
+                aria-label="mock-author Github - opens in new tab"
                 class="link"
                 href="https://github.com/mock-author"
                 rel="noopener noreferrer"
                 style="margin-left: 0px;"
                 target="_blank"
-                title="mock-author"
               >
                 <img
-                  alt="mock-author"
+                  alt=""
                   src="https://github.com/mock-author.png?size=60"
                 />
               </a>

--- a/src/containers/AuthorList/__tests__/__snapshots__/authors-list.test.tsx.snap
+++ b/src/containers/AuthorList/__tests__/__snapshots__/authors-list.test.tsx.snap
@@ -9,29 +9,29 @@ exports[`AuthorsList component renders correctly 1`] = `
     <ul>
       <li>
         <a
+          aria-label="test-author Github - opens in new tab"
           class="link"
           href="https://github.com/test-author"
           rel="noopener noreferrer"
           style="margin-left: 0px;"
           target="_blank"
-          title="test-author"
         >
           <img
-            alt="test-author"
+            alt=""
             src="https://github.com/test-author.png?size=60"
           />
         </a>
       </li>
       <li>
         <a
+          aria-label="another-test-author Github - opens in new tab"
           class="link"
           href="https://github.com/another-test-author"
           rel="noopener noreferrer"
           target="_blank"
-          title="another-test-author"
         >
           <img
-            alt="another-test-author"
+            alt=""
             src="https://github.com/another-test-author.png?size=60"
           />
         </a>

--- a/src/pages/about/__tests__/__snapshots__/governance.test.tsx.snap
+++ b/src/pages/about/__tests__/__snapshots__/governance.test.tsx.snap
@@ -224,15 +224,15 @@ exports[`Governance Page renders correctly 1`] = `
       <ul>
         <li>
           <a
+            aria-label="author-mock Github - opens in new tab"
             class="link"
             href="https://github.com/author-mock"
             rel="noopener noreferrer"
             style="margin-left: 0px;"
             target="_blank"
-            title="author-mock"
           >
             <img
-              alt="author-mock"
+              alt=""
               src="https://github.com/author-mock.png?size=60"
             />
           </a>

--- a/src/pages/about/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/pages/about/__tests__/__snapshots__/index.test.tsx.snap
@@ -223,15 +223,15 @@ exports[`About page renders correctly 1`] = `
       <ul>
         <li>
           <a
+            aria-label="author-mock Github - opens in new tab"
             class="link"
             href="https://github.com/author-mock"
             rel="noopener noreferrer"
             style="margin-left: 0px;"
             target="_blank"
-            title="author-mock"
           >
             <img
-              alt="author-mock"
+              alt=""
               src="https://github.com/author-mock.png?size=60"
             />
           </a>

--- a/src/pages/about/__tests__/__snapshots__/releases.test.tsx.snap
+++ b/src/pages/about/__tests__/__snapshots__/releases.test.tsx.snap
@@ -346,15 +346,15 @@ exports[`Releases page renders correctly 1`] = `
       <ul>
         <li>
           <a
+            aria-label="author-mock Github - opens in new tab"
             class="link"
             href="https://github.com/author-mock"
             rel="noopener noreferrer"
             style="margin-left: 0px;"
             target="_blank"
-            title="author-mock"
           >
             <img
-              alt="author-mock"
+              alt=""
               src="https://github.com/author-mock.png?size=60"
             />
           </a>

--- a/src/pages/about/__tests__/__snapshots__/resources.test.tsx.snap
+++ b/src/pages/about/__tests__/__snapshots__/resources.test.tsx.snap
@@ -411,15 +411,15 @@ exports[`Resources page renders correctly 1`] = `
           <ul>
             <li>
               <a
+                aria-label="MrJithil Github - opens in new tab"
                 class="link"
                 href="https://github.com/MrJithil"
                 rel="noopener noreferrer"
                 style="margin-left: 0px;"
                 target="_blank"
-                title="MrJithil"
               >
                 <img
-                  alt="MrJithil"
+                  alt=""
                   src="https://github.com/MrJithil.png?size=60"
                 />
               </a>

--- a/src/pages/about/__tests__/__snapshots__/security.test.tsx.snap
+++ b/src/pages/about/__tests__/__snapshots__/security.test.tsx.snap
@@ -224,15 +224,15 @@ exports[`Security page renders correctly 1`] = `
       <ul>
         <li>
           <a
+            aria-label="author-mock Github - opens in new tab"
             class="link"
             href="https://github.com/author-mock"
             rel="noopener noreferrer"
             style="margin-left: 0px;"
             target="_blank"
-            title="author-mock"
           >
             <img
-              alt="author-mock"
+              alt=""
               src="https://github.com/author-mock.png?size=60"
             />
           </a>

--- a/src/pages/download/__tests__/__snapshots__/package-manager.test.tsx.snap
+++ b/src/pages/download/__tests__/__snapshots__/package-manager.test.tsx.snap
@@ -412,15 +412,15 @@ exports[`Package Manager Page renders correctly 1`] = `
           <ul>
             <li>
               <a
+                aria-label="author-mock Github - opens in new tab"
                 class="link"
                 href="https://github.com/author-mock"
                 rel="noopener noreferrer"
                 style="margin-left: 0px;"
                 target="_blank"
-                title="author-mock"
               >
                 <img
-                  alt="author-mock"
+                  alt=""
                   src="https://github.com/author-mock.png?size=60"
                 />
               </a>

--- a/src/templates/__tests__/__snapshots__/learn.test.tsx.snap
+++ b/src/templates/__tests__/__snapshots__/learn.test.tsx.snap
@@ -290,29 +290,29 @@ exports[`Learn Template renders correctly 1`] = `
           <ul>
             <li>
               <a
+                aria-label="test-user1 Github - opens in new tab"
                 class="link"
                 href="https://github.com/test-user1"
                 rel="noopener noreferrer"
                 style="margin-left: 0px;"
                 target="_blank"
-                title="test-user1"
               >
                 <img
-                  alt="test-user1"
+                  alt=""
                   src="https://github.com/test-user1.png?size=60"
                 />
               </a>
             </li>
             <li>
               <a
+                aria-label="test-user2 Github - opens in new tab"
                 class="link"
                 href="https://github.com/test-user2"
                 rel="noopener noreferrer"
                 target="_blank"
-                title="test-user2"
               >
                 <img
-                  alt="test-user2"
+                  alt=""
                   src="https://github.com/test-user2.png?size=60"
                 />
               </a>


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

The contributors list on the about page was announcing every person twice when read with a screen reader because link had a title and the image had an alt text. I removed the image alt text and left an empty string so the name is not read out twice. I also replaced title with an aria-label which has better support overall with different assistive technologies. The title attribute is not well supported unfortunately. Also added 'opens in new tab' to the label so that any blind users do not get disorientated by the change of context.

Updated snapshots

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run lint:js -- --fix` and/or `npm run lint:md -- --fix` for my JavaScript and/or Markdown changes.
  - This is important as most of the cases your code changes might not be correctly linted
- [x] I have run `npm run test` to check if all tests are passing, and/or `npm run test -- -u` to update snapshots if I created and/or updated React Components.
- [ ] I have checked that the build works locally and that `npm run build` work fine.
- [ ] I've covered new added functionality with unit tests if necessary.
