### PR TITLE
fix(SearchBar): SearchBar close while navigating tab key

### DIFF
--- a/src/components/CommonComponents/SearchBar/index.tsx
+++ b/src/components/CommonComponents/SearchBar/index.tsx
@@ -68,6 +68,16 @@ const SearchBar = (): JSX.Element => {
     [styles.expanded]: isExpanded,
   });
 
+  const onBlurHandler = (e: React.FocusEvent<HTMLInputElement>) => {
+    if (e.currentTarget.contains(e.relatedTarget)) {
+      if (isEmpty) {
+        collapseContainer();
+      }
+      return;
+    }
+    collapseContainer();
+  };
+
   const onKeyPressHandler = () => {
     if (!isExpanded) {
       expandContainer();
@@ -94,6 +104,7 @@ const SearchBar = (): JSX.Element => {
       variants={containerVariants}
       transition={containerTransition}
       ref={parentRef}
+      onBlur={onBlurHandler}
     >
       <div
         className={styles.searchInputContainer}

--- a/src/components/CommonComponents/SearchBar/index.tsx
+++ b/src/components/CommonComponents/SearchBar/index.tsx
@@ -69,10 +69,7 @@ const SearchBar = (): JSX.Element => {
   });
 
   const onBlurHandler = (e: React.FocusEvent<HTMLInputElement>) => {
-    if (e.currentTarget.contains(e.relatedTarget)) {
-      if (isEmpty) {
-        collapseContainer();
-      }
+    if (e.currentTarget.contains(e.relatedTarget) && !isEmpty) {
       return;
     }
     collapseContainer();


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

1. Check if the search bar closes while moving with the tab key.
2. If there is a search list, go through the list below and move to the theme toggle button.
<!-- Write a brief description of the changes introduced by this PR -->

https://user-images.githubusercontent.com/49237205/197265264-a1cefafa-b2dd-45b7-aab0-86ae7726e378.mov


## Related Issues

#2938 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [X] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [X] I have run `npm run lint:js -- --fix` and/or `npm run lint:md -- --fix` for my JavaScript and/or Markdown changes.
  - This is important as most of the cases your code changes might not be correctly linted
- [X] I have run `npm run test` to check if all tests are passing, and/or `npm run test -- -u` to update snapshots if I created and/or updated React Components.
- [X] I have checked that the build works locally and that `npm run build` work fine.
- [ ] I've covered new added functionality with unit tests if necessary.
