### PR TITLE
Fix for non-clickable area on Search result

### DIFF
--- a/src/components/CommonComponents/SearchBar/index.module.scss
+++ b/src/components/CommonComponents/SearchBar/index.module.scss
@@ -88,7 +88,6 @@
         padding: 5px 0;
 
         &:hover {
-          background-color: var(--black2);
           font-weight: bold;
         }
 

--- a/src/components/CommonComponents/SearchBar/index.module.scss
+++ b/src/components/CommonComponents/SearchBar/index.module.scss
@@ -87,7 +87,13 @@
         margin: 0;
         padding: 5px 0;
 
+        &:hover {
+          background-color: var(--black2);
+          font-weight: bold;
+        }
+
         > a {
+          display: block;
           text-decoration: none;
           text-overflow: ellipsis;
 

--- a/src/components/CommonComponents/SearchBar/index.tsx
+++ b/src/components/CommonComponents/SearchBar/index.tsx
@@ -235,8 +235,8 @@ const SearchBar = (): JSX.Element => {
                       {(result.wrapInCode && <code>{displayTitle}</code>) || (
                         <span>{displayTitle}</span>
                       )}
+                      <SectionTitle path={sectionPath} />
                     </Link>
-                    <SectionTitle path={sectionPath} />
                   </li>
                 );
               })}


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/nodejs/nodejs.dev/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Fix for https://github.com/nodejs/nodejs.dev/issues/3208 issue. Now, complete area is highlighted and made clickable.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
-->

- [X] I have read the [Contributing Guidelines](https://github.com/nodejs/nodejs.dev/blob/main/CONTRIBUTING.md) and made commit messages that follow the guideline.
- [X] I have run `npm run lint:js -- --fix` and/or `npm run lint:md -- --fix` for my JavaScript and/or Markdown changes.
  - This is important as most of the cases your code changes might not be correctly linted
- [X] I have run `npm run test` to check if all tests are passing, and/or `npm run test -- -u` to update snapshots if I created and/or updated React Components.
- [X] I have checked that the build works locally and that `npm run build` work fine.
- [X] I've covered new added functionality with unit tests if necessary.
