### PR TITLE
Fix: download toggle button accessibility/translation support

### DIFF
--- a/src/components/DownloadComponents/DownloadAdditional/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/components/DownloadComponents/DownloadAdditional/__tests__/__snapshots__/index.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`DownloadAdditional component allows to collapse expanded items 1`] = `
           >
             <button
               aria-checked="true"
-              aria-label="Show LTS versions"
+              aria-label="LTS Versions"
               class="active"
               role="switch"
               type="button"
@@ -32,8 +32,8 @@ exports[`DownloadAdditional component allows to collapse expanded items 1`] = `
               LTS
             </button>
             <button
-              aria-checked="true"
-              aria-label="Show LTS versions"
+              aria-checked="false"
+              aria-label="Current Versions"
               class="current"
               role="switch"
               type="button"
@@ -166,7 +166,7 @@ exports[`DownloadAdditional component allows to expand items 1`] = `
           >
             <button
               aria-checked="true"
-              aria-label="Show LTS versions"
+              aria-label="LTS Versions"
               class="active"
               role="switch"
               type="button"
@@ -174,8 +174,8 @@ exports[`DownloadAdditional component allows to expand items 1`] = `
               LTS
             </button>
             <button
-              aria-checked="true"
-              aria-label="Show LTS versions"
+              aria-checked="false"
+              aria-label="Current Versions"
               class="current"
               role="switch"
               type="button"
@@ -308,7 +308,7 @@ exports[`DownloadAdditional component renders correctly 1`] = `
           >
             <button
               aria-checked="true"
-              aria-label="Show LTS versions"
+              aria-label="LTS Versions"
               class="active"
               role="switch"
               type="button"
@@ -316,8 +316,8 @@ exports[`DownloadAdditional component renders correctly 1`] = `
               LTS
             </button>
             <button
-              aria-checked="true"
-              aria-label="Show LTS versions"
+              aria-checked="false"
+              aria-label="Current Versions"
               class="current"
               role="switch"
               type="button"
@@ -359,7 +359,7 @@ exports[`DownloadAdditional component renders correctly with release data 1`] = 
           >
             <button
               aria-checked="true"
-              aria-label="Show LTS versions"
+              aria-label="LTS Versions"
               class="active"
               role="switch"
               type="button"
@@ -367,8 +367,8 @@ exports[`DownloadAdditional component renders correctly with release data 1`] = 
               LTS
             </button>
             <button
-              aria-checked="true"
-              aria-label="Show LTS versions"
+              aria-checked="false"
+              aria-label="Current Versions"
               class="current"
               role="switch"
               type="button"

--- a/src/components/DownloadComponents/DownloadToggle/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/components/DownloadComponents/DownloadToggle/__tests__/__snapshots__/index.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`DownloadToggle component renders correctly 1`] = `
       >
         <button
           aria-checked="true"
-          aria-label="Show LTS versions"
+          aria-label="LTS Versions"
           class="active"
           role="switch"
           type="button"
@@ -21,8 +21,8 @@ exports[`DownloadToggle component renders correctly 1`] = `
           LTS
         </button>
         <button
-          aria-checked="true"
-          aria-label="Show LTS versions"
+          aria-checked="false"
+          aria-label="Current Versions"
           class="current"
           role="switch"
           type="button"

--- a/src/components/DownloadComponents/DownloadToggle/index.tsx
+++ b/src/components/DownloadComponents/DownloadToggle/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import classnames from 'classnames';
 import styles from './index.module.scss';
 
@@ -19,6 +19,7 @@ const DownloadToggle = ({
     [styles.active]: selected === 'CURRENT',
   });
 
+  const intl = useIntl();
   const handleOnClick = () =>
     handleClick(selected === 'CURRENT' ? 'LTS' : 'CURRENT');
 
@@ -30,7 +31,9 @@ const DownloadToggle = ({
             className={activeClassNames}
             type="button"
             role="switch"
-            aria-label="Show LTS versions"
+            aria-label={intl.formatMessage({
+              id: 'components.downloadToggle.ltsVersions',
+            })}
             aria-checked={selected === 'LTS'}
             onClick={handleOnClick}
           >
@@ -40,8 +43,10 @@ const DownloadToggle = ({
             className={currentClassNames}
             type="button"
             role="switch"
-            aria-label="Show LTS versions"
-            aria-checked={selected === 'LTS'}
+            aria-label={intl.formatMessage({
+              id: 'components.downloadToggle.currentVersions',
+            })}
+            aria-checked={selected === 'CURRENT'}
             onClick={handleOnClick}
           >
             <FormattedMessage id="components.downloadToggle.current" />

--- a/src/components/DownloadComponents/DownloadToggle/index.tsx
+++ b/src/components/DownloadComponents/DownloadToggle/index.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
-import { FormattedMessage, useIntl } from 'react-intl';
+import {
+  FormattedMessage,
+  injectIntl,
+  WrappedComponentProps,
+} from 'react-intl';
 import classnames from 'classnames';
 import styles from './index.module.scss';
 
@@ -13,13 +17,13 @@ const DownloadToggle = ({
   handleClick,
   selected,
   showDescription = true,
-}: Props): JSX.Element => {
+  intl,
+}: Props & WrappedComponentProps): JSX.Element => {
   const activeClassNames = classnames({ [styles.active]: selected === 'LTS' });
   const currentClassNames = classnames(styles.current, {
     [styles.active]: selected === 'CURRENT',
   });
 
-  const intl = useIntl();
   const handleOnClick = () =>
     handleClick(selected === 'CURRENT' ? 'LTS' : 'CURRENT');
 
@@ -65,4 +69,4 @@ const DownloadToggle = ({
   );
 };
 
-export default DownloadToggle;
+export default injectIntl(DownloadToggle);

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -92,5 +92,7 @@
   "blog.categories.vulnerability": "Vulnerabilities",
   "blog.categories.announcements.description": "Blog category for Node.js announcements",
   "blog.categories.release.description": "Blog category for Node.js Release announcements",
-  "blog.categories.vulnerability.description": "Blog category regarding Security Vulnerabilities"
+  "blog.categories.vulnerability.description": "Blog category regarding Security Vulnerabilities",
+  "components.downloadToggle.ltsVersions": "LTS Versions",
+  "components.downloadToggle.currentVersions": "Current Versions"
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -92,5 +92,7 @@
   "blog.categories.vulnerability": "Vulnerabilities",
   "blog.categories.announcements.description": "Blog category for Node.js announcements",
   "blog.categories.release.description": "Blog category for Node.js Release announcements",
-  "blog.categories.vulnerability.description": "Blog category regarding Security Vulnerabilities"
+  "blog.categories.vulnerability.description": "Blog category regarding Security Vulnerabilities",
+  "components.downloadToggle.ltsVersions": "LTS Versions",
+  "components.downloadToggle.currentVersions": "Current Versions"
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -92,5 +92,7 @@
   "blog.categories.vulnerability": "Vulnerabilities",
   "blog.categories.announcements.description": "Blog category for Node.js announcements",
   "blog.categories.release.description": "Blog category for Node.js Release announcements",
-  "blog.categories.vulnerability.description": "Blog category regarding Security Vulnerabilities"
+  "blog.categories.vulnerability.description": "Blog category regarding Security Vulnerabilities",
+  "components.downloadToggle.ltsVersions": "LTS Versions",
+  "components.downloadToggle.currentVersions": "Current Versions"
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -92,7 +92,7 @@
   "blog.categories.vulnerability": "Vulnerabilities",
   "blog.categories.announcements.description": "Blog category for Node.js announcements",
   "blog.categories.release.description": "Blog category for Node.js Release announcements",
-  "blog.categories.vulnerability.description": "Blog category regarding Security Vulnerabilities",
+  "blog.categories.vulnerability.description": "Catégorie de blog concernant les vulnérabilités de sécurité",
   "components.downloadToggle.ltsVersions": "LTS Versions",
-  "components.downloadToggle.currentVersions": "Current Versions"
+  "components.downloadToggle.currentVersions": "Versions actuelles"
 }

--- a/src/i18n/locales/zh-cn.json
+++ b/src/i18n/locales/zh-cn.json
@@ -92,5 +92,7 @@
   "blog.categories.vulnerability": "Vulnerabilities",
   "blog.categories.announcements.description": "Blog category for Node.js announcements",
   "blog.categories.release.description": "Blog category for Node.js Release announcements",
-  "blog.categories.vulnerability.description": "Blog category regarding Security Vulnerabilities"
+  "blog.categories.vulnerability.description": "Blog category regarding Security Vulnerabilities",
+  "components.downloadToggle.ltsVersions": "LTS Versions",
+  "components.downloadToggle.currentVersions": "Current Versions"
 }

--- a/src/pages/download/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/pages/download/__tests__/__snapshots__/index.test.tsx.snap
@@ -291,7 +291,7 @@ exports[`Download page renders correctly 1`] = `
           >
             <button
               aria-checked="true"
-              aria-label="Show LTS versions"
+              aria-label="LTS Versions"
               class="active"
               role="switch"
               type="button"
@@ -299,8 +299,8 @@ exports[`Download page renders correctly 1`] = `
               LTS
             </button>
             <button
-              aria-checked="true"
-              aria-label="Show LTS versions"
+              aria-checked="false"
+              aria-label="Current Versions"
               class="current"
               role="switch"
               type="button"
@@ -722,7 +722,7 @@ exports[`Download page renders correctly 1`] = `
               >
                 <button
                   aria-checked="true"
-                  aria-label="Show LTS versions"
+                  aria-label="LTS Versions"
                   class="active"
                   role="switch"
                   type="button"
@@ -730,8 +730,8 @@ exports[`Download page renders correctly 1`] = `
                   LTS
                 </button>
                 <button
-                  aria-checked="true"
-                  aria-label="Show LTS versions"
+                  aria-checked="false"
+                  aria-label="Current Versions"
                   class="current"
                   role="switch"
                   type="button"
@@ -1277,7 +1277,7 @@ exports[`Download page should handle LTS to Current switch 1`] = `
           >
             <button
               aria-checked="false"
-              aria-label="Show LTS versions"
+              aria-label="LTS Versions"
               class=""
               role="switch"
               type="button"
@@ -1285,8 +1285,8 @@ exports[`Download page should handle LTS to Current switch 1`] = `
               LTS
             </button>
             <button
-              aria-checked="false"
-              aria-label="Show LTS versions"
+              aria-checked="true"
+              aria-label="Current Versions"
               class="current active"
               role="switch"
               type="button"
@@ -1708,7 +1708,7 @@ exports[`Download page should handle LTS to Current switch 1`] = `
               >
                 <button
                   aria-checked="false"
-                  aria-label="Show LTS versions"
+                  aria-label="LTS Versions"
                   class=""
                   role="switch"
                   type="button"
@@ -1716,8 +1716,8 @@ exports[`Download page should handle LTS to Current switch 1`] = `
                   LTS
                 </button>
                 <button
-                  aria-checked="false"
-                  aria-label="Show LTS versions"
+                  aria-checked="true"
+                  aria-label="Current Versions"
                   class="current active"
                   role="switch"
                   type="button"


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

The second toggle button on the download page didn't have correct aria-checked or aria-label values due to a copy-paste mistake I am guessing. They are now updated to match the corresponding button. 

While I was there I added them to the translation files ready to be translated.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run lint:js -- --fix` and/or `npm run lint:md -- --fix` for my JavaScript and/or Markdown changes.
  - This is important as most of the cases your code changes might not be correctly linted
- [x] I have run `npm run test` to check if all tests are passing, and/or `npm run test -- -u` to update snapshots if I created and/or updated React Components.
- [x] I have checked that the build works locally and that `npm run build` work fine.
- [ ] I've covered new added functionality with unit tests if necessary.
