### PR TITLE
fix: lang selector keyboard accessibility

### DIFF
--- a/src/components/CommonComponents/Dropdown/index.tsx
+++ b/src/components/CommonComponents/Dropdown/index.tsx
@@ -24,12 +24,18 @@ const Dropdown = <T extends HTMLElement>({
       fontWeight: (item.active ? 'bold' : 'normal') as 'bold' | 'normal',
     };
 
+    const handleKeyPress = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        item.onClick;
+      }
+    };
+
     return (
       <li key={`dropdown-item-${item.label}`}>
         <button
           style={extraStyles}
           onClick={item.onClick}
-          onKeyDown={item.onClick}
+          onKeyDown={handleKeyPress}
           type="button"
         >
           {item.title}

--- a/src/components/CommonComponents/Dropdown/index.tsx
+++ b/src/components/CommonComponents/Dropdown/index.tsx
@@ -26,7 +26,7 @@ const Dropdown = <T extends HTMLElement>({
 
     const handleKeyPress = (e: React.KeyboardEvent<HTMLButtonElement>) => {
       if (e.key === 'Enter' || e.key === ' ') {
-        item.onClick;
+        item.onClick();
       }
     };
 

--- a/src/components/CommonComponents/LanguageSelector/__tests__/__snapshots__/LanguageSelector.test.tsx.snap
+++ b/src/components/CommonComponents/LanguageSelector/__tests__/__snapshots__/LanguageSelector.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`LanguageSelector component renders correctly 1`] = `
 <div>
   <button
+    aria-expanded="false"
     class="languageSwitch"
     type="button"
   >

--- a/src/components/CommonComponents/LanguageSelector/index.tsx
+++ b/src/components/CommonComponents/LanguageSelector/index.tsx
@@ -21,6 +21,7 @@ const LanguageSelector = () => {
         className={styles.languageSwitch}
         ref={languageButtonRef}
         onClick={() => showDropdown(!visible)}
+        aria-expanded={visible}
       >
         <span className="sr-only">Switch Language</span>
         <TranslateIcon />

--- a/src/layouts/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/layouts/__tests__/__snapshots__/index.test.tsx.snap
@@ -158,6 +158,7 @@ exports[`Layout component renders correctly with data 1`] = `
             </li>
             <li>
               <button
+                aria-expanded="false"
                 class="languageSwitch"
                 type="button"
               >

--- a/src/layouts/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/layouts/__tests__/__snapshots__/page.test.tsx.snap
@@ -158,6 +158,7 @@ exports[`PageLayout component renders correctly with data 1`] = `
             </li>
             <li>
               <button
+                aria-expanded="false"
                 class="languageSwitch"
                 type="button"
               >

--- a/src/pages/about/__tests__/__snapshots__/resources.test.tsx.snap
+++ b/src/pages/about/__tests__/__snapshots__/resources.test.tsx.snap
@@ -158,6 +158,7 @@ exports[`Resources page renders correctly 1`] = `
             </li>
             <li>
               <button
+                aria-expanded="false"
                 class="languageSwitch"
                 type="button"
               >

--- a/src/pages/download/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/pages/download/__tests__/__snapshots__/index.test.tsx.snap
@@ -158,6 +158,7 @@ exports[`Download page renders correctly 1`] = `
             </li>
             <li>
               <button
+                aria-expanded="false"
                 class="languageSwitch"
                 type="button"
               >
@@ -1144,6 +1145,7 @@ exports[`Download page should handle LTS to Current switch 1`] = `
             </li>
             <li>
               <button
+                aria-expanded="false"
                 class="languageSwitch"
                 type="button"
               >

--- a/src/pages/download/__tests__/__snapshots__/package-manager.test.tsx.snap
+++ b/src/pages/download/__tests__/__snapshots__/package-manager.test.tsx.snap
@@ -158,6 +158,7 @@ exports[`Package Manager Page renders correctly 1`] = `
             </li>
             <li>
               <button
+                aria-expanded="false"
                 class="languageSwitch"
                 type="button"
               >

--- a/src/sections/Header/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/sections/Header/__tests__/__snapshots__/index.test.tsx.snap
@@ -155,6 +155,7 @@ exports[`Tests for Header component Theme color switcher skips rendering in case
           </li>
           <li>
             <button
+              aria-expanded="false"
               class="languageSwitch"
               type="button"
             >
@@ -389,6 +390,7 @@ exports[`Tests for Header component renders correctly 1`] = `
           </li>
           <li>
             <button
+              aria-expanded="false"
               class="languageSwitch"
               type="button"
             >
@@ -623,6 +625,7 @@ exports[`Tests for Header component renders shorter menu items for mobile 1`] = 
           </li>
           <li>
             <button
+              aria-expanded="false"
               class="languageSwitch"
               type="button"
             >

--- a/src/templates/__tests__/__snapshots__/learn.test.tsx.snap
+++ b/src/templates/__tests__/__snapshots__/learn.test.tsx.snap
@@ -158,6 +158,7 @@ exports[`Learn Template renders correctly 1`] = `
             </li>
             <li>
               <button
+                aria-expanded="false"
                 class="languageSwitch"
                 type="button"
               >

--- a/src/templates/__tests__/__snapshots__/post.test.tsx.snap
+++ b/src/templates/__tests__/__snapshots__/post.test.tsx.snap
@@ -158,6 +158,7 @@ exports[`LearnLayout Template renders correctly 1`] = `
             </li>
             <li>
               <button
+                aria-expanded="false"
                 class="languageSwitch"
                 type="button"
               >


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

The new language selector dropdown had a small bug in that if you tabbed through the selections with the keyboard it would automatically change the language to French as you tabbed away from the dropdown. This is not the expected behaviour.

I added a check to the event to make sure only `space` and `enter` keys could trigger a language change.

I also added an aria-expanded attribute to the button so that screen reader users are made aware that the button has a popup and whether it is open or closed.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run lint:js -- --fix` and/or `npm run lint:md -- --fix` for my JavaScript and/or Markdown changes.
  - This is important as most of the cases your code changes might not be correctly linted
- [x] I have run `npm run test` to check if all tests are passing, and/or `npm run test -- -u` to update snapshots if I created and/or updated React Components.
- [x] I have checked that the build works locally and that `npm run build` work fine.
- [ ] I've covered new added functionality with unit tests if necessary.
