### PR TITLE
ci: Use gatsby-cache action to cache gatsby build outputs

### DIFF
--- a/.github/workflows/firebase-deployment.yml
+++ b/.github/workflows/firebase-deployment.yml
@@ -26,17 +26,9 @@ jobs:
       - name: Install NPM packages
         run: npm ci
 
-      - name: Gatsby Cache Folder
-        uses: actions/cache@v3
+      - uses: jongwooo/gatsby-cache@v1.1.0
         with:
-          key: cache-folder-ubuntu-latest
-          path: .cache
-
-      - name: Gatsby Public Folder
-        uses: actions/cache@v3
-        with:
-          key: public-folder-ubuntu-latest
-          path: public
+          key: firebase-deployment-gatsby-ubuntu-latest
 
       - name: Build Gatsby
         run: npm run build-ci

--- a/.github/workflows/generate-preview.yml
+++ b/.github/workflows/generate-preview.yml
@@ -51,6 +51,10 @@ jobs:
       - name: Install NPM packages
         run: npm ci
 
+      - uses: jongwooo/gatsby-cache@v1.1.0
+        with:
+          key: generate-preview-gatsby-ubuntu-latest
+
       - name: Build Gatsby
         run: npm run build-ci
         env:

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -30,17 +30,9 @@ jobs:
       - name: Install NPM packages
         run: npm ci
 
-      - name: Gatsby Cache Folder
-        uses: actions/cache@v3
+      - uses: jongwooo/gatsby-cache@v1.1.0
         with:
-          key: cache-folder-ubuntu-latest
-          path: .cache
-
-      - name: Gatsby Public Folder
-        uses: actions/cache@v3
-        with:
-          key: public-folder-ubuntu-latest
-          path: public
+          key: github-pages-gatsby-ubuntu-latest
 
       - name: Build Gatsby
         run: npm run build-ci

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -58,17 +58,9 @@ jobs:
       - name: Install NPM packages
         run: npm ci
 
-      - name: Gatsby Cache Folder
-        uses: actions/cache@v3
+      - uses: jongwooo/gatsby-cache@v1.1.0
         with:
-          key: cache-folder-${{ matrix.os }}
-          path: .cache
-
-      - name: Gatsby Public Folder
-        uses: actions/cache@v3
-        with:
-          key: public-folder-${{ matrix.os }}
-          path: public
+          key: pull-request-gatsby-ubuntu-latest
 
       - name: Build Gatsby
         run: npm run build-ci

--- a/.github/workflows/sync-api.yml
+++ b/.github/workflows/sync-api.yml
@@ -34,17 +34,9 @@ jobs:
       - name: Lint Markdown files
         run: npm run lint:md
 
-      - name: Gatsby Cache Folder
-        uses: actions/cache@v3
+      - uses: jongwooo/gatsby-cache@v1.1.0
         with:
-          key: cache-folder-ubuntu-latest
-          path: .cache
-
-      - name: Gatsby Public Folder
-        uses: actions/cache@v3
-        with:
-          key: public-folder-ubuntu-latest
-          path: public
+          key: sync-api-gatsby-ubuntu-latest
 
       - name: Build Gatsby
         run: npm run build-ci


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Description

I created an action to cache Gatsby's build outputs. This action is easy to set up. 

**AS-IS**

```yaml
- name: Gatsby Cache Folder
  uses: actions/cache@v3
  with:
    key: cache-folder-ubuntu-latest
    path: .cache

- name: Gatsby Public Folder
  uses: actions/cache@v3
  with:
    key: public-folder-ubuntu-latest
    path: public
```

**TO-BE**

```yaml
- uses: jongwooo/gatsby-cache@v1.1.0
  with:
    key: build-gatsby-ubuntu-latest
```

## References

- [https://github.com/jongwooo/gatsby-cache](https://github.com/jongwooo/gatsby-cache)

## Related Issues

N/A

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [ ] I have run `npm run lint:js -- --fix` and/or `npm run lint:md -- --fix` for my JavaScript and/or Markdown changes.
  - This is important as most of the cases your code changes might not be correctly linted
- [ ] I have run `npm run test` to check if all tests are passing, and/or `npm run test -- -u` to update snapshots if I created and/or updated React Components.
- [ ] I have checked that the build works locally and that `npm run build` work fine.
- [ ] I've covered new added functionality with unit tests if necessary.
