### PR TITLE
fix(node-writing-files.en.md): markdown

### DIFF
--- a/content/learn/manipulating-files/node-writing-files.en.md
+++ b/content/learn/manipulating-files/node-writing-files.en.md
@@ -66,33 +66,13 @@ fs.writeFile('/Users/joe/test.txt', content, { flag: 'a+' }, err => {});
 
 #### The flags you'll likely use are
 
-<table>
-  <tr>
-    <th>Flag</th>
-    <th>Description</th>
-    <th>File gets created if it doesn't exist</th>
-  </tr>
-  <tr>
-    <td><code>r+</code></td>
-    <td>This flag opens the file for <b>reading</b> and <b>writing</b></td>
-    <td style="text-align: center;">❌</td>
-  </tr>
-  <tr>
-    <td><code>w+</code></td>
-    <td>This flag opens the file for <b>reading</b> and <b>writing</b> and it also positions the stream at the <b>beginning</b> of the file</td>
-    <td style="text-align: center;">✅</td>
-  </tr>
-  <tr>
     <td><code>a</code></td>
-    <td>This flag opens the file for <b>writing</b> and it also positions the stream at the <b>end</b> of the file</td>
-    <td style="text-align: center;">✅</td>
-  </tr>
-  <tr>
-    <td><code>a+</code></td>
-    <td>This flag opens the file for <b>reading</b> and <b>writing</b> and it also positions the stream at the <b>end</b> of the file</td>
-    <td style="text-align: center;">✅</td>
-  </tr>
-</table>
+|Flag|Description|File gets created if it doesn't exist|
+|------|------|------|
+|`r+`|This flag opens the file for **reading** and **writing**|<p style="text-align: center;">❌</p>|
+|`w+`|This flag opens the file for **reading** and **writing** and it also positions the stream at the **beginning** of the file|<p style="text-align: center;">✅</p>|
+|`a`|This flag opens the file for **writing** and it also positions the stream at the **end** of the file|<p style="text-align: center;">✅</p>|
+|`a+`|This flag opens the file for **reading** and **writing** and it also positions the stream at the **end** of the file|<p style="text-align: center;">✅</p>|
 
 * You can find more information about the flags in the [fs documentation](/api/fs/#file-system-flags).
 

--- a/content/learn/manipulating-files/node-writing-files.en.md
+++ b/content/learn/manipulating-files/node-writing-files.en.md
@@ -66,12 +66,12 @@ fs.writeFile('/Users/joe/test.txt', content, { flag: 'a+' }, err => {});
 
 #### The flags you'll likely use are
 
-| Flag | Description | File gets created if it doesn't exist                                              |
-|------|-------------|------------------------------------------------------------------------------------|
-| `r+` | This flag opens the file for **reading** and **writing** | <p style="text-align: center;">❌</p> |
-| `w+` | This flag opens the file for **reading** and **writing** and it also positions the stream at the **beginning** of the file | <p style="text-align: center;">✅</p>                                                          |
-| `a`  | This flag opens the file for **writing** and it also positions the stream at the **end** of the file | <p style="text-align: center;">✅</p>                                                                        |
-| `a+` | This flag opens the file for **reading** and **writing** and it also positions the stream at the **end** of the file | <p style="text-align: center;">✅</p>                                                              |
+| Flag | Description | File gets created if it doesn't exist           |
+|------|-------------|:-----------------------------------------------:|
+| `r+` | This flag opens the file for **reading** and **writing** | ❌ |
+| `w+` | This flag opens the file for **reading** and **writing** and it also positions the stream at the **beginning** of the file | ✅                                                          |
+| `a`  | This flag opens the file for **writing** and it also positions the stream at the **end** of the file | ✅                                                                     |
+| `a+` | This flag opens the file for **reading** and **writing** and it also positions the stream at the **end** of the file | ✅                                                              |
 
 * You can find more information about the flags in the [fs documentation](/api/fs/#file-system-flags).
 

--- a/content/learn/manipulating-files/node-writing-files.en.md
+++ b/content/learn/manipulating-files/node-writing-files.en.md
@@ -66,7 +66,6 @@ fs.writeFile('/Users/joe/test.txt', content, { flag: 'a+' }, err => {});
 
 #### The flags you'll likely use are
 
-    <td><code>a</code></td>
 |Flag|Description|File gets created if it doesn't exist|
 |------|------|------|
 |`r+`|This flag opens the file for **reading** and **writing**|<p style="text-align: center;">❌</p>|

--- a/content/learn/manipulating-files/node-writing-files.en.md
+++ b/content/learn/manipulating-files/node-writing-files.en.md
@@ -66,12 +66,12 @@ fs.writeFile('/Users/joe/test.txt', content, { flag: 'a+' }, err => {});
 
 #### The flags you'll likely use are
 
-|Flag|Description|File gets created if it doesn't exist|
-|------|------|------|
-|`r+`|This flag opens the file for **reading** and **writing**|<p style="text-align: center;">❌</p>|
-|`w+`|This flag opens the file for **reading** and **writing** and it also positions the stream at the **beginning** of the file|<p style="text-align: center;">✅</p>|
-|`a`|This flag opens the file for **writing** and it also positions the stream at the **end** of the file|<p style="text-align: center;">✅</p>|
-|`a+`|This flag opens the file for **reading** and **writing** and it also positions the stream at the **end** of the file|<p style="text-align: center;">✅</p>|
+| Flag | Description | File gets created if it doesn't exist                                              |
+|------|-------------|------------------------------------------------------------------------------------|
+| `r+` | This flag opens the file for **reading** and **writing** | <p style="text-align: center;">❌</p> |
+| `w+` | This flag opens the file for **reading** and **writing** and it also positions the stream at the **beginning** of the file | <p style="text-align: center;">✅</p>                                                          |
+| `a`  | This flag opens the file for **writing** and it also positions the stream at the **end** of the file | <p style="text-align: center;">✅</p>                                                                        |
+| `a+` | This flag opens the file for **reading** and **writing** and it also positions the stream at the **end** of the file | <p style="text-align: center;">✅</p>                                                              |
 
 * You can find more information about the flags in the [fs documentation](/api/fs/#file-system-flags).
 


### PR DESCRIPTION

## Description

By "convention" you should avoid html on a markdown file

## Related Issues

No related issues

### Check List

- [X] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run lint:js -- --fix` and/or `npm run lint:md -- --fix` for my JavaScript and/or Markdown changes.
  - This is important as most of the cases your code changes might not be correctly linted
- [x] I have run `npm run test` to check if all tests are passing, and/or `npm run test -- -u` to update snapshots if I created and/or updated React Components.
- [x] I have checked that the build works locally and that `npm run build` work fine.
- [ ] I've covered new added functionality with unit tests if necessary.
