### PR TITLE
fix: remove redundant character ">" in documentation md

### DIFF
--- a/content/api/v16/buffer.en.md
+++ b/content/api/v16/buffer.en.md
@@ -4287,7 +4287,7 @@ See [`Buffer.from(array)`][].
 
 <Metadata version="v16.19.0" data={{"changes":[{"version":"v10.0.0","pr-url":"https://github.com/nodejs/node/pull/19524","description":"Calling this constructor emits a deprecation warning when run from code outside the `node_modules` directory."},{"version":"v7.2.1","pr-url":"https://github.com/nodejs/node/pull/9529","description":"Calling this constructor no longer emits a deprecation warning."},{"version":"v7.0.0","pr-url":"https://github.com/nodejs/node/pull/8169","description":"Calling this constructor emits a deprecation warning now."},{"version":"v6.0.0","pr-url":"https://github.com/nodejs/node/pull/4682","description":"The `byteOffset` and `length` parameters are supported now."}],"update":{"type":"deprecated","version":["v6.0.0"]}}} />
 
-<Metadata version="v16.19.0" data={{"stability":{"level":0,"text":" - Deprecated: Use [`Buffer.from(arrayBuffer[, byteOffset[, length]])`][`Buffer.from(arrayBuf)`]\n> instead."}}} />
+<Metadata version="v16.19.0" data={{"stability":{"level":0,"text":" - Deprecated: Use [`Buffer.from(arrayBuffer[, byteOffset[, length]])`][`Buffer.from(arrayBuf)`] instead."}}} />
 
 * `arrayBuffer` [`ArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) | [`SharedArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer) An [`ArrayBuffer`][],
   [`SharedArrayBuffer`][] or the `.buffer` property of a [`TypedArray`][].

--- a/content/api/v16/documentation.en.md
+++ b/content/api/v16/documentation.en.md
@@ -30,11 +30,11 @@ The stability indices are as follows:
 
 <Metadata version="v16.19.0" data={{"stability":{"level":0,"text":" - Deprecated. The feature may emit warnings. Backward compatibility is not guaranteed."}}} />
 
-<Metadata version="v16.19.0" data={{"stability":{"level":1,"text":" - Experimental. The feature is not subject to semantic versioning rules. Non-backward compatible changes or removal may\n> occur in any future release. Use of the feature is not recommended in\n> production environments."}}} />
+<Metadata version="v16.19.0" data={{"stability":{"level":1,"text":" - Experimental. The feature is not subject to semantic versioning rules. Non-backward compatible changes or removal may occur in any future release. Use of the feature is not recommended in production environments."}}} />
 
 <Metadata version="v16.19.0" data={{"stability":{"level":2,"text":" - Stable. Compatibility with the npm ecosystem is a high priority."}}} />
 
-<Metadata version="v16.19.0" data={{"stability":{"level":3,"text":" - Legacy. Although this feature is unlikely to be removed and is still covered by semantic versioning guarantees, it is no longer actively\n> maintained, and other alternatives are available."}}} />
+<Metadata version="v16.19.0" data={{"stability":{"level":3,"text":" - Legacy. Although this feature is unlikely to be removed and is still covered by semantic versioning guarantees, it is no longer actively maintained, and other alternatives are available."}}} />
 
 Features are marked as legacy rather than being deprecated if their use does no
 harm, and they are widely relied upon within the npm ecosystem. Bugs found in

--- a/content/api/v16/process.en.md
+++ b/content/api/v16/process.en.md
@@ -3355,7 +3355,7 @@ flag's behavior.
 
 <Metadata version="v16.19.0" data={{"changes":[{"version":["v14.0.0","v12.19.0"],"pr-url":"https://github.com/nodejs/node/pull/32499","description":"Calling `process.umask()` with no arguments is deprecated."}],"update":{"type":"added","version":["v0.1.19"]}}} />
 
-<Metadata version="v16.19.0" data={{"stability":{"level":0,"text":" - Deprecated. Calling `process.umask()` with no argument causes the process-wide umask to be written twice. This introduces a race condition\n> between threads, and is a potential security vulnerability. There is no safe,\n> cross-platform alternative API."}}} />
+<Metadata version="v16.19.0" data={{"stability":{"level":0,"text":" - Deprecated. Calling `process.umask()` with no argument causes the process-wide umask to be written twice. This introduces a race condition between threads, and is a potential security vulnerability. There is no safe, cross-platform alternative API."}}} />
 
 `process.umask()` returns the Node.js process's file mode creation mask. Child
 processes inherit the mask from the parent process.

--- a/content/api/v16/util.en.md
+++ b/content/api/v16/util.en.md
@@ -2357,7 +2357,7 @@ util.isObject(() => {});
 
 <Metadata version="v16.19.0" data={{"update":{"type":"deprecated","version":["v4.0.0"]}}} />
 
-<Metadata version="v16.19.0" data={{"stability":{"level":0,"text":" - Deprecated: Use `(typeof value !== 'object' && typeof value !== 'function') || value === null`\n> instead."}}} />
+<Metadata version="v16.19.0" data={{"stability":{"level":0,"text":" - Deprecated: Use `(typeof value !== 'object' && typeof value !== 'function') || value === null` instead."}}} />
 
 * `object` [`any`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Data_types)
 * Returns: [`boolean`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)

--- a/content/api/v18/async_hooks.en.md
+++ b/content/api/v18/async_hooks.en.md
@@ -7,7 +7,7 @@ version: 'v18'
 
 <Metadata version="v18.13.0" data={{"update":{"type":"introduced_in","version":["v8.1.0"]}}} />
 
-<Metadata version="v18.13.0" data={{"stability":{"level":1,"text":" - Experimental. Please migrate away from this API, if you can. We do not recommend using the `createHook`][], [`AsyncHook`, and\n> `executionAsyncResource` APIs as they have usability issues, safety risks,\n> and performance implications. Async context tracking use cases are better\n> served by the stable `AsyncLocalStorage` API. If you have a use case for\n> `createHook`, `AsyncHook`, or `executionAsyncResource` beyond the context\n> tracking need solved by `AsyncLocalStorage` or diagnostics data currently\n> provided by Diagnostics Channel, please open an issue at\n> <https://github.com/nodejs/node/issues> describing your use case so we can\n> create a more purpose-focused API."}}} />
+<Metadata version="v18.13.0" data={{"stability":{"level":1,"text":" - Experimental. Please migrate away from this API, if you can. We do not recommend using the `createHook`][], [`AsyncHook`][], and [`executionAsyncResource`][] APIs as they have usability issues, safety risks, and performance implications. Async context tracking use cases are better served by the stable [`AsyncLocalStorage`][] API. If you have a use case for `createHook`, `AsyncHook`, or `executionAsyncResource` beyond the context tracking need solved by [`AsyncLocalStorage`][] or diagnostics data currently provided by [Diagnostics Channel, please open an issue at <https://github.com/nodejs/node/issues> describing your use case so we can create a more purpose-focused API."}}} />
 
 <Metadata version="v18.13.0" data={{"source_link":"lib/async_hooks.js"}} />
 

--- a/content/api/v18/buffer.en.md
+++ b/content/api/v18/buffer.en.md
@@ -4300,7 +4300,7 @@ See [`Buffer.from(array)`][].
 
 <Metadata version="v18.13.0" data={{"changes":[{"version":"v10.0.0","pr-url":"https://github.com/nodejs/node/pull/19524","description":"Calling this constructor emits a deprecation warning when run from code outside the `node_modules` directory."},{"version":"v7.2.1","pr-url":"https://github.com/nodejs/node/pull/9529","description":"Calling this constructor no longer emits a deprecation warning."},{"version":"v7.0.0","pr-url":"https://github.com/nodejs/node/pull/8169","description":"Calling this constructor emits a deprecation warning now."},{"version":"v6.0.0","pr-url":"https://github.com/nodejs/node/pull/4682","description":"The `byteOffset` and `length` parameters are supported now."}],"update":{"type":"deprecated","version":["v6.0.0"]}}} />
 
-<Metadata version="v18.13.0" data={{"stability":{"level":0,"text":" - Deprecated: Use [`Buffer.from(arrayBuffer[, byteOffset[, length]])`][`Buffer.from(arrayBuf)`]\n> instead."}}} />
+<Metadata version="v18.13.0" data={{"stability":{"level":0,"text":" - Deprecated: Use [`Buffer.from(arrayBuffer[, byteOffset[, length]])`][`Buffer.from(arrayBuf)`] instead."}}} />
 
 * `arrayBuffer` [`ArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) | [`SharedArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer) An [`ArrayBuffer`][],
   [`SharedArrayBuffer`][] or the `.buffer` property of a [`TypedArray`][].

--- a/content/api/v18/documentation.en.md
+++ b/content/api/v18/documentation.en.md
@@ -30,11 +30,11 @@ The stability indices are as follows:
 
 <Metadata version="v18.13.0" data={{"stability":{"level":0,"text":" - Deprecated. The feature may emit warnings. Backward compatibility is not guaranteed."}}} />
 
-<Metadata version="v18.13.0" data={{"stability":{"level":1,"text":" - Experimental. The feature is not subject to semantic versioning rules. Non-backward compatible changes or removal may\n> occur in any future release. Use of the feature is not recommended in\n> production environments."}}} />
+<Metadata version="v18.13.0" data={{"stability":{"level":1,"text":" - Experimental. The feature is not subject to semantic versioning rules. Non-backward compatible changes or removal may occur in any future release. Use of the feature is not recommended in production environments."}}} />
 
 <Metadata version="v18.13.0" data={{"stability":{"level":2,"text":" - Stable. Compatibility with the npm ecosystem is a high priority."}}} />
 
-<Metadata version="v18.13.0" data={{"stability":{"level":3,"text":" - Legacy. Although this feature is unlikely to be removed and is still covered by semantic versioning guarantees, it is no longer actively\n> maintained, and other alternatives are available."}}} />
+<Metadata version="v18.13.0" data={{"stability":{"level":3,"text":" - Legacy. Although this feature is unlikely to be removed and is still covered by semantic versioning guarantees, it is no longer actively maintained, and other alternatives are available."}}} />
 
 Features are marked as legacy rather than being deprecated if their use does no
 harm, and they are widely relied upon within the npm ecosystem. Bugs found in

--- a/content/api/v18/process.en.md
+++ b/content/api/v18/process.en.md
@@ -3355,7 +3355,7 @@ flag's behavior.
 
 <Metadata version="v18.13.0" data={{"changes":[{"version":["v14.0.0","v12.19.0"],"pr-url":"https://github.com/nodejs/node/pull/32499","description":"Calling `process.umask()` with no arguments is deprecated."}],"update":{"type":"added","version":["v0.1.19"]}}} />
 
-<Metadata version="v18.13.0" data={{"stability":{"level":0,"text":" - Deprecated. Calling `process.umask()` with no argument causes the process-wide umask to be written twice. This introduces a race condition\n> between threads, and is a potential security vulnerability. There is no safe,\n> cross-platform alternative API."}}} />
+<Metadata version="v18.13.0" data={{"stability":{"level":0,"text":" - Deprecated. Calling `process.umask()` with no argument causes the process-wide umask to be written twice. This introduces a race condition between threads, and is a potential security vulnerability. There is no safe, cross-platform alternative API."}}} />
 
 `process.umask()` returns the Node.js process's file mode creation mask. Child
 processes inherit the mask from the parent process.

--- a/content/api/v18/util.en.md
+++ b/content/api/v18/util.en.md
@@ -2728,7 +2728,7 @@ util.isObject(() => {});
 
 <Metadata version="v18.13.0" data={{"update":{"type":"deprecated","version":["v4.0.0"]}}} />
 
-<Metadata version="v18.13.0" data={{"stability":{"level":0,"text":" - Deprecated: Use `(typeof value !== 'object' && typeof value !== 'function') || value === null`\n> instead."}}} />
+<Metadata version="v18.13.0" data={{"stability":{"level":0,"text":" - Deprecated: Use `(typeof value !== 'object' && typeof value !== 'function') || value === null` instead."}}} />
 
 * `object` [`any`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Data_types)
 * Returns: [`boolean`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)

--- a/content/api/v19/async_hooks.en.md
+++ b/content/api/v19/async_hooks.en.md
@@ -7,7 +7,7 @@ version: 'v19'
 
 <Metadata version="v19.4.0" data={{"update":{"type":"introduced_in","version":["v8.1.0"]}}} />
 
-<Metadata version="v19.4.0" data={{"stability":{"level":1,"text":" - Experimental. Please migrate away from this API, if you can. We do not recommend using the `createHook`][], [`AsyncHook`, and\n> `executionAsyncResource` APIs as they have usability issues, safety risks,\n> and performance implications. Async context tracking use cases are better\n> served by the stable `AsyncLocalStorage` API. If you have a use case for\n> `createHook`, `AsyncHook`, or `executionAsyncResource` beyond the context\n> tracking need solved by `AsyncLocalStorage` or diagnostics data currently\n> provided by Diagnostics Channel, please open an issue at\n> <https://github.com/nodejs/node/issues> describing your use case so we can\n> create a more purpose-focused API."}}} />
+<Metadata version="v19.4.0" data={{"stability":{"level":1,"text":" - Experimental. Please migrate away from this API, if you can. We do not recommend using the `createHook`][], [`AsyncHook`][], and [`executionAsyncResource`][] APIs as they have usability issues, safety risks, and performance implications. Async context tracking use cases are better served by the stable [`AsyncLocalStorage`][] API. If you have a use case for `createHook`, `AsyncHook`, or `executionAsyncResource` beyond the context tracking need solved by [`AsyncLocalStorage`][] or diagnostics data currently provided by [Diagnostics Channel, please open an issue at <https://github.com/nodejs/node/issues> describing your use case so we can create a more purpose-focused API."}}} />
 
 <Metadata version="v19.4.0" data={{"source_link":"lib/async_hooks.js"}} />
 

--- a/content/api/v19/buffer.en.md
+++ b/content/api/v19/buffer.en.md
@@ -4300,7 +4300,7 @@ See [`Buffer.from(array)`][].
 
 <Metadata version="v19.4.0" data={{"changes":[{"version":"v10.0.0","pr-url":"https://github.com/nodejs/node/pull/19524","description":"Calling this constructor emits a deprecation warning when run from code outside the `node_modules` directory."},{"version":"v7.2.1","pr-url":"https://github.com/nodejs/node/pull/9529","description":"Calling this constructor no longer emits a deprecation warning."},{"version":"v7.0.0","pr-url":"https://github.com/nodejs/node/pull/8169","description":"Calling this constructor emits a deprecation warning now."},{"version":"v6.0.0","pr-url":"https://github.com/nodejs/node/pull/4682","description":"The `byteOffset` and `length` parameters are supported now."}],"update":{"type":"deprecated","version":["v6.0.0"]}}} />
 
-<Metadata version="v19.4.0" data={{"stability":{"level":0,"text":" - Deprecated: Use [`Buffer.from(arrayBuffer[, byteOffset[, length]])`][`Buffer.from(arrayBuf)`]\n> instead."}}} />
+<Metadata version="v19.4.0" data={{"stability":{"level":0,"text":" - Deprecated: Use [`Buffer.from(arrayBuffer[, byteOffset[, length]])`][`Buffer.from(arrayBuf)`] instead."}}} />
 
 * `arrayBuffer` [`ArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) | [`SharedArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer) An [`ArrayBuffer`][],
   [`SharedArrayBuffer`][] or the `.buffer` property of a [`TypedArray`][].

--- a/content/api/v19/documentation.en.md
+++ b/content/api/v19/documentation.en.md
@@ -30,11 +30,11 @@ The stability indices are as follows:
 
 <Metadata version="v19.4.0" data={{"stability":{"level":0,"text":" - Deprecated. The feature may emit warnings. Backward compatibility is not guaranteed."}}} />
 
-<Metadata version="v19.4.0" data={{"stability":{"level":1,"text":" - Experimental. The feature is not subject to semantic versioning rules. Non-backward compatible changes or removal may\n> occur in any future release. Use of the feature is not recommended in\n> production environments."}}} />
+<Metadata version="v19.4.0" data={{"stability":{"level":1,"text":" - Experimental. The feature is not subject to semantic versioning rules. Non-backward compatible changes or removal may occur in any future release. Use of the feature is not recommended in production environments."}}} />
 
 <Metadata version="v19.4.0" data={{"stability":{"level":2,"text":" - Stable. Compatibility with the npm ecosystem is a high priority."}}} />
 
-<Metadata version="v19.4.0" data={{"stability":{"level":3,"text":" - Legacy. Although this feature is unlikely to be removed and is still covered by semantic versioning guarantees, it is no longer actively\n> maintained, and other alternatives are available."}}} />
+<Metadata version="v19.4.0" data={{"stability":{"level":3,"text":" - Legacy. Although this feature is unlikely to be removed and is still covered by semantic versioning guarantees, it is no longer actively maintained, and other alternatives are available."}}} />
 
 Features are marked as legacy rather than being deprecated if their use does no
 harm, and they are widely relied upon within the npm ecosystem. Bugs found in

--- a/content/api/v19/process.en.md
+++ b/content/api/v19/process.en.md
@@ -3346,7 +3346,7 @@ flag's behavior.
 
 <Metadata version="v19.4.0" data={{"changes":[{"version":["v14.0.0","v12.19.0"],"pr-url":"https://github.com/nodejs/node/pull/32499","description":"Calling `process.umask()` with no arguments is deprecated."}],"update":{"type":"added","version":["v0.1.19"]}}} />
 
-<Metadata version="v19.4.0" data={{"stability":{"level":0,"text":" - Deprecated. Calling `process.umask()` with no argument causes the process-wide umask to be written twice. This introduces a race condition\n> between threads, and is a potential security vulnerability. There is no safe,\n> cross-platform alternative API."}}} />
+<Metadata version="v19.4.0" data={{"stability":{"level":0,"text":" - Deprecated. Calling `process.umask()` with no argument causes the process-wide umask to be written twice. This introduces a race condition between threads, and is a potential security vulnerability. There is no safe, cross-platform alternative API."}}} />
 
 `process.umask()` returns the Node.js process's file mode creation mask. Child
 processes inherit the mask from the parent process.

--- a/content/api/v19/util.en.md
+++ b/content/api/v19/util.en.md
@@ -2729,7 +2729,7 @@ util.isObject(() => {});
 
 <Metadata version="v19.4.0" data={{"update":{"type":"deprecated","version":["v4.0.0"]}}} />
 
-<Metadata version="v19.4.0" data={{"stability":{"level":0,"text":" - Deprecated: Use `(typeof value !== 'object' && typeof value !== 'function') || value === null`\n> instead."}}} />
+<Metadata version="v19.4.0" data={{"stability":{"level":0,"text":" - Deprecated: Use `(typeof value !== 'object' && typeof value !== 'function') || value === null` instead."}}} />
 
 * `object` [`any`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Data_types)
 * Returns: [`boolean`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)

--- a/util-node/apiDocsTransformUtils.js
+++ b/util-node/apiDocsTransformUtils.js
@@ -132,7 +132,7 @@ function createApiDocsFrontmatter(firstLine, { version, name }) {
 function replaceStabilityIndex(metadata) {
   return (_, __, level, text) => {
     const sanitizedText = text
-      .replace('\n>', '')
+      .replace(/(\n)>/g, '')
       .replace(/\[(.+)\]\[\]/g, (___, piece) => piece);
 
     const data = safeJSON.toString({


### PR DESCRIPTION
## Description

Remove redundant character ">" in documentation md of API v16, v18, v19.

## Related Issues

Fixes #3164

### Check List

- [x] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [x] I have run `npm run lint:js -- --fix` and/or `npm run lint:md -- --fix` for my JavaScript and/or Markdown changes.
  - This is important as most of the cases your code changes might not be correctly linted
- [x] I have run `npm run test` to check if all tests are passing, and/or `npm run test -- -u` to update snapshots if I created and/or updated React Components.
- [x] I have checked that the build works locally and that `npm run build` work fine.
- [x] I've covered new added functionality with unit tests if necessary.
