### PR TITLE
fix: remove link to deleted event loop page

### DIFF
--- a/content/about/about.en.md
+++ b/content/about/about.en.md
@@ -44,7 +44,7 @@ If some of this language is unfamiliar, there is a full article on
 
 Node.js is similar in design to, and influenced by, systems like Ruby's
 [Event Machine][] and Python's [Twisted][]. Node.js takes the event model a bit
-further. It presents an [event loop][] as a runtime construct instead of as a library. In other systems,
+further. It presents an event loop as a runtime construct instead of as a library. In other systems,
 there is always a blocking call to start the event-loop.
 Typically, behavior is defined through callbacks at the beginning of a script, and
 at the end a server is started through a blocking call like `EventMachine::run()`.
@@ -66,6 +66,5 @@ over your cores.
 [blocking vs. non-blocking]: /learn/overview-of-blocking-vs-non-blocking/
 [`child_process.fork()`]: /api/child_process/
 [`cluster`]: https://nodejs.org/api/cluster.html
-[event loop]: /learn/the-nodejs-event-loop/
 [event machine]: https://github.com/eventmachine/eventmachine
 [twisted]: https://twistedmatrix.com/trac/


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

The linked page about event loop seems to have been deleted by #2796 , so the link is broken.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run lint:js -- --fix` and/or `npm run lint:md -- --fix` for my JavaScript and/or Markdown changes.
  - This is important as most of the cases your code changes might not be correctly linted
- [x] I have run `npm run test` to check if all tests are passing, and/or `npm run test -- -u` to update snapshots if I created and/or updated React Components.
- [x] I have checked that the build works locally and that `npm run build` work fine.
- [x] I've covered new added functionality with unit tests if necessary.
